### PR TITLE
커뮤니티 기능 개선: SecurityRequirement 어노테이션 및 DB 마이그레이션 정리

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -250,6 +250,7 @@ public class UserService {
 - Controller 메서드에 `@Operation`, `@ApiResponse` 어노테이션
     - 컨트롤러에는 꼭 Swagger/OpenAPI 관련 어노테이션을 붙여서 문서화 할 것
 - 새로운 기능 구현, 기능 수정 이후에는 Swagger 관련 코드를 업데이트 해서 문서화 상태를 항상 최신으로 유지할 것
+- 인증이 필요한 엔드포인트에는 `@SecurityRequirement` 를 붙일 것
 
 ### 12. SOLID 원칙 준수
 - SRP(Single Responsibility Principle): 단일 책임 원칙

--- a/backend/src/main/java/igrus/web/community/board/controller/BoardController.java
+++ b/backend/src/main/java/igrus/web/community/board/controller/BoardController.java
@@ -13,7 +13,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import igrus.web.common.config.SwaggerConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +32,7 @@ import java.util.List;
  * 게시판 목록 조회 및 상세 조회 API를 제공합니다.
  */
 @Tag(name = "Board", description = "게시판 API")
+@SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/boards")

--- a/backend/src/main/java/igrus/web/community/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/igrus/web/community/bookmark/controller/BookmarkController.java
@@ -12,7 +12,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import igrus.web.common.config.SwaggerConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -84,6 +86,7 @@ public class BookmarkController {
                     )
             )
     })
+    @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
     @PostMapping("/api/v1/posts/{postId}/bookmarks")
     @PreAuthorize("hasAnyRole('MEMBER', 'OPERATOR', 'ADMIN')")
     public ResponseEntity<BookmarkToggleResponse> toggleBookmark(
@@ -127,6 +130,7 @@ public class BookmarkController {
                     )
             )
     })
+    @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
     @GetMapping("/api/v1/posts/{postId}/bookmarks/status")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<BookmarkStatusResponse> getBookmarkStatus(
@@ -158,6 +162,7 @@ public class BookmarkController {
                     )
             )
     })
+    @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
     @GetMapping("/api/v1/users/me/bookmarks")
     @PreAuthorize("hasAnyRole('MEMBER', 'OPERATOR', 'ADMIN')")
     public ResponseEntity<Page<BookmarkedPostResponse>> getMyBookmarks(

--- a/backend/src/main/java/igrus/web/community/comment/controller/CommentController.java
+++ b/backend/src/main/java/igrus/web/community/comment/controller/CommentController.java
@@ -12,7 +12,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import igrus.web.common.config.SwaggerConfig;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 댓글 작성, 조회, 삭제 API를 제공합니다.
  */
 @Tag(name = "Comment", description = "댓글 API")
+@SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/posts/{postId}/comments")

--- a/backend/src/main/java/igrus/web/community/comment/controller/CommentReportController.java
+++ b/backend/src/main/java/igrus/web/community/comment/controller/CommentReportController.java
@@ -12,7 +12,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import igrus.web.common.config.SwaggerConfig;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -80,6 +82,7 @@ public class CommentReportController {
                     )
             )
     })
+    @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
     @PostMapping("/api/v1/comments/{commentId}/reports")
     public ResponseEntity<CommentReportResponse> reportComment(
             @Parameter(description = "댓글 ID", example = "1")
@@ -119,6 +122,7 @@ public class CommentReportController {
                     )
             )
     })
+    @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
     @PreAuthorize("hasAnyRole('OPERATOR', 'ADMIN')")
     @GetMapping("/api/v1/admin/comment-reports")
     public ResponseEntity<List<CommentReportResponse>> getPendingReports(
@@ -172,6 +176,7 @@ public class CommentReportController {
                     )
             )
     })
+    @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
     @PreAuthorize("hasAnyRole('OPERATOR', 'ADMIN')")
     @PatchMapping("/api/v1/admin/comment-reports/{reportId}")
     public ResponseEntity<Void> updateReportStatus(

--- a/backend/src/main/java/igrus/web/community/like/comment_like/controller/CommentLikeController.java
+++ b/backend/src/main/java/igrus/web/community/like/comment_like/controller/CommentLikeController.java
@@ -9,7 +9,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import igrus.web.common.config.SwaggerConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 댓글 좋아요 추가/취소 API를 제공합니다.
  */
 @Tag(name = "Comment Like", description = "댓글 좋아요 API")
+@SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/comments/{commentId}/likes")

--- a/backend/src/main/java/igrus/web/community/like/post_like/controller/PostLikeController.java
+++ b/backend/src/main/java/igrus/web/community/like/post_like/controller/PostLikeController.java
@@ -12,7 +12,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import igrus.web.common.config.SwaggerConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -84,6 +86,7 @@ public class PostLikeController {
                     )
             )
     })
+    @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
     @PostMapping("/api/v1/posts/{postId}/likes")
     @PreAuthorize("hasAnyRole('MEMBER', 'OPERATOR', 'ADMIN')")
     public ResponseEntity<PostLikeToggleResponse> toggleLike(
@@ -127,6 +130,7 @@ public class PostLikeController {
                     )
             )
     })
+    @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
     @GetMapping("/api/v1/posts/{postId}/likes/status")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<PostLikeStatusResponse> getLikeStatus(
@@ -158,6 +162,7 @@ public class PostLikeController {
                     )
             )
     })
+    @SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
     @GetMapping("/api/v1/users/me/likes")
     @PreAuthorize("hasAnyRole('MEMBER', 'OPERATOR', 'ADMIN')")
     public ResponseEntity<Page<LikedPostResponse>> getMyLikes(

--- a/backend/src/main/java/igrus/web/community/post/controller/PostController.java
+++ b/backend/src/main/java/igrus/web/community/post/controller/PostController.java
@@ -17,7 +17,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import igrus.web.common.config.SwaggerConfig;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +36,7 @@ import org.springframework.web.bind.annotation.*;
  * 게시글 작성, 조회, 수정, 삭제 API를 제공합니다.
  */
 @Tag(name = "Post", description = "게시글 API")
+@SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/boards/{boardCode}/posts")


### PR DESCRIPTION
## Summary
- 커뮤니티 컨트롤러에 `@SecurityRequirement` 어노테이션 추가하여 Swagger 문서에서 인증 필요 엔드포인트 명시
- DB 마이그레이션 네이밍 컨벤션 적용 및 버전 재정렬

## Test plan
- [ ] Swagger UI에서 인증 필요 엔드포인트에 자물쇠 아이콘 표시 확인
- [ ] 기존 API 동작에 영향 없음 확인