### PR TITLE
feat(backend): 헬스체크 엔드포인트 및 정적 리소스 서빙 추가

### DIFF
--- a/backend/src/main/java/igrus/web/common/controller/HealthController.java
+++ b/backend/src/main/java/igrus/web/common/controller/HealthController.java
@@ -1,0 +1,28 @@
+package igrus.web.common.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/health")
+@Tag(name = "Health", description = "헬스체크 API")
+public class HealthController {
+
+    @Operation(summary = "헬스체크", description = "서버 상태를 확인합니다.")
+    @ApiResponse(responseCode = "200", description = "서버 정상 작동")
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> healthCheck() {
+        return ResponseEntity.ok(Map.of(
+                "status", "UP",
+                "timestamp", Instant.now().toString()
+        ));
+    }
+}

--- a/backend/src/main/java/igrus/web/security/config/PublicResourceSecurityConfig.java
+++ b/backend/src/main/java/igrus/web/security/config/PublicResourceSecurityConfig.java
@@ -19,6 +19,9 @@ public class PublicResourceSecurityConfig {
 
         // Swagger 및 공개 리소스 경로 담당
         http.securityMatcher(
+                "/",
+                "/index.html",
+                "/favicon.svg",
                 "/swagger-ui/**",
                 "/swagger-ui.html",
                 "/v3/api-docs/**",

--- a/backend/src/main/java/igrus/web/security/config/SecurityPaths.java
+++ b/backend/src/main/java/igrus/web/security/config/SecurityPaths.java
@@ -10,6 +10,7 @@ public final class SecurityPaths {
      * 인증 없이 접근 가능한 API 경로 목록
      */
     public static final String[] PUBLIC_PATHS = {
+            "/api/health",               // 헬스체크
             "/api/v1/auth/password/**",  // 비밀번호 기반 인증 (로그인, 회원가입, 토큰 갱신)
             "/api/privacy/policy",       // 개인정보 처리방침
             "/api/v1/inquiries/guest",   // 문의 작성 (비로그인 가능)

--- a/backend/src/main/resources/static/favicon.svg
+++ b/backend/src/main/resources/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#00d9ff;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#00ff88;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" rx="20" fill="#1a1a2e"/>
+  <text x="50" y="68" font-family="Arial, sans-serif" font-size="50" font-weight="bold" fill="url(#grad)" text-anchor="middle">IG</text>
+</svg>

--- a/backend/src/main/resources/static/index.html
+++ b/backend/src/main/resources/static/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>IGRUS API Server</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    
+</head>
+<body>
+    <h1>IGRUS API SERVER</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 헬스체크 엔드포인트(`/api/health`) 추가
- 정적 리소스 서빙 설정 (`/`, `/index.html`, `/favicon.svg`)
- 보안 설정에 공개 경로 추가

## Test plan
- [ ] `/api/health` 엔드포인트 응답 확인
- [ ] 정적 리소스 접근 확인 (`/`, `/index.html`, `/favicon.svg`)