### PR TITLE
chore(backend): Swagger 서버 URL을 프로필별 설정으로 분리

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -22,6 +22,9 @@ spring:
           starttls:
             enable: true
 
+springdoc:
+  server-url: http://localhost:8080
+
 logging:
   level:
     org.springframework.security.oauth2: DEBUG

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -32,6 +32,9 @@ spring:
           starttls:
             enable: true
 
+springdoc:
+  server-url: http://igrus-web-alb-535342735.ap-northeast-2.elb.amazonaws.com
+
 app:
   cookie:
     secure: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,9 +5,6 @@ spring:
     enabled: true
     locations: classpath:db/migration
 
-springdoc:
-  server-url: ${SWAGGER_SERVER_URL:http://localhost:8080}
-
 app:
   jwt:
     access-token-validity: 3600000      # 1시간


### PR DESCRIPTION
## Summary
- Swagger 서버 URL 설정을 환경변수 기반에서 프로필별 명시적 설정으로 변경
- `application.yml`에서 공통 springdoc 설정 제거
- `application-local.yml`에 localhost:8080 설정 추가
- `application-prod.yml`에 ALB 주소 설정 추가

## Test plan
- [ ] 로컬 환경에서 Swagger UI 접근 시 서버 URL이 localhost:8080으로 표시되는지 확인
- [ ] 프로덕션 환경에서 Swagger UI 접근 시 ALB 주소로 표시되는지 확인