### PR TITLE
feat(backend): 리프레시 토큰 로테이션 및 탈취 감지 구현

### DIFF
--- a/backend/docs/test-case/auth/token-test-cases.md
+++ b/backend/docs/test-case/auth/token-test-cases.md
@@ -1,7 +1,7 @@
 # 토큰 갱신 테스트 케이스
 
 **작성일**: 2026-01-23
-**버전**: 1.0
+**버전**: 1.3
 **관련 스펙**: [auth-spec.md](../../../../docs/feature/auth/auth-spec.md)
 **우선순위**: P2
 
@@ -11,30 +11,47 @@
 
 토큰 갱신 기능에 대한 테스트 케이스입니다. 로그인한 사용자가 Access Token 만료 시 Refresh Token을 사용하여 새로운 Access Token을 발급받는 과정을 검증합니다.
 
+리프레시 토큰 로테이션 및 탈취 감지 기능이 포함되어 있습니다:
+- **토큰 로테이션**: 갱신 시 기존 Refresh Token을 폐기하고 새 Refresh Token을 발급
+- **Token Family**: 같은 로그인 세션에서 파생된 토큰 체인을 그룹화
+- **탈취 감지**: 이미 폐기된 토큰 재사용 시 해당 Token Family 전체 무효화
+- **Grace Period (10초)**: 동시 탭에서의 경쟁 조건을 처리
+
 ---
 
 ## 2. 테스트 케이스
 
-### 2.1 토큰 갱신 성공
+### 2.1 토큰 갱신 성공 (로테이션 포함)
 
 | ID | 테스트 케이스 | 사전 조건 | 테스트 단계 | 예상 결과 | 상태 |
 |----|-------------|----------|-----------|----------|------|
-| TKN-001 | 유효한 Refresh Token으로 갱신 성공 | Access Token 만료, Refresh Token 유효 | Refresh Token으로 갱신 요청 | 새로운 Access Token 발급 | ✅ |
-| TKN-002 | 갱신된 Access Token 1시간 유효 | 토큰 갱신 성공 | 새로운 Access Token 만료 시간 확인 | 1시간 유효기간 설정 | ✅ |
-| TKN-003 | 갱신된 Access Token으로 API 호출 성공 | 토큰 갱신 성공 | 새 Access Token으로 보호된 API 호출 | 정상 응답 | ✅ |
-| TKN-004 | Access Token 만료 전 갱신 가능 | Access Token 유효한 상태 | Refresh Token으로 갱신 요청 | 새로운 Access Token 발급 | ✅ |
+| TKN-001 | 유효한 Refresh Token으로 갱신 성공 | Access Token 만료, Refresh Token 유효 | Refresh Token으로 갱신 요청 | 새로운 Access Token + 새로운 Refresh Token 발급 | ✅ |
+| TKN-002 | 갱신된 Access Token 5분 유효 | 토큰 갱신 성공 | 새로운 Access Token 만료 시간 확인 | 5분 유효기간 설정 | ✅ |
+| TKN-003 | 연쇄 갱신 시 매번 새 Refresh Token 발급 | 토큰 갱신 성공 | 새 Refresh Token으로 다시 갱신 요청 반복 | 매 갱신마다 새 Refresh Token 발급, 이전 토큰 폐기 | ✅ |
+| TKN-004 | Access Token 만료 전 갱신 가능 | Access Token 유효한 상태 | Refresh Token으로 갱신 요청 | 새로운 Access Token + 새로운 Refresh Token 발급 | ✅ |
+| TKN-005 | 갱신 시 Set-Cookie 헤더에 새 Refresh Token 포함 | 토큰 갱신 요청 | HTTP 응답 헤더 확인 | Set-Cookie 헤더에 새 Refresh Token이 HttpOnly 쿠키로 설정 | ✅ |
+| TKN-006 | 갱신 후 기존 Refresh Token 폐기 확인 | 토큰 갱신 성공 | DB에서 기존 토큰 상태 확인 | 기존 토큰 revoked=true, replacedByToken에 새 토큰 기록 | ✅ |
 
 ### 2.2 토큰 갱신 실패
 
 | ID | 테스트 케이스 | 사전 조건 | 테스트 단계 | 예상 결과 | 상태 |
 |----|-------------|----------|-----------|----------|------|
-| TKN-010 | 만료된 Refresh Token으로 갱신 시도 | Refresh Token 만료 (7일 경과) | 토큰 갱신 요청 | "토큰이 만료되었습니다" 메시지, 재로그인 필요 | ✅ |
+| TKN-010 | 만료된 Refresh Token으로 갱신 시도 | Refresh Token 만료 (3일 경과) | 토큰 갱신 요청 | "토큰이 만료되었습니다" 메시지, 재로그인 필요 | ✅ |
 | TKN-011 | 유효하지 않은 Refresh Token으로 갱신 시도 | 잘못된 형식의 Refresh Token | 토큰 갱신 요청 | "유효하지 않은 토큰입니다" 메시지 표시 | ✅ |
 | TKN-012 | 변조된 Refresh Token으로 갱신 시도 | Refresh Token 페이로드 변조 | 토큰 갱신 요청 | "유효하지 않은 토큰입니다" 메시지 표시 | ✅ |
 | TKN-013 | 빈 Refresh Token으로 갱신 시도 | - | 빈 토큰으로 갱신 요청 | 400 Bad Request 응답 | ✅ |
 | TKN-014 | 로그아웃된 Refresh Token으로 갱신 시도 | 로그아웃 후 토큰 무효화 | 이전 Refresh Token으로 갱신 요청 | "유효하지 않은 토큰입니다" 메시지 표시 | ✅ |
 
-### 2.3 계정 상태 변경 시 토큰 처리
+### 2.3 토큰 탈취 감지 및 Grace Period
+
+| ID | 테스트 케이스 | 사전 조건 | 테스트 단계 | 예상 결과 | 상태 |
+|----|-------------|----------|-----------|----------|------|
+| TKN-040 | 폐기된 토큰 재사용 시 탈취 감지 | 갱신 후 10초 경과 | 이전(폐기된) Refresh Token으로 갱신 요청 | "토큰 도용이 감지되어 모든 세션이 종료되었습니다" 메시지, 401 응답 | ✅ |
+| TKN-041 | 탈취 감지 시 같은 패밀리의 모든 토큰 무효화 | 폐기된 토큰 재사용 감지 | DB에서 동일 Token Family 토큰 상태 확인 | 같은 Token Family의 모든 토큰 revoked=true | ✅ |
+| TKN-042 | Grace Period 내 폐기된 토큰 사용 시 성공 | 갱신 직후 (10초 이내) | 이전(폐기된) Refresh Token으로 갱신 요청 | 현재 활성 토큰 기반으로 새 Access Token 발급 (탈취로 간주하지 않음) | ✅ |
+| TKN-043 | Grace Period 내이지만 활성 토큰 없는 경우 | 폐기 후 10초 이내, 활성 토큰 없음 | 이전 Refresh Token으로 갱신 요청 | "유효하지 않은 토큰입니다" 메시지 표시 | ✅ |
+
+### 2.4 계정 상태 변경 시 토큰 처리
 
 | ID | 테스트 케이스 | 사전 조건 | 테스트 단계 | 예상 결과 | 상태 |
 |----|-------------|----------|-----------|----------|------|
@@ -58,8 +75,9 @@
 
 | ID | 요구사항 | 관련 테스트 케이스 |
 |----|---------|------------------|
-| FR-013 | Access Token(1시간), Refresh Token(7일) 발급 | TKN-001, TKN-002, TKN-010 |
-| FR-015 | Refresh Token으로 Access Token 재발급 | TKN-001 ~ TKN-004 |
+| FR-013 | Access Token(5분), Refresh Token(3일) 발급 | TKN-001, TKN-002, TKN-010 |
+| FR-015 | Refresh Token 로테이션으로 Access Token + 새 Refresh Token 재발급 | TKN-001 ~ TKN-006 |
+| FR-015a | 토큰 탈취 감지 (Token Family 기반) | TKN-040 ~ TKN-043 |
 | FR-019 | 비밀번호 재설정 시 모든 토큰 무효화 | TKN-024 |
 | FR-022 | 계정 정지/탈퇴 시 모든 토큰 즉시 무효화 | TKN-020 ~ TKN-023 |
 
@@ -67,13 +85,17 @@
 
 ## 4. 구현된 테스트 클래스
 
-### 4.1 Service 테스트
+### 4.1 Service 단위 테스트
 - **파일**: `backend/src/test/java/igrus/web/security/auth/password/service/PasswordAuthServiceTokenTest.java`
 - **테스트 범위**: TKN-001 ~ TKN-024 (비즈니스 로직)
 
-### 4.2 Controller 테스트
+### 4.2 RefreshTokenService 단위 테스트
+- **파일**: `backend/src/test/java/igrus/web/security/auth/password/service/RefreshTokenServiceTest.java`
+- **테스트 범위**: TKN-001 ~ TKN-006, TKN-040 ~ TKN-043 (로테이션, 탈취 감지, Grace Period)
+
+### 4.3 Controller 단위 테스트
 - **파일**: `backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerTokenTest.java`
-- **테스트 범위**: TKN-001 ~ TKN-014 (HTTP 레이어)
+- **테스트 범위**: TKN-001 ~ TKN-014 (HTTP 레이어, TokenRotationResult 반환)
 
 ```java
 @WebMvcTest(PasswordAuthController.class)
@@ -85,7 +107,7 @@ class PasswordAuthControllerTokenTest {
     @Nested
     @DisplayName("토큰 갱신 성공")
     class TokenRefreshSuccessTest {
-        // TKN-001 ~ TKN-004
+        // TKN-001 ~ TKN-005 (Set-Cookie 헤더 검증 포함)
     }
 
     @Nested
@@ -96,20 +118,30 @@ class PasswordAuthControllerTokenTest {
 }
 ```
 
-### 4.3 통합 테스트
+### 4.4 Controller 통합 테스트
+- **파일**: `backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerTokenIntegrationTest.java`
+- **테스트 범위**: TKN-001 ~ TKN-006 (실제 DB + HTTP 레이어, 연쇄 갱신 검증)
+
+### 4.5 서비스 통합 테스트
 - **파일**: `backend/src/test/java/igrus/web/security/auth/password/integration/TokenRefreshIntegrationTest.java`
-- **테스트 범위**: TKN-001 ~ TKN-032 (서비스 통합 테스트)
-- **테스트 수**: 18개
+- **테스트 범위**: TKN-001 ~ TKN-043 (서비스 통합 테스트)
 
 ```java
 @DisplayName("토큰 갱신 통합 테스트")
 class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
-    @Nested class TokenRefreshSuccessTest { /* TKN-001 ~ TKN-004 */ }
+    @Nested class TokenRefreshSuccessTest { /* TKN-001 ~ TKN-006 */ }
     @Nested class TokenRefreshFailureTest { /* TKN-010 ~ TKN-014 */ }
     @Nested class AccountStatusTokenTest { /* TKN-020 ~ TKN-024 */ }
     @Nested class TokenSecurityTest { /* TKN-030 ~ TKN-032 */ }
+    @Nested class TokenTheftDetectionTest { /* TKN-040 ~ TKN-043 */ }
 }
 ```
+
+### 4.6 E2E 테스트
+- **파일**: `backend/src/test/java/igrus/web/security/auth/e2e/AuthFlowE2ETest.java`
+- **테스트 범위**: TKN-001, TKN-003, TKN-005 (HTTP 레이어 E2E, Set-Cookie 검증, 연쇄 갱신)
+- **파일**: `backend/src/test/java/igrus/web/security/auth/e2e/AuthenticationE2ETest.java`
+- **테스트 범위**: TKN-001, TKN-003 (서비스 레이어 E2E, TokenRotationResult 연쇄 갱신)
 
 ---
 
@@ -120,3 +152,4 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
 | 1.0 | 2026-01-23 | - | 최초 작성 |
 | 1.1 | 2026-01-24 | - | 컨트롤러 레벨 테스트 구현 정보 추가 |
 | 1.2 | 2026-01-25 | - | 서비스 테스트 및 통합 테스트(TokenRefreshIntegrationTest) 구현 정보 추가 |
+| 1.3 | 2026-02-06 | Claude | 리프레시 토큰 로테이션 및 탈취 감지 반영: TKN-005~006, TKN-040~043 추가, 유효기간 변경(5분/3일), E2E 테스트 클래스 정보 추가 |

--- a/backend/src/main/java/igrus/web/common/exception/ErrorCode.java
+++ b/backend/src/main/java/igrus/web/common/exception/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
     ACCOUNT_NOT_RECOVERABLE(400, "복구 기간이 만료된 계정입니다"),
     REFRESH_TOKEN_INVALID(401, "유효하지 않은 리프레시 토큰입니다"),
     REFRESH_TOKEN_EXPIRED(401, "리프레시 토큰이 만료되었습니다"),
+    REFRESH_TOKEN_THEFT_DETECTED(401, "토큰 도용이 감지되어 모든 세션이 종료되었습니다"),
     PASSWORD_RESET_TOKEN_INVALID(400, "유효하지 않은 비밀번호 재설정 토큰입니다"),
     PASSWORD_RESET_TOKEN_EXPIRED(400, "비밀번호 재설정 토큰이 만료되었습니다"),
     EMAIL_SEND_FAILED(500, "이메일 발송에 실패했습니다"),

--- a/backend/src/main/java/igrus/web/security/auth/common/domain/RefreshToken.java
+++ b/backend/src/main/java/igrus/web/security/auth/common/domain/RefreshToken.java
@@ -7,13 +7,18 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Duration;
 import java.time.Instant;
+import java.util.UUID;
 
 /**
  * 리프레시 토큰 정보를 저장하는 엔티티.
  *
  * <p>JWT 기반 인증에서 액세스 토큰 갱신을 위한 리프레시 토큰을 관리합니다.
  * 토큰의 만료 시간과 폐기 여부를 추적하여 토큰의 유효성을 검증합니다.</p>
+ *
+ * <p>토큰 로테이션을 지원하며, 같은 로그인 세션에서 파생된 토큰들은
+ * 동일한 {@code tokenFamily}로 그룹화되어 탈취 감지에 활용됩니다.</p>
  *
  * @see igrus.web.common.domain.BaseEntity
  * @see igrus.web.user.domain.User
@@ -64,18 +69,50 @@ public class RefreshToken extends BaseEntity {
     private boolean revoked = false;
 
     /**
-     * RefreshToken 엔티티를 생성합니다.
+     * 토큰 패밀리 식별자. 같은 로그인 세션에서 파생된 토큰 체인을 그룹화합니다.
+     */
+    @Column(name = "refresh_tokens_token_family", nullable = false, length = 36)
+    private String tokenFamily;
+
+    /**
+     * 로테이션 시 이 토큰을 대체한 새 토큰 값.
+     */
+    @Column(name = "refresh_tokens_replaced_by_token", length = 2048)
+    private String replacedByToken;
+
+    /**
+     * 토큰이 폐기된 시점. Grace Period 판단에 사용됩니다.
+     */
+    @Column(name = "refresh_tokens_revoked_at")
+    private Instant revokedAt;
+
+    /**
+     * 로그인 시 새로운 토큰 패밀리와 함께 RefreshToken을 생성합니다.
      *
      * @param user 토큰을 발급받는 사용자
      * @param token 리프레시 토큰 문자열
      * @param expiryMillis 만료 시간 (밀리초)
+     * @return 새 토큰 패밀리가 할당된 RefreshToken 엔티티
+     */
+    public static RefreshToken createInitial(User user, String token, long expiryMillis) {
+        return create(user, token, expiryMillis, UUID.randomUUID().toString());
+    }
+
+    /**
+     * 기존 토큰 패밀리를 이어받아 RefreshToken을 생성합니다. (로테이션용)
+     *
+     * @param user 토큰을 발급받는 사용자
+     * @param token 리프레시 토큰 문자열
+     * @param expiryMillis 만료 시간 (밀리초)
+     * @param tokenFamily 토큰 패밀리 식별자
      * @return 생성된 RefreshToken 엔티티
      */
-    public static RefreshToken create(User user, String token, long expiryMillis) {
+    public static RefreshToken create(User user, String token, long expiryMillis, String tokenFamily) {
         RefreshToken refreshToken = new RefreshToken();
         refreshToken.user = user;
         refreshToken.token = token;
         refreshToken.expiresAt = Instant.now().plusMillis(expiryMillis);
+        refreshToken.tokenFamily = tokenFamily;
         return refreshToken;
     }
 
@@ -102,5 +139,31 @@ public class RefreshToken extends BaseEntity {
      */
     public void revoke() {
         this.revoked = true;
+        this.revokedAt = Instant.now();
+    }
+
+    /**
+     * 토큰을 로테이션합니다. 현재 토큰을 폐기하고 대체 토큰 정보를 기록합니다.
+     *
+     * @param newToken 이 토큰을 대체하는 새 토큰 값
+     */
+    public void rotateWith(String newToken) {
+        this.revoked = true;
+        this.revokedAt = Instant.now();
+        this.replacedByToken = newToken;
+    }
+
+    /**
+     * 토큰이 폐기된 후 유예 기간 내에 있는지 확인합니다.
+     * 동시 탭 등에서의 경쟁 조건을 처리하기 위해 사용됩니다.
+     *
+     * @param gracePeriod 유예 기간
+     * @return 유예 기간 내 여부
+     */
+    public boolean isWithinGracePeriod(Duration gracePeriod) {
+        if (this.revokedAt == null) {
+            return false;
+        }
+        return Instant.now().isBefore(this.revokedAt.plus(gracePeriod));
     }
 }

--- a/backend/src/main/java/igrus/web/security/auth/common/exception/token/RefreshTokenTheftException.java
+++ b/backend/src/main/java/igrus/web/security/auth/common/exception/token/RefreshTokenTheftException.java
@@ -1,0 +1,10 @@
+package igrus.web.security.auth.common.exception.token;
+
+import igrus.web.common.exception.CustomBaseException;
+import igrus.web.common.exception.ErrorCode;
+
+public class RefreshTokenTheftException extends CustomBaseException {
+    public RefreshTokenTheftException() {
+        super(ErrorCode.REFRESH_TOKEN_THEFT_DETECTED);
+    }
+}

--- a/backend/src/main/java/igrus/web/security/auth/common/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/igrus/web/security/auth/common/repository/RefreshTokenRepository.java
@@ -18,8 +18,18 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     List<RefreshToken> findByUserIdAndRevokedFalse(Long userId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE RefreshToken r SET r.revoked = true WHERE r.user.id = :userId")
-    void revokeAllByUserId(@Param("userId") Long userId);
+    @Query("UPDATE RefreshToken r SET r.revoked = true, r.revokedAt = :now WHERE r.user.id = :userId AND r.revoked = false")
+    void revokeAllByUserId(@Param("userId") Long userId, @Param("now") Instant now);
+
+    default void revokeAllByUserId(Long userId) {
+        revokeAllByUserId(userId, Instant.now());
+    }
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE RefreshToken r SET r.revoked = true, r.revokedAt = :now WHERE r.tokenFamily = :tokenFamily AND r.revoked = false")
+    void revokeAllByTokenFamily(@Param("tokenFamily") String tokenFamily, @Param("now") Instant now);
+
+    Optional<RefreshToken> findByTokenFamilyAndRevokedFalse(String tokenFamily);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM RefreshToken r WHERE r.expiresAt < :now")

--- a/backend/src/main/java/igrus/web/security/auth/common/service/account/RecoverAccountService.java
+++ b/backend/src/main/java/igrus/web/security/auth/common/service/account/RecoverAccountService.java
@@ -104,7 +104,7 @@ public class RecoverAccountService {
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
         // 8. RefreshToken 저장
-        RefreshToken refreshTokenEntity = RefreshToken.create(user, refreshToken, refreshTokenValidity);
+        RefreshToken refreshTokenEntity = RefreshToken.createInitial(user, refreshToken, refreshTokenValidity);
         refreshTokenRepository.save(refreshTokenEntity);
 
         log.info("계정 복구 성공: studentId={}, userId={}, role={}", studentId, user.getId(), user.getRole());

--- a/backend/src/main/java/igrus/web/security/auth/password/controller/PasswordAuthController.java
+++ b/backend/src/main/java/igrus/web/security/auth/password/controller/PasswordAuthController.java
@@ -17,6 +17,7 @@ import igrus.web.security.auth.password.dto.request.PasswordResetRequest;
 import igrus.web.security.auth.password.dto.request.PasswordSignupRequest;
 import igrus.web.security.auth.password.dto.response.PasswordLoginResponse;
 import igrus.web.security.auth.password.dto.response.PasswordSignupResponse;
+import igrus.web.security.auth.password.dto.internal.TokenRotationResult;
 import igrus.web.security.auth.password.dto.response.TokenRefreshResponse;
 import igrus.web.security.auth.password.dto.response.VerificationResendResponse;
 import igrus.web.security.auth.password.service.reset.RequestPasswordResetService;
@@ -190,12 +191,21 @@ public class PasswordAuthController {
             )
     })
     @PostMapping("/refresh")
-    public ResponseEntity<TokenRefreshResponse> refreshToken(HttpServletRequest httpRequest) {
+    public ResponseEntity<TokenRefreshResponse> refreshToken(
+            HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
         String refreshToken = cookieUtil.getRefreshTokenFromCookies(httpRequest)
                 .orElseThrow(RefreshTokenInvalidException::new);
 
-        TokenRefreshResponse response = refreshTokenService.refreshToken(refreshToken);
-        return ResponseEntity.ok(response);
+        TokenRotationResult result = refreshTokenService.refreshToken(refreshToken);
+
+        // 새 리프레시 토큰을 HttpOnly 쿠키로 설정
+        ResponseCookie cookie = cookieUtil.createRefreshTokenCookie(
+                result.newRefreshToken(),
+                Duration.ofMillis(result.refreshTokenValidity())
+        );
+        httpResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ResponseEntity.ok(result.toResponse());
     }
 
     @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다. 등록 후 이메일 인증이 필요합니다.")

--- a/backend/src/main/java/igrus/web/security/auth/password/dto/internal/TokenRotationResult.java
+++ b/backend/src/main/java/igrus/web/security/auth/password/dto/internal/TokenRotationResult.java
@@ -1,0 +1,30 @@
+package igrus.web.security.auth.password.dto.internal;
+
+import igrus.web.security.auth.password.dto.response.TokenRefreshResponse;
+
+/**
+ * 토큰 로테이션 결과를 담는 내부 DTO.
+ * <p>
+ * 서비스 레이어에서 컨트롤러로 토큰 갱신 결과를 전달할 때 사용합니다.
+ * 컨트롤러에서 newRefreshToken은 쿠키로 설정하고, accessToken은 응답 본문으로 반환합니다.
+ *
+ * @param accessToken          새로 발급된 액세스 토큰
+ * @param newRefreshToken      새로 발급된 리프레시 토큰
+ * @param accessTokenValidity  액세스 토큰 유효 기간 (밀리초)
+ * @param refreshTokenValidity 리프레시 토큰 유효 기간 (밀리초)
+ */
+public record TokenRotationResult(
+        String accessToken,
+        String newRefreshToken,
+        long accessTokenValidity,
+        long refreshTokenValidity
+) {
+    /**
+     * 응답 DTO로 변환합니다 (refreshToken 제외).
+     *
+     * @return TokenRefreshResponse
+     */
+    public TokenRefreshResponse toResponse() {
+        return TokenRefreshResponse.of(accessToken, accessTokenValidity);
+    }
+}

--- a/backend/src/main/java/igrus/web/security/auth/password/service/auth/LoginService.java
+++ b/backend/src/main/java/igrus/web/security/auth/password/service/auth/LoginService.java
@@ -152,7 +152,7 @@ public class LoginService {
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
         // 8. RefreshToken 저장
-        RefreshToken refreshTokenEntity = RefreshToken.create(user, refreshToken, refreshTokenValidity);
+        RefreshToken refreshTokenEntity = RefreshToken.createInitial(user, refreshToken, refreshTokenValidity);
         refreshTokenRepository.save(refreshTokenEntity);
 
         log.info("로그인 성공: studentId={}, userId={}", request.studentId(), user.getId());

--- a/backend/src/main/java/igrus/web/security/auth/password/service/auth/RefreshTokenService.java
+++ b/backend/src/main/java/igrus/web/security/auth/password/service/auth/RefreshTokenService.java
@@ -3,8 +3,9 @@ package igrus.web.security.auth.password.service.auth;
 import igrus.web.security.auth.common.domain.RefreshToken;
 import igrus.web.security.auth.common.exception.token.RefreshTokenExpiredException;
 import igrus.web.security.auth.common.exception.token.RefreshTokenInvalidException;
+import igrus.web.security.auth.common.exception.token.RefreshTokenTheftException;
 import igrus.web.security.auth.common.repository.RefreshTokenRepository;
-import igrus.web.security.auth.password.dto.response.TokenRefreshResponse;
+import igrus.web.security.auth.password.dto.internal.TokenRotationResult;
 import igrus.web.security.jwt.JwtTokenProvider;
 import igrus.web.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
 
 @Slf4j
 @Service
@@ -25,41 +29,109 @@ public class RefreshTokenService {
     @Value("${app.jwt.access-token-validity}")
     private long accessTokenValidity;
 
+    @Value("${app.jwt.refresh-token-validity}")
+    private long refreshTokenValidity;
+
+    @Value("${app.jwt.refresh-token-grace-period:10000}")
+    private long gracePeriodMillis;
+
     /**
-     * 리프레시 토큰으로 새로운 액세스 토큰을 발급합니다.
+     * 리프레시 토큰으로 새로운 액세스 토큰을 발급하고, 리프레시 토큰을 로테이션합니다.
+     *
+     * <p>토큰 로테이션: 매 갱신 시 기존 리프레시 토큰을 폐기하고 새 리프레시 토큰을 발급합니다.
+     * <p>탈취 감지: 이미 폐기된 토큰이 사용되면 해당 토큰 패밀리 전체를 무효화합니다.
+     * <p>Grace Period: 동시 요청(다중 탭)에 의한 경쟁 조건을 처리합니다.
      *
      * @param refreshTokenValue 리프레시 토큰
-     * @return 새로운 액세스 토큰 응답
+     * @return 새로운 액세스 토큰과 리프레시 토큰을 포함한 로테이션 결과
      * @throws RefreshTokenInvalidException 리프레시 토큰이 유효하지 않은 경우
      * @throws RefreshTokenExpiredException 리프레시 토큰이 만료된 경우
+     * @throws RefreshTokenTheftException   토큰 도용이 감지된 경우
      */
-    @Transactional(readOnly = true)
-    public TokenRefreshResponse refreshToken(String refreshTokenValue) {
+    @Transactional(noRollbackFor = RefreshTokenTheftException.class)
+    public TokenRotationResult refreshToken(String refreshTokenValue) {
         log.info("토큰 갱신 시도");
 
-        // 1. DB에서 Refresh Token 조회 (revoked가 아닌 토큰)
-        RefreshToken refreshTokenEntity = refreshTokenRepository.findByTokenAndRevokedFalse(refreshTokenValue)
+        // 1. DB에서 Refresh Token 조회 (revoked 포함 - 탈취 감지를 위해)
+        RefreshToken tokenEntity = refreshTokenRepository.findByToken(refreshTokenValue)
                 .orElseThrow(() -> {
                     log.warn("토큰 갱신 실패 - 유효하지 않은 리프레시 토큰");
                     return new RefreshTokenInvalidException();
                 });
 
-        // 2. 만료 여부 확인
-        if (refreshTokenEntity.isExpired()) {
-            log.warn("토큰 갱신 실패 - 리프레시 토큰 만료: userId={}", refreshTokenEntity.getUser().getId());
+        // 2. 이미 폐기된 토큰인 경우 - 탈취 가능성 또는 동시 요청
+        if (tokenEntity.isRevoked()) {
+            return handleRevokedToken(tokenEntity);
+        }
+
+        // 3. 만료 여부 확인
+        if (tokenEntity.isExpired()) {
+            log.warn("토큰 갱신 실패 - 리프레시 토큰 만료: userId={}", tokenEntity.getUser().getId());
             throw new RefreshTokenExpiredException();
         }
 
-        // 3. 새 Access Token 발급
-        User user = refreshTokenEntity.getUser();
+        // 4. 토큰 로테이션 수행
+        return rotateToken(tokenEntity);
+    }
+
+    /**
+     * 이미 폐기된 토큰이 사용된 경우를 처리합니다.
+     * Grace Period 내이면 동시 요청으로 간주하고, 아니면 탈취로 감지합니다.
+     */
+    private TokenRotationResult handleRevokedToken(RefreshToken revokedToken) {
+        Duration gracePeriod = Duration.ofMillis(gracePeriodMillis);
+
+        // Grace Period 내: 동시 탭에서의 경쟁 조건으로 간주
+        if (revokedToken.isWithinGracePeriod(gracePeriod)) {
+            log.info("유예 기간 내 이미 교체된 토큰 사용 - tokenFamily={}", revokedToken.getTokenFamily());
+
+            RefreshToken activeToken = refreshTokenRepository
+                    .findByTokenFamilyAndRevokedFalse(revokedToken.getTokenFamily())
+                    .orElseThrow(() -> {
+                        log.warn("유예 기간이지만 활성 토큰 없음 - 전체 무효화");
+                        return new RefreshTokenInvalidException();
+                    });
+
+            User user = activeToken.getUser();
+            String newAccessToken = jwtTokenProvider.createAccessToken(
+                    user.getId(), user.getStudentId(), user.getRole().name());
+
+            return new TokenRotationResult(
+                    newAccessToken, activeToken.getToken(), accessTokenValidity, refreshTokenValidity);
+        }
+
+        // Grace Period 밖: 토큰 탈취 감지 → 패밀리 전체 무효화
+        log.warn("토큰 도용 감지! tokenFamily={}, userId={}",
+                revokedToken.getTokenFamily(), revokedToken.getUser().getId());
+        refreshTokenRepository.revokeAllByTokenFamily(revokedToken.getTokenFamily(), Instant.now());
+        throw new RefreshTokenTheftException();
+    }
+
+    /**
+     * 유효한 토큰의 로테이션을 수행합니다.
+     * 기존 토큰을 폐기하고 새 리프레시 토큰과 액세스 토큰을 발급합니다.
+     */
+    private TokenRotationResult rotateToken(RefreshToken oldToken) {
+        User user = oldToken.getUser();
+
+        // 새 리프레시 토큰 JWT 생성
+        String newRefreshTokenValue = jwtTokenProvider.createRefreshToken(user.getId());
+
+        // 기존 토큰 폐기 및 교체 토큰 기록
+        oldToken.rotateWith(newRefreshTokenValue);
+
+        // 같은 토큰 패밀리로 새 RefreshToken 엔티티 생성
+        RefreshToken newTokenEntity = RefreshToken.create(
+                user, newRefreshTokenValue, refreshTokenValidity, oldToken.getTokenFamily());
+        refreshTokenRepository.save(newTokenEntity);
+
+        // 새 액세스 토큰 발급
         String newAccessToken = jwtTokenProvider.createAccessToken(
-                user.getId(),
-                user.getStudentId(),
-                user.getRole().name()
-        );
+                user.getId(), user.getStudentId(), user.getRole().name());
 
-        log.info("토큰 갱신 성공: userId={}", user.getId());
+        log.info("토큰 로테이션 성공: userId={}, tokenFamily={}", user.getId(), oldToken.getTokenFamily());
 
-        return TokenRefreshResponse.of(newAccessToken, accessTokenValidity);
+        return new TokenRotationResult(
+                newAccessToken, newRefreshTokenValue, accessTokenValidity, refreshTokenValidity);
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,8 +7,9 @@ spring:
 
 app:
   jwt:
-    access-token-validity: 3600000      # 1시간
-    refresh-token-validity: 604800000   # 7일
+    access-token-validity: 300000        # 5분
+    refresh-token-validity: 259200000   # 3일
+    refresh-token-grace-period: 10000   # 10초
     issuer: igrus-api
     audience: igrus-web
   security:

--- a/backend/src/main/resources/db/migration/V20__add_refresh_token_rotation_fields.sql
+++ b/backend/src/main/resources/db/migration/V20__add_refresh_token_rotation_fields.sql
@@ -1,0 +1,19 @@
+-- V20: 리프레시 토큰 로테이션 지원 필드 추가
+-- tokenFamily: 같은 로그인 세션에서 파생된 토큰 체인을 그룹화
+-- replacedByToken: 로테이션 시 어떤 새 토큰으로 교체되었는지 추적
+-- revokedAt: 폐기 시점 기록 (Grace Period 판단용)
+
+ALTER TABLE refresh_tokens
+    ADD COLUMN refresh_tokens_token_family VARCHAR(36) NOT NULL DEFAULT '' AFTER refresh_tokens_revoked;
+
+ALTER TABLE refresh_tokens
+    ADD COLUMN refresh_tokens_replaced_by_token VARCHAR(2048) NULL AFTER refresh_tokens_token_family;
+
+ALTER TABLE refresh_tokens
+    ADD COLUMN refresh_tokens_revoked_at DATETIME(6) NULL AFTER refresh_tokens_replaced_by_token;
+
+-- 기존 토큰에 고유한 token_family 값 부여
+UPDATE refresh_tokens SET refresh_tokens_token_family = UUID() WHERE refresh_tokens_token_family = '';
+
+-- token_family 기반 조회를 위한 인덱스
+CREATE INDEX idx_refresh_tokens_token_family ON refresh_tokens(refresh_tokens_token_family);

--- a/backend/src/test/java/igrus/web/security/auth/common/domain/RefreshTokenTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/common/domain/RefreshTokenTest.java
@@ -7,12 +7,15 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("RefreshToken 도메인")
 class RefreshTokenTest {
+
+    private static final String TEST_TOKEN_FAMILY = "test-family-uuid";
 
     private User createTestUser() {
         return User.create("20231234", "홍길동", "test@inha.edu", "010-1234-5678", "컴퓨터공학과", "테스트 동기", Gender.MALE, 1);
@@ -28,15 +31,16 @@ class RefreshTokenTest {
             // given
             User user = createTestUser();
             String token = "test-refresh-token";
-            long expiryMillis = 604800000L; // 7일
+            long expiryMillis = 259200000L; // 3일
 
             // when
-            RefreshToken refreshToken = RefreshToken.create(user, token, expiryMillis);
+            RefreshToken refreshToken = RefreshToken.create(user, token, expiryMillis, TEST_TOKEN_FAMILY);
 
             // then
             assertThat(refreshToken).isNotNull();
             assertThat(refreshToken.getUser()).isEqualTo(user);
             assertThat(refreshToken.getToken()).isEqualTo(token);
+            assertThat(refreshToken.getTokenFamily()).isEqualTo(TEST_TOKEN_FAMILY);
         }
 
         @Test
@@ -45,12 +49,12 @@ class RefreshTokenTest {
             // given
             User user = createTestUser();
             String token = "test-refresh-token";
-            long expiryMillis = 604800000L; // 7일
+            long expiryMillis = 259200000L; // 3일
 
             Instant beforeCreate = Instant.now();
 
             // when
-            RefreshToken refreshToken = RefreshToken.create(user, token, expiryMillis);
+            RefreshToken refreshToken = RefreshToken.create(user, token, expiryMillis, TEST_TOKEN_FAMILY);
 
             // then
             Instant afterCreate = Instant.now();
@@ -68,13 +72,46 @@ class RefreshTokenTest {
             // given
             User user = createTestUser();
             String token = "test-refresh-token";
-            long expiryMillis = 604800000L;
+            long expiryMillis = 259200000L;
 
             // when
-            RefreshToken refreshToken = RefreshToken.create(user, token, expiryMillis);
+            RefreshToken refreshToken = RefreshToken.create(user, token, expiryMillis, TEST_TOKEN_FAMILY);
 
             // then
             assertThat(refreshToken.isRevoked()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("createInitial 정적 팩토리 메서드")
+    class CreateInitialTest {
+
+        @Test
+        @DisplayName("createInitial로 생성 시 tokenFamily가 자동 생성")
+        void createInitial_GeneratesTokenFamily() {
+            // given
+            User user = createTestUser();
+
+            // when
+            RefreshToken refreshToken = RefreshToken.createInitial(user, "token", 259200000L);
+
+            // then
+            assertThat(refreshToken.getTokenFamily()).isNotNull();
+            assertThat(refreshToken.getTokenFamily()).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("createInitial로 두 번 생성 시 서로 다른 tokenFamily")
+        void createInitial_TwoCalls_DifferentFamilies() {
+            // given
+            User user = createTestUser();
+
+            // when
+            RefreshToken token1 = RefreshToken.createInitial(user, "token1", 259200000L);
+            RefreshToken token2 = RefreshToken.createInitial(user, "token2", 259200000L);
+
+            // then
+            assertThat(token1.getTokenFamily()).isNotEqualTo(token2.getTokenFamily());
         }
     }
 
@@ -87,7 +124,7 @@ class RefreshTokenTest {
         void isExpired_WhenExpired_ReturnsTrue() throws Exception {
             // given
             User user = createTestUser();
-            RefreshToken refreshToken = RefreshToken.create(user, "token", 1000L);
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 1000L, TEST_TOKEN_FAMILY);
 
             // 리플렉션으로 expiresAt을 과거 시간으로 설정
             Field expiresAtField = RefreshToken.class.getDeclaredField("expiresAt");
@@ -106,7 +143,7 @@ class RefreshTokenTest {
         void isExpired_WhenNotExpired_ReturnsFalse() {
             // given
             User user = createTestUser();
-            RefreshToken refreshToken = RefreshToken.create(user, "token", 604800000L); // 7일
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 259200000L, TEST_TOKEN_FAMILY);
 
             // when
             boolean expired = refreshToken.isExpired();
@@ -125,7 +162,7 @@ class RefreshTokenTest {
         void isValid_WhenNotExpiredAndNotRevoked_ReturnsTrue() {
             // given
             User user = createTestUser();
-            RefreshToken refreshToken = RefreshToken.create(user, "token", 604800000L);
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 259200000L, TEST_TOKEN_FAMILY);
 
             // when
             boolean valid = refreshToken.isValid();
@@ -139,7 +176,7 @@ class RefreshTokenTest {
         void isValid_WhenExpired_ReturnsFalse() throws Exception {
             // given
             User user = createTestUser();
-            RefreshToken refreshToken = RefreshToken.create(user, "token", 1000L);
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 1000L, TEST_TOKEN_FAMILY);
 
             // 리플렉션으로 expiresAt을 과거 시간으로 설정
             Field expiresAtField = RefreshToken.class.getDeclaredField("expiresAt");
@@ -158,7 +195,7 @@ class RefreshTokenTest {
         void isValid_WhenRevoked_ReturnsFalse() {
             // given
             User user = createTestUser();
-            RefreshToken refreshToken = RefreshToken.create(user, "token", 604800000L);
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 259200000L, TEST_TOKEN_FAMILY);
             refreshToken.revoke();
 
             // when
@@ -173,7 +210,7 @@ class RefreshTokenTest {
         void isValid_WhenExpiredAndRevoked_ReturnsFalse() throws Exception {
             // given
             User user = createTestUser();
-            RefreshToken refreshToken = RefreshToken.create(user, "token", 1000L);
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 1000L, TEST_TOKEN_FAMILY);
             refreshToken.revoke();
 
             // 리플렉션으로 expiresAt을 과거 시간으로 설정
@@ -194,18 +231,23 @@ class RefreshTokenTest {
     class RevokeTest {
 
         @Test
-        @DisplayName("revoke 호출 시 revoked가 true로 변경")
-        void revoke_ChangesRevokedToTrue() {
+        @DisplayName("revoke 호출 시 revoked가 true로 변경되고 revokedAt이 설정")
+        void revoke_ChangesRevokedToTrueAndSetsRevokedAt() {
             // given
             User user = createTestUser();
-            RefreshToken refreshToken = RefreshToken.create(user, "token", 604800000L);
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 259200000L, TEST_TOKEN_FAMILY);
             assertThat(refreshToken.isRevoked()).isFalse();
+            assertThat(refreshToken.getRevokedAt()).isNull();
+
+            Instant beforeRevoke = Instant.now();
 
             // when
             refreshToken.revoke();
 
             // then
             assertThat(refreshToken.isRevoked()).isTrue();
+            assertThat(refreshToken.getRevokedAt()).isNotNull();
+            assertThat(refreshToken.getRevokedAt()).isAfterOrEqualTo(beforeRevoke);
         }
 
         @Test
@@ -213,7 +255,7 @@ class RefreshTokenTest {
         void revoke_WhenAlreadyRevoked_StaysRevoked() {
             // given
             User user = createTestUser();
-            RefreshToken refreshToken = RefreshToken.create(user, "token", 604800000L);
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 259200000L, TEST_TOKEN_FAMILY);
             refreshToken.revoke();
 
             // when
@@ -221,6 +263,84 @@ class RefreshTokenTest {
 
             // then
             assertThat(refreshToken.isRevoked()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("rotateWith 메서드")
+    class RotateWithTest {
+
+        @Test
+        @DisplayName("rotateWith 호출 시 토큰이 폐기되고 교체 토큰이 기록")
+        void rotateWith_RevokesAndRecordsReplacement() {
+            // given
+            User user = createTestUser();
+            RefreshToken refreshToken = RefreshToken.create(user, "old-token", 259200000L, TEST_TOKEN_FAMILY);
+            String newToken = "new-token";
+
+            Instant beforeRotate = Instant.now();
+
+            // when
+            refreshToken.rotateWith(newToken);
+
+            // then
+            assertThat(refreshToken.isRevoked()).isTrue();
+            assertThat(refreshToken.getRevokedAt()).isAfterOrEqualTo(beforeRotate);
+            assertThat(refreshToken.getReplacedByToken()).isEqualTo(newToken);
+        }
+    }
+
+    @Nested
+    @DisplayName("isWithinGracePeriod 메서드")
+    class IsWithinGracePeriodTest {
+
+        @Test
+        @DisplayName("폐기되지 않은 토큰은 Grace Period 내가 아님")
+        void isWithinGracePeriod_WhenNotRevoked_ReturnsFalse() {
+            // given
+            User user = createTestUser();
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 259200000L, TEST_TOKEN_FAMILY);
+
+            // when
+            boolean withinGracePeriod = refreshToken.isWithinGracePeriod(Duration.ofSeconds(10));
+
+            // then
+            assertThat(withinGracePeriod).isFalse();
+        }
+
+        @Test
+        @DisplayName("폐기 직후 토큰은 Grace Period 내")
+        void isWithinGracePeriod_WhenJustRevoked_ReturnsTrue() {
+            // given
+            User user = createTestUser();
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 259200000L, TEST_TOKEN_FAMILY);
+            refreshToken.revoke();
+
+            // when
+            boolean withinGracePeriod = refreshToken.isWithinGracePeriod(Duration.ofSeconds(10));
+
+            // then
+            assertThat(withinGracePeriod).isTrue();
+        }
+
+        @Test
+        @DisplayName("Grace Period가 지난 토큰은 false 반환")
+        void isWithinGracePeriod_WhenPastGracePeriod_ReturnsFalse() throws Exception {
+            // given
+            User user = createTestUser();
+            RefreshToken refreshToken = RefreshToken.create(user, "token", 259200000L, TEST_TOKEN_FAMILY);
+            refreshToken.revoke();
+
+            // revokedAt을 과거로 설정 (11초 전)
+            Field revokedAtField = RefreshToken.class.getDeclaredField("revokedAt");
+            revokedAtField.setAccessible(true);
+            revokedAtField.set(refreshToken, Instant.now().minusSeconds(11));
+
+            // when
+            boolean withinGracePeriod = refreshToken.isWithinGracePeriod(Duration.ofSeconds(10));
+
+            // then
+            assertThat(withinGracePeriod).isFalse();
         }
     }
 }

--- a/backend/src/test/java/igrus/web/security/auth/common/service/RefreshTokenCleanupServiceTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/common/service/RefreshTokenCleanupServiceTest.java
@@ -31,7 +31,7 @@ class RefreshTokenCleanupServiceTest extends ServiceIntegrationTestBase {
     }
 
     private RefreshToken createAndSaveRefreshToken(User user, Instant expiresAt) {
-        RefreshToken token = RefreshToken.create(user, "token-" + System.nanoTime(), 3600000L);
+        RefreshToken token = RefreshToken.createInitial(user, "token-" + System.nanoTime(), 3600000L);
         ReflectionTestUtils.setField(token, "expiresAt", expiresAt);
         return refreshTokenRepository.save(token);
     }

--- a/backend/src/test/java/igrus/web/security/auth/common/service/WithdrawnUserCleanupServiceTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/common/service/WithdrawnUserCleanupServiceTest.java
@@ -78,7 +78,7 @@ class WithdrawnUserCleanupServiceTest extends ServiceIntegrationTestBase {
 
     private RefreshToken createAndSaveRefreshToken(User user) {
         long sevenDaysInMillis = Duration.ofDays(7).toMillis();
-        RefreshToken token = RefreshToken.create(user, "test-refresh-token", sevenDaysInMillis);
+        RefreshToken token = RefreshToken.createInitial(user, "test-refresh-token", sevenDaysInMillis);
         return refreshTokenRepository.save(token);
     }
 

--- a/backend/src/test/java/igrus/web/security/auth/e2e/AuthFlowE2ETest.java
+++ b/backend/src/test/java/igrus/web/security/auth/e2e/AuthFlowE2ETest.java
@@ -61,6 +61,7 @@ class AuthFlowE2ETest extends ServiceIntegrationTestBase {
 
     private static final long ACCESS_TOKEN_VALIDITY = 3600000L; // 1시간
     private static final long REFRESH_TOKEN_VALIDITY = 604800000L; // 7일
+    private static final long REFRESH_TOKEN_GRACE_PERIOD = 10000L; // 10초
     private static final long VERIFICATION_CODE_EXPIRY = 600000L; // 10분
 
     private static final String TEST_STUDENT_ID = "12345678";
@@ -106,6 +107,8 @@ class AuthFlowE2ETest extends ServiceIntegrationTestBase {
         ReflectionTestUtils.setField(loginService, "accessTokenValidity", ACCESS_TOKEN_VALIDITY);
         ReflectionTestUtils.setField(loginService, "refreshTokenValidity", REFRESH_TOKEN_VALIDITY);
         ReflectionTestUtils.setField(refreshTokenService, "accessTokenValidity", ACCESS_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(refreshTokenService, "refreshTokenValidity", REFRESH_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(refreshTokenService, "gracePeriodMillis", REFRESH_TOKEN_GRACE_PERIOD);
         ReflectionTestUtils.setField(signupService, "verificationCodeExpiry", VERIFICATION_CODE_EXPIRY);
         ReflectionTestUtils.setField(verifyEmailService, "maxAttempts", 5);
         ReflectionTestUtils.setField(resendVerificationService, "verificationCodeExpiry", VERIFICATION_CODE_EXPIRY);
@@ -200,7 +203,7 @@ class AuthFlowE2ETest extends ServiceIntegrationTestBase {
     class TokenRefreshFlowTest {
 
         @Test
-        @DisplayName("E2E-HTTP-002: 로그인 → 토큰 갱신 → 새 토큰으로 검증")
+        @DisplayName("E2E-HTTP-002: 로그인 → 토큰 갱신 → 새 토큰으로 검증 (로테이션 포함)")
         void tokenRefreshFlow_viaHttp() throws Exception {
             // === Setup: 인증된 사용자 생성 ===
             User user = createAndSaveUser(TEST_STUDENT_ID, TEST_EMAIL, UserRole.MEMBER);
@@ -222,7 +225,7 @@ class AuthFlowE2ETest extends ServiceIntegrationTestBase {
             String refreshToken = extractRefreshTokenFromCookie(loginResult);
             assertThat(refreshToken).isNotNull();
 
-            // === Step 2: POST /refresh (쿠키로) → 새 Access Token 발급 ===
+            // === Step 2: POST /refresh (쿠키로) → 새 Access Token + 새 Refresh Token 발급 ===
             MvcResult refreshResult = mockMvc.perform(post(API_BASE_PATH + "/refresh")
                             .cookie(new Cookie("refreshToken", refreshToken)))
                     .andExpect(status().isOk())
@@ -236,13 +239,18 @@ class AuthFlowE2ETest extends ServiceIntegrationTestBase {
             // === Step 3: 새 Access Token이 다른 것 확인 ===
             assertThat(newAccessToken).isNotEqualTo(originalAccessToken);
 
-            // === Step 4: 새 Access Token으로 사용자 정보 검증 ===
+            // === Step 4: Set-Cookie 헤더에 새 Refresh Token 포함 확인 ===
+            String newRefreshToken = extractRefreshTokenFromCookie(refreshResult);
+            assertThat(newRefreshToken).isNotNull();
+            assertThat(newRefreshToken).isNotEqualTo(refreshToken);
+
+            // === Step 5: 새 Access Token으로 사용자 정보 검증 ===
             var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(newAccessToken);
             assertThat(jwtTokenProvider.getUserIdFromClaims(claims)).isEqualTo(user.getId());
         }
 
         @Test
-        @DisplayName("E2E-HTTP-003: 여러 번 토큰 갱신해도 항상 새로운 토큰 발급")
+        @DisplayName("E2E-HTTP-003: 연쇄 토큰 갱신 시 매번 새 Refresh Token으로 갱신")
         void multipleTokenRefreshes_viaHttp() throws Exception {
             // === Setup ===
             User user = createAndSaveUser(TEST_STUDENT_ID, TEST_EMAIL, UserRole.MEMBER);
@@ -258,24 +266,27 @@ class AuthFlowE2ETest extends ServiceIntegrationTestBase {
                     .andExpect(status().isOk())
                     .andReturn();
 
-            String refreshToken = extractRefreshTokenFromCookie(loginResult);
-            assertThat(refreshToken).isNotNull();
+            String currentRefreshToken = extractRefreshTokenFromCookie(loginResult);
+            assertThat(currentRefreshToken).isNotNull();
 
-            // === 여러 번 갱신 (쿠키로) ===
+            // === 연쇄 갱신 - 매번 새 Refresh Token 사용 ===
             MvcResult refresh1 = mockMvc.perform(post(API_BASE_PATH + "/refresh")
-                            .cookie(new Cookie("refreshToken", refreshToken)))
+                            .cookie(new Cookie("refreshToken", currentRefreshToken)))
                     .andExpect(status().isOk())
                     .andReturn();
 
+            String refreshToken1 = extractRefreshTokenFromCookie(refresh1);
+            assertThat(refreshToken1).isNotNull().isNotEqualTo(currentRefreshToken);
+
             MvcResult refresh2 = mockMvc.perform(post(API_BASE_PATH + "/refresh")
-                            .cookie(new Cookie("refreshToken", refreshToken)))
+                            .cookie(new Cookie("refreshToken", refreshToken1)))
                     .andExpect(status().isOk())
                     .andReturn();
 
             String token1 = objectMapper.readTree(refresh1.getResponse().getContentAsString()).get("accessToken").asText();
             String token2 = objectMapper.readTree(refresh2.getResponse().getContentAsString()).get("accessToken").asText();
 
-            // 서로 다른 토큰
+            // 서로 다른 Access Token
             assertThat(token1).isNotEqualTo(token2);
         }
     }
@@ -370,13 +381,18 @@ class AuthFlowE2ETest extends ServiceIntegrationTestBase {
             // === Step 4: Device A 토큰 무효화 확인 ===
             assertThat(refreshTokenRepository.findByTokenAndRevokedFalse(deviceARefreshToken)).isEmpty();
 
-            // === Step 5: Device B 토큰 유효 확인 ===
+            // === Step 5: Device B 토큰 유효 확인 및 갱신 가능 ===
             assertThat(refreshTokenRepository.findByTokenAndRevokedFalse(deviceBRefreshToken)).isPresent();
 
-            // Device B로 토큰 갱신 가능
-            mockMvc.perform(post(API_BASE_PATH + "/refresh")
+            // Device B로 토큰 갱신 가능 (로테이션 포함)
+            MvcResult deviceBRefreshResult = mockMvc.perform(post(API_BASE_PATH + "/refresh")
                             .cookie(new Cookie("refreshToken", deviceBRefreshToken)))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // Device B의 새 Refresh Token 발급 확인
+            String newDeviceBRefreshToken = extractRefreshTokenFromCookie(deviceBRefreshResult);
+            assertThat(newDeviceBRefreshToken).isNotNull().isNotEqualTo(deviceBRefreshToken);
         }
 
         @Test

--- a/backend/src/test/java/igrus/web/security/auth/e2e/AuthenticationE2ETest.java
+++ b/backend/src/test/java/igrus/web/security/auth/e2e/AuthenticationE2ETest.java
@@ -13,7 +13,7 @@ import igrus.web.security.auth.password.dto.internal.LoginResult;
 import igrus.web.security.auth.password.dto.request.PasswordLoginRequest;
 import igrus.web.security.auth.password.dto.request.PasswordSignupRequest;
 import igrus.web.security.auth.password.dto.response.PasswordSignupResponse;
-import igrus.web.security.auth.password.dto.response.TokenRefreshResponse;
+import igrus.web.security.auth.password.dto.internal.TokenRotationResult;
 import igrus.web.security.auth.password.service.reset.RequestPasswordResetService;
 import igrus.web.security.auth.password.service.reset.ResetPasswordService;
 import igrus.web.security.auth.password.service.reset.ValidateResetTokenService;
@@ -100,6 +100,7 @@ class AuthenticationE2ETest extends ServiceIntegrationTestBase {
 
     private static final long ACCESS_TOKEN_VALIDITY = 3600000L; // 1시간
     private static final long REFRESH_TOKEN_VALIDITY = 604800000L; // 7일
+    private static final long REFRESH_TOKEN_GRACE_PERIOD = 10000L; // 10초
     private static final long VERIFICATION_CODE_EXPIRY = 600000L; // 10분
     private static final long PASSWORD_RESET_EXPIRY = 1800000L; // 30분
 
@@ -119,6 +120,8 @@ class AuthenticationE2ETest extends ServiceIntegrationTestBase {
         ReflectionTestUtils.setField(loginService, "accessTokenValidity", ACCESS_TOKEN_VALIDITY);
         ReflectionTestUtils.setField(loginService, "refreshTokenValidity", REFRESH_TOKEN_VALIDITY);
         ReflectionTestUtils.setField(refreshTokenService, "accessTokenValidity", ACCESS_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(refreshTokenService, "refreshTokenValidity", REFRESH_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(refreshTokenService, "gracePeriodMillis", REFRESH_TOKEN_GRACE_PERIOD);
         ReflectionTestUtils.setField(signupService, "verificationCodeExpiry", VERIFICATION_CODE_EXPIRY);
         ReflectionTestUtils.setField(verifyEmailService, "maxAttempts", 5);
         ReflectionTestUtils.setField(resendVerificationService, "verificationCodeExpiry", VERIFICATION_CODE_EXPIRY);
@@ -270,7 +273,7 @@ class AuthenticationE2ETest extends ServiceIntegrationTestBase {
     class TokenRefreshFlowTest {
 
         @Test
-        @DisplayName("Access Token 만료 후 Refresh Token으로 갱신 성공")
+        @DisplayName("Access Token 만료 후 Refresh Token으로 갱신 성공 (로테이션 포함)")
         void accessTokenExpired_refreshSucceeds() {
             // === Setup: 인증된 사용자 생성 및 로그인 ===
             User user = createAndSaveUser(TEST_STUDENT_ID, TEST_EMAIL, UserRole.MEMBER);
@@ -284,25 +287,23 @@ class AuthenticationE2ETest extends ServiceIntegrationTestBase {
             String originalAccessToken = loginResult.accessToken();
             String refreshToken = loginResult.refreshToken();
 
-            // === Step 1: Access Token 만료 시뮬레이션 (실제로 만료된 것처럼 가정) ===
-            // 실제 만료를 기다릴 수 없으므로, 새로운 토큰 발급으로 시뮬레이션
+            // === Step 1: Refresh Token으로 새 Access Token + 새 Refresh Token 발급 ===
+            TokenRotationResult rotationResult = refreshTokenService.refreshToken(refreshToken);
 
-            // === Step 2: Refresh Token으로 새 Access Token 발급 ===
-            TokenRefreshResponse refreshResponse = refreshTokenService.refreshToken(refreshToken);
+            assertThat(rotationResult).isNotNull();
+            assertThat(rotationResult.accessToken()).isNotNull();
+            assertThat(rotationResult.accessToken()).isNotEqualTo(originalAccessToken);
+            assertThat(rotationResult.accessTokenValidity()).isEqualTo(ACCESS_TOKEN_VALIDITY);
+            assertThat(rotationResult.newRefreshToken()).isNotNull().isNotEqualTo(refreshToken);
 
-            assertThat(refreshResponse).isNotNull();
-            assertThat(refreshResponse.accessToken()).isNotNull();
-            assertThat(refreshResponse.accessToken()).isNotEqualTo(originalAccessToken);
-            assertThat(refreshResponse.expiresIn()).isEqualTo(ACCESS_TOKEN_VALIDITY);
-
-            // === Step 3: 새 Access Token으로 API 호출 가능 확인 ===
-            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(refreshResponse.accessToken());
+            // === Step 2: 새 Access Token으로 API 호출 가능 확인 ===
+            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(rotationResult.accessToken());
             assertThat(jwtTokenProvider.getUserIdFromClaims(claims)).isEqualTo(user.getId());
             assertThat(jwtTokenProvider.getStudentIdFromClaims(claims)).isEqualTo(TEST_STUDENT_ID);
         }
 
         @Test
-        @DisplayName("여러 번 토큰 갱신해도 항상 새로운 Access Token 발급")
+        @DisplayName("연쇄 토큰 갱신 시 매번 새로운 Access Token 및 Refresh Token 발급")
         void multipleRefreshes_alwaysNewAccessToken() {
             // === Setup ===
             User user = createAndSaveUser(TEST_STUDENT_ID, TEST_EMAIL, UserRole.MEMBER);
@@ -313,16 +314,16 @@ class AuthenticationE2ETest extends ServiceIntegrationTestBase {
             PasswordLoginRequest loginRequest = new PasswordLoginRequest(TEST_STUDENT_ID, TEST_PASSWORD);
             LoginResult loginResult = loginService.login(loginRequest, TEST_IP_ADDRESS, TEST_USER_AGENT);
 
-            String refreshToken = loginResult.refreshToken();
+            // === 연쇄 갱신 - 매번 새 Refresh Token 사용 ===
+            TokenRotationResult response1 = refreshTokenService.refreshToken(loginResult.refreshToken());
+            TokenRotationResult response2 = refreshTokenService.refreshToken(response1.newRefreshToken());
+            TokenRotationResult response3 = refreshTokenService.refreshToken(response2.newRefreshToken());
 
-            // === 여러 번 갱신 ===
-            TokenRefreshResponse response1 = refreshTokenService.refreshToken(refreshToken);
-            TokenRefreshResponse response2 = refreshTokenService.refreshToken(refreshToken);
-            TokenRefreshResponse response3 = refreshTokenService.refreshToken(refreshToken);
-
-            // 매번 다른 Access Token
+            // 매번 다른 Access Token 및 Refresh Token
             assertThat(response1.accessToken()).isNotEqualTo(response2.accessToken());
             assertThat(response2.accessToken()).isNotEqualTo(response3.accessToken());
+            assertThat(response1.newRefreshToken()).isNotEqualTo(response2.newRefreshToken());
+            assertThat(response2.newRefreshToken()).isNotEqualTo(response3.newRefreshToken());
         }
     }
 

--- a/backend/src/test/java/igrus/web/security/auth/password/controller/ControllerIntegrationTestBase.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/controller/ControllerIntegrationTestBase.java
@@ -48,6 +48,7 @@ public abstract class ControllerIntegrationTestBase extends ServiceIntegrationTe
 
     protected static final long ACCESS_TOKEN_VALIDITY = 3600000L; // 1시간
     protected static final long REFRESH_TOKEN_VALIDITY = 604800000L; // 7일
+    protected static final long REFRESH_TOKEN_GRACE_PERIOD = 10000L; // 10초
     protected static final long VERIFICATION_CODE_EXPIRY = 600000L; // 10분
     protected static final int MAX_VERIFICATION_ATTEMPTS = 5;
     protected static final long RESEND_RATE_LIMIT_SECONDS = 60L;
@@ -107,6 +108,8 @@ public abstract class ControllerIntegrationTestBase extends ServiceIntegrationTe
         ReflectionTestUtils.setField(loginService, "accessTokenValidity", ACCESS_TOKEN_VALIDITY);
         ReflectionTestUtils.setField(loginService, "refreshTokenValidity", REFRESH_TOKEN_VALIDITY);
         ReflectionTestUtils.setField(refreshTokenService, "accessTokenValidity", ACCESS_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(refreshTokenService, "refreshTokenValidity", REFRESH_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(refreshTokenService, "gracePeriodMillis", REFRESH_TOKEN_GRACE_PERIOD);
         ReflectionTestUtils.setField(signupService, "verificationCodeExpiry", VERIFICATION_CODE_EXPIRY);
         ReflectionTestUtils.setField(verifyEmailService, "maxAttempts", MAX_VERIFICATION_ATTEMPTS);
         ReflectionTestUtils.setField(resendVerificationService, "verificationCodeExpiry", VERIFICATION_CODE_EXPIRY);

--- a/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerTokenIntegrationTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerTokenIntegrationTest.java
@@ -75,19 +75,17 @@ class PasswordAuthControllerTokenIntegrationTest extends ControllerIntegrationTe
         }
 
         @Test
-        @DisplayName("[TOK-003] 여러 번 토큰 갱신 시 매번 새로운 Access Token 발급")
+        @DisplayName("[TOK-003] 여러 번 토큰 갱신 시 매번 새로운 Access Token 및 Refresh Token 발급")
         void refreshToken_multipleRefreshes_generatesUniqueTokens() throws Exception {
             // given
             createAndSaveDefaultUserWithCredential();
             PasswordLoginRequest loginRequest = new PasswordLoginRequest(TEST_STUDENT_ID, TEST_PASSWORD);
             LoginResult loginResult = loginService.login(loginRequest, TEST_IP_ADDRESS, TEST_USER_AGENT);
 
-            String refreshToken = loginResult.refreshToken();
-
-            // when
-            var response1 = refreshTokenService.refreshToken(refreshToken);
-            var response2 = refreshTokenService.refreshToken(refreshToken);
-            var response3 = refreshTokenService.refreshToken(refreshToken);
+            // when - 로테이션으로 매번 새 리프레시 토큰 사용
+            var response1 = refreshTokenService.refreshToken(loginResult.refreshToken());
+            var response2 = refreshTokenService.refreshToken(response1.newRefreshToken());
+            var response3 = refreshTokenService.refreshToken(response2.newRefreshToken());
 
             // then - 모든 Access Token이 서로 다름
             assertThat(response1.accessToken())

--- a/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerTokenTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerTokenTest.java
@@ -8,7 +8,7 @@ import igrus.web.security.auth.common.service.account.CheckRecoveryEligibilitySe
 import igrus.web.security.auth.common.service.account.RecoverAccountService;
 import igrus.web.security.auth.common.service.AccountStatusService;
 import igrus.web.security.auth.common.util.CookieUtil;
-import igrus.web.security.auth.password.dto.response.TokenRefreshResponse;
+import igrus.web.security.auth.password.dto.internal.TokenRotationResult;
 import igrus.web.security.auth.password.service.reset.RequestPasswordResetService;
 import igrus.web.security.auth.password.service.reset.ResetPasswordService;
 import igrus.web.security.auth.password.service.reset.ValidateResetTokenService;
@@ -25,11 +25,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseCookie;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -98,12 +100,20 @@ class PasswordAuthControllerTokenTest {
     private static final String FORGED_REFRESH_TOKEN = "forged.malicious.token";
     private static final String REVOKED_REFRESH_TOKEN = "revoked.logout.token";
     private static final long EXPIRES_IN = 3600000L; // 1 hour
+    private static final long REFRESH_TOKEN_VALIDITY = 604800000L; // 7 days
 
     @BeforeEach
     void setUp() {
         // Mock for refresh - getRefreshTokenFromCookies returns the token from cookie
         given(cookieUtil.getRefreshTokenFromCookies(any()))
                 .willReturn(Optional.of(VALID_REFRESH_TOKEN));
+
+        // Mock for refresh - createRefreshTokenCookie returns a cookie
+        given(cookieUtil.createRefreshTokenCookie(anyString(), any(Duration.class)))
+                .willReturn(ResponseCookie.from("refreshToken", "new.refresh.token")
+                        .httpOnly(true)
+                        .path("/api/v1/auth")
+                        .build());
     }
 
     @Nested
@@ -114,9 +124,9 @@ class PasswordAuthControllerTokenTest {
         @DisplayName("유효한 Refresh Token으로 갱신 시 새 Access Token 반환 [TKN-001]")
         void refreshToken_withValidToken_returns200() throws Exception {
             // given
-            TokenRefreshResponse response = TokenRefreshResponse.of("new.access.token", EXPIRES_IN);
+            TokenRotationResult result = new TokenRotationResult("new.access.token", "new.refresh.token", EXPIRES_IN, REFRESH_TOKEN_VALIDITY);
             given(refreshTokenService.refreshToken(anyString()))
-                .willReturn(response);
+                .willReturn(result);
 
             // when & then
             mockMvc.perform(post("/api/v1/auth/password/refresh")
@@ -130,9 +140,9 @@ class PasswordAuthControllerTokenTest {
         @DisplayName("새 Access Token 유효기간 확인 [TKN-002]")
         void refreshToken_withValidToken_returnsExpiresInGreaterThanZero() throws Exception {
             // given
-            TokenRefreshResponse response = TokenRefreshResponse.of("new.access.token", EXPIRES_IN);
+            TokenRotationResult result = new TokenRotationResult("new.access.token", "new.refresh.token", EXPIRES_IN, REFRESH_TOKEN_VALIDITY);
             given(refreshTokenService.refreshToken(anyString()))
-                .willReturn(response);
+                .willReturn(result);
 
             // when & then
             mockMvc.perform(post("/api/v1/auth/password/refresh")
@@ -147,9 +157,9 @@ class PasswordAuthControllerTokenTest {
         void refreshToken_withValidToken_returnsValidAccessToken() throws Exception {
             // given
             String newAccessToken = "valid.new.access.token.for.api.calls";
-            TokenRefreshResponse response = TokenRefreshResponse.of(newAccessToken, EXPIRES_IN);
+            TokenRotationResult result = new TokenRotationResult(newAccessToken, "new.refresh.token", EXPIRES_IN, REFRESH_TOKEN_VALIDITY);
             given(refreshTokenService.refreshToken(anyString()))
-                .willReturn(response);
+                .willReturn(result);
 
             // when & then
             mockMvc.perform(post("/api/v1/auth/password/refresh")

--- a/backend/src/test/java/igrus/web/security/auth/password/integration/PasswordResetIntegrationTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/integration/PasswordResetIntegrationTest.java
@@ -110,7 +110,7 @@ class PasswordResetIntegrationTest extends ServiceIntegrationTestBase {
     }
 
     private RefreshToken createAndSaveRefreshToken(User user, String token) {
-        RefreshToken refreshToken = RefreshToken.create(user, token, 604800000L);
+        RefreshToken refreshToken = RefreshToken.createInitial(user, token, 604800000L);
         return refreshTokenRepository.save(refreshToken);
     }
 

--- a/backend/src/test/java/igrus/web/security/auth/password/integration/TokenRefreshIntegrationTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/integration/TokenRefreshIntegrationTest.java
@@ -4,7 +4,8 @@ import igrus.web.common.ServiceIntegrationTestBase;
 import igrus.web.security.auth.common.domain.RefreshToken;
 import igrus.web.security.auth.common.exception.token.RefreshTokenExpiredException;
 import igrus.web.security.auth.common.exception.token.RefreshTokenInvalidException;
-import igrus.web.security.auth.password.dto.response.TokenRefreshResponse;
+import igrus.web.security.auth.common.exception.token.RefreshTokenTheftException;
+import igrus.web.security.auth.password.dto.internal.TokenRotationResult;
 import igrus.web.security.auth.password.service.auth.RefreshTokenService;
 import igrus.web.security.jwt.JwtTokenProvider;
 import igrus.web.user.domain.User;
@@ -22,16 +23,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * 토큰 갱신 통합 테스트 (18개 테스트 케이스)
+ * 토큰 갱신 통합 테스트
  *
  * <p>테스트 케이스 문서: docs/test-case/auth/token-test-cases.md</p>
  *
  * <p>테스트 범위:</p>
  * <ul>
- *     <li>TKN-001 ~ TKN-004: 토큰 갱신 성공</li>
+ *     <li>TKN-001 ~ TKN-008: 토큰 갱신 및 로테이션 성공</li>
  *     <li>TKN-010 ~ TKN-014: 토큰 갱신 실패</li>
  *     <li>TKN-020 ~ TKN-024: 계정 상태 변경 시 토큰 처리</li>
- *     <li>TKN-030 ~ TKN-032: 토큰 보안</li>
+ *     <li>TKN-030 ~ TKN-032: 토큰 보안 및 탈취 감지</li>
  * </ul>
  */
 @DisplayName("토큰 갱신 통합 테스트")
@@ -43,13 +44,17 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    private static final long ACCESS_TOKEN_VALIDITY = 3600000L; // 1시간
-    private static final long REFRESH_TOKEN_VALIDITY = 604800000L; // 7일
+    private static final long ACCESS_TOKEN_VALIDITY = 300000L; // 5분
+    private static final long REFRESH_TOKEN_VALIDITY = 259200000L; // 3일
+    private static final long GRACE_PERIOD_MILLIS = 10000L; // 10초
+    private static final String TEST_TOKEN_FAMILY = "test-family-uuid";
 
     @BeforeEach
     void setUp() {
         setUpBase();
         ReflectionTestUtils.setField(refreshTokenService, "accessTokenValidity", ACCESS_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(refreshTokenService, "refreshTokenValidity", REFRESH_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(refreshTokenService, "gracePeriodMillis", GRACE_PERIOD_MILLIS);
     }
 
     private User createAndSaveTestUser() {
@@ -57,13 +62,12 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
     }
 
     private RefreshToken createAndSaveValidRefreshToken(User user, String token) {
-        RefreshToken refreshToken = RefreshToken.create(user, token, REFRESH_TOKEN_VALIDITY);
+        RefreshToken refreshToken = RefreshToken.create(user, token, REFRESH_TOKEN_VALIDITY, TEST_TOKEN_FAMILY);
         return refreshTokenRepository.save(refreshToken);
     }
 
     private RefreshToken createAndSaveExpiredRefreshToken(User user, String token) {
-        RefreshToken refreshToken = RefreshToken.create(user, token, REFRESH_TOKEN_VALIDITY);
-        // 리플렉션으로 expiresAt을 과거 시간으로 설정
+        RefreshToken refreshToken = RefreshToken.create(user, token, REFRESH_TOKEN_VALIDITY, TEST_TOKEN_FAMILY);
         ReflectionTestUtils.setField(refreshToken, "expiresAt", Instant.now().minusMillis(1000L));
         return refreshTokenRepository.save(refreshToken);
     }
@@ -83,16 +87,15 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(refreshTokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.accessToken()).isNotNull();
-            assertThat(response.accessToken()).isNotEmpty();
+            assertThat(result).isNotNull();
+            assertThat(result.accessToken()).isNotNull().isNotEmpty();
         }
 
         @Test
-        @DisplayName("[TKN-002] 갱신된 Access Token 1시간 유효")
+        @DisplayName("[TKN-002] 갱신된 Access Token 유효기간 확인")
         void refreshToken_withValidToken_returnsCorrectExpiresIn() {
             // given
             User user = createAndSaveTestUser();
@@ -100,10 +103,10 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(refreshTokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            assertThat(response.expiresIn()).isEqualTo(ACCESS_TOKEN_VALIDITY);
+            assertThat(result.accessTokenValidity()).isEqualTo(ACCESS_TOKEN_VALIDITY);
         }
 
         @Test
@@ -115,11 +118,11 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(refreshTokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            assertThat(response.accessToken()).isNotNull();
-            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(response.accessToken());
+            assertThat(result.accessToken()).isNotNull();
+            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(result.accessToken());
             assertThat(jwtTokenProvider.getUserIdFromClaims(claims)).isEqualTo(user.getId());
             assertThat(jwtTokenProvider.getStudentIdFromClaims(claims)).isEqualTo(user.getStudentId());
             assertThat(jwtTokenProvider.getRoleFromClaims(claims)).isEqualTo(user.getRole().name());
@@ -134,27 +137,28 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(refreshTokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.accessToken()).isNotNull();
+            assertThat(result).isNotNull();
+            assertThat(result.accessToken()).isNotNull();
         }
 
         @Test
-        @DisplayName("[TKN-003] 여러 번 갱신해도 매번 새로운 Access Token 발급")
-        void refreshToken_multipleTimes_generatesNewAccessTokenEachTime() {
+        @DisplayName("[TKN-003] 연쇄 갱신 시 매번 새로운 Access Token 및 Refresh Token 발급")
+        void refreshToken_chainedRotation_generatesNewTokensEachTime() {
             // given
             User user = createAndSaveTestUser();
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
-            // when
-            TokenRefreshResponse response1 = refreshTokenService.refreshToken(refreshTokenString);
-            TokenRefreshResponse response2 = refreshTokenService.refreshToken(refreshTokenString);
+            // when - 로테이션으로 인해 새 토큰으로 연쇄 갱신
+            TokenRotationResult result1 = refreshTokenService.refreshToken(refreshTokenString);
+            TokenRotationResult result2 = refreshTokenService.refreshToken(result1.newRefreshToken());
 
             // then
-            assertThat(response1.accessToken()).isNotEqualTo(response2.accessToken());
+            assertThat(result1.accessToken()).isNotEqualTo(result2.accessToken());
+            assertThat(result1.newRefreshToken()).isNotEqualTo(result2.newRefreshToken());
         }
     }
 
@@ -211,29 +215,29 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
         }
 
         @Test
-        @DisplayName("[TKN-014] 로그아웃된 Refresh Token으로 갱신 시도 시 예외 발생")
-        void refreshToken_withRevokedToken_throwsException() {
+        @DisplayName("[TKN-014] 로그아웃된 Refresh Token으로 갱신 시도 시 탈취 감지")
+        void refreshToken_withRevokedToken_throwsTheftException() {
             // given
             User user = createAndSaveTestUser();
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
             RefreshToken refreshToken = createAndSaveValidRefreshToken(user, refreshTokenString);
 
-            // 토큰 무효화
+            // 토큰 무효화 (Grace Period 밖)
             refreshToken.revoke();
+            ReflectionTestUtils.setField(refreshToken, "revokedAt", Instant.now().minusSeconds(11));
             refreshTokenRepository.save(refreshToken);
 
             // when & then
             assertThatThrownBy(() -> refreshTokenService.refreshToken(refreshTokenString))
-                    .isInstanceOf(RefreshTokenInvalidException.class);
+                    .isInstanceOf(RefreshTokenTheftException.class);
         }
 
         @Test
         @DisplayName("[TKN-011] DB에 존재하지 않는 토큰으로 갱신 시도 시 예외 발생")
         void refreshToken_withNonExistentToken_throwsException() {
-            // given - DB에 저장하지 않은 유효한 형식의 토큰
+            // given
             User user = createAndSaveTestUser();
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
-            // DB에 저장하지 않음
 
             // when & then
             assertThatThrownBy(() -> refreshTokenService.refreshToken(refreshTokenString))
@@ -259,21 +263,24 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
         }
 
         @Test
-        @DisplayName("[TKN-021] 모든 토큰이 무효화된 경우 갱신 실패")
-        void refreshToken_whenAllTokensRevoked_throwsException() {
+        @DisplayName("[TKN-021] 모든 토큰이 무효화된 경우 탈취 감지")
+        void refreshToken_whenAllTokensRevoked_throwsTheftException() {
             // given
             User user = createAndSaveTestUser();
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
-            // 모든 토큰 무효화 (비밀번호 재설정 등의 시나리오)
             transactionTemplate.executeWithoutResult(status ->
                     refreshTokenRepository.revokeAllByUserId(user.getId())
             );
 
+            RefreshToken revokedToken = refreshTokenRepository.findByToken(refreshTokenString).orElseThrow();
+            ReflectionTestUtils.setField(revokedToken, "revokedAt", Instant.now().minusSeconds(11));
+            refreshTokenRepository.save(revokedToken);
+
             // when & then
             assertThatThrownBy(() -> refreshTokenService.refreshToken(refreshTokenString))
-                    .isInstanceOf(RefreshTokenInvalidException.class);
+                    .isInstanceOf(RefreshTokenTheftException.class);
         }
 
         @Test
@@ -284,21 +291,20 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
             String oldRefreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
             createAndSaveValidRefreshToken(user, oldRefreshTokenString);
 
-            // 모든 토큰 무효화
             transactionTemplate.executeWithoutResult(status ->
                     refreshTokenRepository.revokeAllByUserId(user.getId())
             );
 
-            // 새 토큰 발급
             String newRefreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
-            createAndSaveValidRefreshToken(user, newRefreshTokenString);
+            RefreshToken newToken = RefreshToken.createInitial(user, newRefreshTokenString, REFRESH_TOKEN_VALIDITY);
+            refreshTokenRepository.save(newToken);
 
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(newRefreshTokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(newRefreshTokenString);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.accessToken()).isNotNull();
+            assertThat(result).isNotNull();
+            assertThat(result.accessToken()).isNotNull();
         }
     }
 
@@ -317,10 +323,10 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(refreshTokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
-            // then - 유효한 토큰은 검증 통과
-            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(response.accessToken());
+            // then
+            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(result.accessToken());
             assertThat(claims).isNotNull();
         }
 
@@ -333,10 +339,10 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(refreshTokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(response.accessToken());
+            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(result.accessToken());
             String role = jwtTokenProvider.getRoleFromClaims(claims);
             assertThat(role).isEqualTo(UserRole.MEMBER.name());
         }
@@ -350,10 +356,10 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(refreshTokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(response.accessToken());
+            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(result.accessToken());
             Long userId = jwtTokenProvider.getUserIdFromClaims(claims);
             assertThat(userId).isEqualTo(user.getId());
         }
@@ -367,10 +373,10 @@ class TokenRefreshIntegrationTest extends ServiceIntegrationTestBase {
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(refreshTokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(response.accessToken());
+            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(result.accessToken());
             String studentId = jwtTokenProvider.getStudentIdFromClaims(claims);
             assertThat(studentId).isEqualTo(user.getStudentId());
         }

--- a/backend/src/test/java/igrus/web/security/auth/password/service/auth/RefreshTokenServiceTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/service/auth/RefreshTokenServiceTest.java
@@ -4,7 +4,8 @@ import igrus.web.common.ServiceIntegrationTestBase;
 import igrus.web.security.auth.common.domain.RefreshToken;
 import igrus.web.security.auth.common.exception.token.RefreshTokenExpiredException;
 import igrus.web.security.auth.common.exception.token.RefreshTokenInvalidException;
-import igrus.web.security.auth.password.dto.response.TokenRefreshResponse;
+import igrus.web.security.auth.common.exception.token.RefreshTokenTheftException;
+import igrus.web.security.auth.password.dto.internal.TokenRotationResult;
 import igrus.web.security.jwt.JwtTokenProvider;
 import igrus.web.user.domain.User;
 import igrus.web.user.domain.UserRole;
@@ -29,13 +30,17 @@ class RefreshTokenServiceTest extends ServiceIntegrationTestBase {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    private static final long ACCESS_TOKEN_VALIDITY = 3600000L; // 1시간
-    private static final long REFRESH_TOKEN_VALIDITY = 604800000L; // 7일
+    private static final long ACCESS_TOKEN_VALIDITY = 300000L; // 5분
+    private static final long REFRESH_TOKEN_VALIDITY = 259200000L; // 3일
+    private static final long GRACE_PERIOD_MILLIS = 10000L; // 10초
+    private static final String TEST_TOKEN_FAMILY = "test-family-uuid";
 
     @BeforeEach
     void setUp() {
         setUpBase();
         ReflectionTestUtils.setField(refreshTokenService, "accessTokenValidity", ACCESS_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(refreshTokenService, "refreshTokenValidity", REFRESH_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(refreshTokenService, "gracePeriodMillis", GRACE_PERIOD_MILLIS);
     }
 
     private User createAndSaveTestUser() {
@@ -43,38 +48,35 @@ class RefreshTokenServiceTest extends ServiceIntegrationTestBase {
     }
 
     private RefreshToken createAndSaveValidRefreshToken(User user, String token) {
-        RefreshToken refreshToken = RefreshToken.create(user, token, REFRESH_TOKEN_VALIDITY);
+        RefreshToken refreshToken = RefreshToken.create(user, token, REFRESH_TOKEN_VALIDITY, TEST_TOKEN_FAMILY);
         return refreshTokenRepository.save(refreshToken);
     }
 
     private RefreshToken createAndSaveExpiredRefreshToken(User user, String token) {
-        RefreshToken refreshToken = RefreshToken.create(user, token, REFRESH_TOKEN_VALIDITY);
+        RefreshToken refreshToken = RefreshToken.create(user, token, REFRESH_TOKEN_VALIDITY, TEST_TOKEN_FAMILY);
         // 리플렉션으로 expiresAt을 과거 시간으로 설정
         ReflectionTestUtils.setField(refreshToken, "expiresAt", Instant.now().minusMillis(1000L));
         return refreshTokenRepository.save(refreshToken);
     }
 
     @Nested
-    @DisplayName("토큰 갱신 성공")
+    @DisplayName("토큰 갱신 및 로테이션 성공")
     class TokenRefreshSuccessTest {
 
         @Test
-        @DisplayName("유효한 Refresh Token으로 갱신 성공 [TKN-001]")
+        @DisplayName("유효한 Refresh Token으로 갱신 성공 - 새 Access Token 반환 [TKN-001]")
         void refreshToken_WithValidToken_ReturnsNewAccessToken() {
             // given
             User user = createAndSaveTestUser();
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
-            String tokenString = refreshTokenString;
-
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(tokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.accessToken()).isNotNull();
-            assertThat(response.accessToken()).isNotEmpty();
+            assertThat(result).isNotNull();
+            assertThat(result.accessToken()).isNotNull().isNotEmpty();
         }
 
         @Test
@@ -85,13 +87,11 @@ class RefreshTokenServiceTest extends ServiceIntegrationTestBase {
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
-            String tokenString = refreshTokenString;
-
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(tokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            assertThat(response.expiresIn()).isEqualTo(ACCESS_TOKEN_VALIDITY);
+            assertThat(result.accessTokenValidity()).isEqualTo(ACCESS_TOKEN_VALIDITY);
         }
 
         @Test
@@ -102,36 +102,82 @@ class RefreshTokenServiceTest extends ServiceIntegrationTestBase {
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
-            String tokenString = refreshTokenString;
-
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(tokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            assertThat(response.accessToken()).isNotNull();
-            // 실제 Access Token 검증
-            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(response.accessToken());
+            var claims = jwtTokenProvider.validateAccessTokenAndGetClaims(result.accessToken());
             assertThat(jwtTokenProvider.getUserIdFromClaims(claims)).isEqualTo(user.getId());
             assertThat(jwtTokenProvider.getStudentIdFromClaims(claims)).isEqualTo(user.getStudentId());
             assertThat(jwtTokenProvider.getRoleFromClaims(claims)).isEqualTo(user.getRole().name());
         }
 
         @Test
-        @DisplayName("Access Token 만료 전 갱신 가능 [TKN-004]")
-        void refreshToken_BeforeAccessTokenExpires_ReturnsNewAccessToken() {
+        @DisplayName("토큰 로테이션 - 새 Refresh Token 발급 [TKN-005]")
+        void refreshToken_WithValidToken_ReturnsNewRefreshToken() {
             // given
             User user = createAndSaveTestUser();
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
             createAndSaveValidRefreshToken(user, refreshTokenString);
 
-            String tokenString = refreshTokenString;
-
             // when
-            TokenRefreshResponse response = refreshTokenService.refreshToken(tokenString);
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.accessToken()).isNotNull();
+            assertThat(result.newRefreshToken()).isNotNull().isNotEmpty();
+            assertThat(result.newRefreshToken()).isNotEqualTo(refreshTokenString);
+        }
+
+        @Test
+        @DisplayName("토큰 로테이션 후 기존 토큰 폐기 확인 [TKN-006]")
+        void refreshToken_AfterRotation_OldTokenRevoked() {
+            // given
+            User user = createAndSaveTestUser();
+            String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
+            createAndSaveValidRefreshToken(user, refreshTokenString);
+
+            // when
+            refreshTokenService.refreshToken(refreshTokenString);
+
+            // then
+            RefreshToken oldToken = refreshTokenRepository.findByToken(refreshTokenString).orElseThrow();
+            assertThat(oldToken.isRevoked()).isTrue();
+            assertThat(oldToken.getRevokedAt()).isNotNull();
+            assertThat(oldToken.getReplacedByToken()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("토큰 로테이션 후 새 토큰이 같은 패밀리 [TKN-007]")
+        void refreshToken_AfterRotation_SameTokenFamily() {
+            // given
+            User user = createAndSaveTestUser();
+            String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
+            createAndSaveValidRefreshToken(user, refreshTokenString);
+
+            // when
+            TokenRotationResult result = refreshTokenService.refreshToken(refreshTokenString);
+
+            // then
+            RefreshToken newToken = refreshTokenRepository.findByToken(result.newRefreshToken()).orElseThrow();
+            assertThat(newToken.getTokenFamily()).isEqualTo(TEST_TOKEN_FAMILY);
+        }
+
+        @Test
+        @DisplayName("연쇄 토큰 로테이션 - 새 토큰으로 다시 갱신 가능 [TKN-008]")
+        void refreshToken_ChainedRotation_Works() {
+            // given
+            User user = createAndSaveTestUser();
+            String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
+            createAndSaveValidRefreshToken(user, refreshTokenString);
+
+            // when - 1차 갱신
+            TokenRotationResult result1 = refreshTokenService.refreshToken(refreshTokenString);
+            // when - 2차 갱신 (새 토큰으로)
+            TokenRotationResult result2 = refreshTokenService.refreshToken(result1.newRefreshToken());
+
+            // then
+            assertThat(result2.accessToken()).isNotNull().isNotEmpty();
+            assertThat(result2.newRefreshToken()).isNotEqualTo(result1.newRefreshToken());
         }
     }
 
@@ -147,10 +193,8 @@ class RefreshTokenServiceTest extends ServiceIntegrationTestBase {
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
             createAndSaveExpiredRefreshToken(user, refreshTokenString);
 
-            String tokenString = refreshTokenString;
-
             // when & then
-            assertThatThrownBy(() -> refreshTokenService.refreshToken(tokenString))
+            assertThatThrownBy(() -> refreshTokenService.refreshToken(refreshTokenString))
                     .isInstanceOf(RefreshTokenExpiredException.class);
         }
 
@@ -186,24 +230,81 @@ class RefreshTokenServiceTest extends ServiceIntegrationTestBase {
             assertThatThrownBy(() -> refreshTokenService.refreshToken(tokenString))
                     .isInstanceOf(RefreshTokenInvalidException.class);
         }
+    }
+
+    @Nested
+    @DisplayName("토큰 탈취 감지")
+    class TokenTheftDetectionTest {
 
         @Test
-        @DisplayName("로그아웃된 Refresh Token으로 갱신 시도 시 예외 발생 [TKN-014]")
-        void refreshToken_WithRevokedToken_ThrowsException() {
+        @DisplayName("폐기된 토큰 사용 시 (Grace Period 밖) 탈취 감지 예외 발생 [TKN-030]")
+        void refreshToken_WithRevokedTokenOutsideGracePeriod_ThrowsTheftException() {
             // given
             User user = createAndSaveTestUser();
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
             RefreshToken refreshToken = createAndSaveValidRefreshToken(user, refreshTokenString);
 
-            // 토큰 무효화
+            // 토큰 폐기 후 Grace Period 지나게 설정
             refreshToken.revoke();
+            ReflectionTestUtils.setField(refreshToken, "revokedAt", Instant.now().minusSeconds(11));
             refreshTokenRepository.save(refreshToken);
 
-            String tokenString = refreshTokenString;
-
             // when & then
-            assertThatThrownBy(() -> refreshTokenService.refreshToken(tokenString))
-                    .isInstanceOf(RefreshTokenInvalidException.class);
+            assertThatThrownBy(() -> refreshTokenService.refreshToken(refreshTokenString))
+                    .isInstanceOf(RefreshTokenTheftException.class);
+        }
+
+        @Test
+        @DisplayName("탈취 감지 시 같은 패밀리의 모든 토큰 무효화 [TKN-031]")
+        void refreshToken_TheftDetected_RevokesEntireFamily() {
+            // given
+            User user = createAndSaveTestUser();
+            String oldRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+            RefreshToken oldToken = createAndSaveValidRefreshToken(user, oldRefreshToken);
+
+            // 새 토큰을 같은 패밀리로 생성 (로테이션 시뮬레이션)
+            String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+            RefreshToken newToken = RefreshToken.create(user, newRefreshToken, REFRESH_TOKEN_VALIDITY, TEST_TOKEN_FAMILY);
+            refreshTokenRepository.save(newToken);
+
+            // 기존 토큰을 폐기 (Grace Period 밖)
+            oldToken.revoke();
+            ReflectionTestUtils.setField(oldToken, "revokedAt", Instant.now().minusSeconds(11));
+            refreshTokenRepository.save(oldToken);
+
+            // when - 폐기된 기존 토큰으로 갱신 시도 (탈취 시나리오)
+            assertThatThrownBy(() -> refreshTokenService.refreshToken(oldRefreshToken))
+                    .isInstanceOf(RefreshTokenTheftException.class);
+
+            // then - 같은 패밀리의 새 토큰도 무효화됨
+            RefreshToken revokedNewToken = refreshTokenRepository.findByToken(newRefreshToken).orElseThrow();
+            assertThat(revokedNewToken.isRevoked()).isTrue();
+        }
+
+        @Test
+        @DisplayName("Grace Period 내 폐기된 토큰 사용 시 정상 응답 [TKN-032]")
+        void refreshToken_WithRevokedTokenWithinGracePeriod_Succeeds() {
+            // given
+            User user = createAndSaveTestUser();
+            String oldRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+            RefreshToken oldToken = createAndSaveValidRefreshToken(user, oldRefreshToken);
+
+            // 새 토큰을 같은 패밀리로 생성 (로테이션 완료 상태)
+            String activeRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+            RefreshToken activeToken = RefreshToken.create(user, activeRefreshToken, REFRESH_TOKEN_VALIDITY, TEST_TOKEN_FAMILY);
+            refreshTokenRepository.save(activeToken);
+
+            // 기존 토큰을 방금 폐기 (Grace Period 내)
+            oldToken.rotateWith(activeRefreshToken);
+            refreshTokenRepository.save(oldToken);
+
+            // when - Grace Period 내에 폐기된 토큰으로 갱신 시도 (동시 탭 시나리오)
+            TokenRotationResult result = refreshTokenService.refreshToken(oldRefreshToken);
+
+            // then - 정상적으로 액세스 토큰 발급
+            assertThat(result).isNotNull();
+            assertThat(result.accessToken()).isNotNull().isNotEmpty();
+            assertThat(result.newRefreshToken()).isEqualTo(activeRefreshToken);
         }
     }
 
@@ -223,8 +324,8 @@ class RefreshTokenServiceTest extends ServiceIntegrationTestBase {
         }
 
         @Test
-        @DisplayName("모든 토큰이 무효화된 경우 갱신 실패 [TKN-021]")
-        void refreshToken_WhenAllTokensRevoked_ThrowsException() {
+        @DisplayName("모든 토큰이 무효화된 경우 탈취 감지 [TKN-021]")
+        void refreshToken_WhenAllTokensRevoked_ThrowsTheftException() {
             // given
             User user = createAndSaveTestUser();
             String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getId());
@@ -235,11 +336,14 @@ class RefreshTokenServiceTest extends ServiceIntegrationTestBase {
                     refreshTokenRepository.revokeAllByUserId(user.getId())
             );
 
-            String tokenString = refreshTokenString;
+            // revokedAt이 방금 설정되었으므로 Grace Period 밖으로 설정
+            RefreshToken revokedToken = refreshTokenRepository.findByToken(refreshTokenString).orElseThrow();
+            ReflectionTestUtils.setField(revokedToken, "revokedAt", Instant.now().minusSeconds(11));
+            refreshTokenRepository.save(revokedToken);
 
             // when & then
-            assertThatThrownBy(() -> refreshTokenService.refreshToken(tokenString))
-                    .isInstanceOf(RefreshTokenInvalidException.class);
+            assertThatThrownBy(() -> refreshTokenService.refreshToken(refreshTokenString))
+                    .isInstanceOf(RefreshTokenTheftException.class);
         }
     }
 }

--- a/backend/src/test/java/igrus/web/security/auth/password/service/reset/ResetPasswordServiceTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/service/reset/ResetPasswordServiceTest.java
@@ -123,8 +123,8 @@ class ResetPasswordServiceTest extends ServiceIntegrationTestBase {
             createAndSaveCredential(user);
 
             // 리프레시 토큰 생성
-            RefreshToken refreshToken1 = RefreshToken.create(user, "refresh-token-1", 604800000L);
-            RefreshToken refreshToken2 = RefreshToken.create(user, "refresh-token-2", 604800000L);
+            RefreshToken refreshToken1 = RefreshToken.createInitial(user, "refresh-token-1", 604800000L);
+            RefreshToken refreshToken2 = RefreshToken.createInitial(user, "refresh-token-2", 604800000L);
             refreshTokenRepository.save(refreshToken1);
             refreshTokenRepository.save(refreshToken2);
 

--- a/docs/adr/v20260206-refresh_token_rotation_and_theft_detection.md
+++ b/docs/adr/v20260206-refresh_token_rotation_and_theft_detection.md
@@ -1,0 +1,55 @@
+# 리프레시 토큰 로테이션 및 탈취 감지
+
+## 배경
+
+기존 구현에서는 Access Token 재발급 시 동일한 Refresh Token이 만료(7일)까지 재사용되는 구조였다. 이 경우 Refresh Token이 탈취되면 만료 전까지 공격자가 자유롭게 사용할 수 있으며, 탈취 사실을 감지할 수단이 없었다.
+
+보안을 강화하기 위해 Refresh Token 로테이션(매 갱신마다 새 토큰 발급)과 Token Family 기반 탈취 감지 메커니즘 도입이 필요했다.
+
+## 선택지
+
+1. **Refresh Token 로테이션 없이 유효기간만 단축**: 단순히 Refresh Token 유효기간을 줄여 탈취 위험을 낮춘다. 구현이 간단하지만 탈취 자체를 감지할 수 없다.
+2. **Refresh Token 로테이션 + Token Family 기반 탈취 감지**: 매 갱신마다 토큰을 교체하고, 이미 폐기된 토큰이 재사용되면 탈취로 간주하여 해당 Token Family 전체를 무효화한다. Grace Period를 두어 동시 탭에서의 경쟁 조건을 처리한다.
+3. **Refresh Token을 Redis에 저장**: 서버 사이드 세션처럼 Redis에 토큰 상태를 저장하여 즉시 무효화를 지원한다. 인프라 복잡도가 증가하고 현재 스택(RDB 기반)과의 정합성 문제가 있다.
+
+## 결정
+
+- **선택지 2: Refresh Token 로테이션 + Token Family 기반 탈취 감지** 채택
+
+## 결정 이유
+
+- **탈취 감지 가능**: 폐기된 토큰의 재사용을 탐지하여 공격자와 정당한 사용자 모두를 보호할 수 있다
+- **OWASP 권장 사항**: OWASP에서 권장하는 Refresh Token 로테이션 패턴을 따른다
+- **Grace Period로 실용성 확보**: 동시 탭(다중 탭 열어둔 상태)에서의 경쟁 조건을 10초 Grace Period로 처리하여 사용자 경험을 해치지 않는다
+- **기존 인프라 활용**: 추가 인프라(Redis 등) 없이 기존 RDB 기반으로 구현 가능하다
+- **유효기간 단축과 시너지**: Access Token 5분 + Refresh Token 3일로 단축하여 토큰 노출 시간을 최소화한다
+
+## 적용 범위
+
+- `RefreshToken` 엔티티: `tokenFamily`, `replacedByToken`, `revokedAt` 필드 추가
+- `RefreshTokenService.refreshToken()`: 로테이션 + 탈취 감지 로직
+- `PasswordAuthController`: 갱신 응답에 새 Refresh Token을 Set-Cookie 헤더로 포함
+- `LoginService`, `RecoverAccountService`: 로그인/복구 시 `createInitial()`로 새 Token Family 생성
+- `application.yml`: Access Token 5분, Refresh Token 3일, Grace Period 10초
+
+## 결과
+
+### 구현 완료 항목
+
+- DB 마이그레이션 V20: `token_family`, `replaced_by_token`, `revoked_at` 컬럼 추가
+- 엔티티 변경: `RefreshToken.createInitial()`, `rotateWith()`, `isWithinGracePeriod()`
+- 레포지토리 변경: `revokeAllByTokenFamily()`, `findByTokenFamilyAndRevokedFalse()`
+- 서비스 로직: `@Transactional(noRollbackFor = RefreshTokenTheftException.class)` 적용
+- 컨트롤러: `TokenRotationResult` 반환, Set-Cookie 헤더에 새 Refresh Token 설정
+- 전체 테스트 통과 (1309개)
+
+### 주요 기술적 결정
+
+- **Hibernate 6 JPQL 제약**: `CURRENT_TIMESTAMP`가 `Instant` 필드에 할당 불가 → 파라미터 `@Param("now") Instant now` + default 메서드 패턴으로 해결
+- **트랜잭션 롤백 방지**: 탈취 감지 시 Token Family 무효화가 롤백되지 않도록 `noRollbackFor` 적용
+
+## 후속 조치
+
+- [ ] Refresh Token 정리 스케줄러: 만료된 토큰 체인(Token Family) 주기적 삭제
+- [ ] 프론트엔드: 갱신 응답의 Set-Cookie에서 새 Refresh Token을 자동으로 사용하도록 확인
+- [ ] 모니터링: 탈취 감지 이벤트 로깅 및 알림 체계 구축

--- a/docs/feature/auth/auth-spec.md
+++ b/docs/feature/auth/auth-spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: 로그인/회원가입
 
 **Created**: 2026-01-23
-**Updated**: 2026-01-28
+**Updated**: 2026-02-06
 **Status**: In Progress
 **Input**: PRD V2 기반 로그인/회원가입 기능 명세
 
@@ -49,17 +49,19 @@
 
 ### User Story 3 - 토큰 갱신 (Priority: P2)
 
-로그인한 사용자가 Access Token 만료 시 Refresh Token을 사용하여 새로운 Access Token을 발급받는다.
+로그인한 사용자가 Access Token 만료 시 Refresh Token을 사용하여 새로운 Access Token을 발급받는다. 갱신 시 Refresh Token 로테이션을 통해 보안을 강화하며, 토큰 탈취 감지 기능을 제공한다.
 
 **Why this priority**: 사용자 경험을 위해 세션이 자동으로 유지되어야 하며, 매번 재로그인하는 불편함을 방지한다.
 
-**Independent Test**: 만료된 Access Token 상태에서 유효한 Refresh Token으로 새 Access Token을 발급받을 수 있는지 확인한다.
+**Independent Test**: 만료된 Access Token 상태에서 유효한 Refresh Token으로 새 Access Token과 새 Refresh Token을 발급받을 수 있는지 확인한다.
 
 **Acceptance Scenarios**:
 
-1. **Given** Access Token이 만료된 상태에서, **When** 유효한 Refresh Token으로 갱신을 요청하면, **Then** 새로운 Access Token이 발급된다
+1. **Given** Access Token이 만료된 상태에서, **When** 유효한 Refresh Token으로 갱신을 요청하면, **Then** 새로운 Access Token이 발급되고, 새로운 Refresh Token이 HttpOnly 쿠키로 설정되며, 기존 Refresh Token은 폐기된다
 2. **Given** Refresh Token이 만료된 상태에서, **When** 토큰 갱신을 요청하면, **Then** "토큰이 만료되었습니다" 메시지와 함께 재로그인이 필요하다
 3. **Given** 유효하지 않은 Refresh Token으로, **When** 갱신을 요청하면, **Then** "유효하지 않은 토큰입니다" 메시지가 표시된다
+4. **Given** 이미 폐기된 Refresh Token으로 (10초 경과 후), **When** 갱신을 요청하면, **Then** 토큰 탈취로 감지되어 해당 Token Family의 모든 토큰이 무효화되고, "토큰 도용이 감지되어 모든 세션이 종료되었습니다" 메시지가 표시된다
+5. **Given** 이미 폐기된 Refresh Token으로 (10초 이내), **When** 갱신을 요청하면, **Then** Grace Period 내 동시 요청으로 간주되어 현재 활성 토큰 기반으로 새 Access Token이 발급된다
 
 ---
 
@@ -145,9 +147,10 @@
 **로그인/인증**
 - **FR-011**: 시스템은 학번과 비밀번호로 사용자를 인증해야 한다
 - **FR-012**: 시스템은 이메일 인증이 완료된 사용자만 로그인을 허용해야 한다
-- **FR-013**: 시스템은 로그인 성공 시 Access Token(1시간 유효)과 Refresh Token(7일 유효)을 발급해야 한다
+- **FR-013**: 시스템은 로그인 성공 시 Access Token(5분 유효)과 Refresh Token(3일 유효)을 발급해야 한다
 - **FR-014**: 시스템은 로그인 시 사용자의 역할(ASSOCIATE/MEMBER/OPERATOR/ADMIN) 정보를 반환해야 한다
-- **FR-015**: 시스템은 Refresh Token으로 Access Token 재발급을 지원해야 한다
+- **FR-015**: 시스템은 Refresh Token 로테이션을 통해 Access Token 재발급을 지원해야 한다 (갱신 시 기존 Refresh Token 폐기 + 새 Refresh Token 발급)
+- **FR-015a**: 시스템은 Token Family 기반 탈취 감지를 지원해야 한다 (폐기된 토큰 재사용 시 해당 패밀리 전체 무효화, 10초 Grace Period 적용)
 - **FR-016**: 시스템은 로그아웃 시 현재 세션의 토큰을 무효화해야 한다
 
 **로그인 히스토리** *(구현 완료)*
@@ -190,7 +193,7 @@
 - **PasswordCredential**: 비밀번호 인증 자격증명 (비밀번호 해시, 계정 상태, 승인 정보)
 - **UserSuspension**: 계정 정지 이력 (정지 사유, 시작일, 종료일, 해제일)
 - **UserRoleHistory**: 역할 변경 감사 이력
-- **RefreshToken**: 리프레시 토큰 관리
+- **RefreshToken**: 리프레시 토큰 관리 (토큰 로테이션, Token Family, 탈취 감지, Grace Period 지원)
 - **EmailVerification**: 이메일 인증 코드 관리 (인증 코드, 만료 시간, 시도 횟수)
 - **PrivacyConsent**: 개인정보 동의 이력
 - **LoginHistory**: 로그인 시도 이력 (사용자 ID, 학번, IP 주소, User-Agent, 성공 여부, 실패 사유, 시도 시각)
@@ -229,3 +232,15 @@
 - 생체 인증
 - 세션 동시 접속 제한
 - ~~로그인 시도 횟수 제한 (Brute Force 방지)~~ → **구현 완료** (LoginAttempt 엔티티 사용)
+
+---
+
+## Clarifications
+
+### Session 2026-02-06
+
+- Q: 토큰 갱신 시 Refresh Token은 어떻게 처리되는가? → A: **Refresh Token 로테이션** 적용. 매 갱신마다 기존 Refresh Token을 폐기하고 새 Refresh Token을 발급한다. Token Family(UUID)로 같은 로그인 세션에서 파생된 토큰 체인을 그룹화한다.
+- Q: 탈취된 Refresh Token으로 갱신 요청이 오면? → A: 이미 폐기된 토큰이 10초(Grace Period) 이후에 재사용되면 **탈취로 감지**하고, 해당 Token Family의 모든 토큰을 즉시 무효화한다.
+- Q: 동시 탭에서 동시에 갱신 요청이 오면? → A: **Grace Period (10초)** 내에 폐기된 토큰이 사용되면 동시 요청으로 간주하고, 현재 활성 토큰 기반으로 Access Token만 발급한다.
+- Q: Access Token/Refresh Token 유효기간은? → A: Access Token 1시간 → **5분**, Refresh Token 7일 → **3일**로 변경. 짧은 Access Token 유효기간은 로테이션과 함께 보안 강화 효과를 높인다.
+- Q: `@Transactional` 롤백과 탈취 감지의 관계는? → A: 탈취 감지 시 Token Family 전체를 무효화한 후 예외를 던지는데, 일반 `@Transactional`에서는 RuntimeException으로 인해 무효화가 롤백된다. `@Transactional(noRollbackFor = RefreshTokenTheftException.class)` 적용으로 해결.


### PR DESCRIPTION
## Summary
- Token Family 기반 Refresh Token 로테이션 구현: 매 갱신마다 기존 토큰 폐기 + 새 토큰 발급
- 탈취 감지: 폐기된 토큰 재사용 시 해당 Token Family 전체 무효화 (OWASP 권장 패턴)
- Grace Period(10초)로 동시 탭에서의 경쟁 조건 처리
- Access Token 5분, Refresh Token 3일로 유효기간 단축하여 토큰 노출 시간 최소화
- V20 Flyway 마이그레이션: tokenFamily, replacedByToken, revokedAt 컬럼 추가
- 단위/통합/E2E 테스트 전체 업데이트 및 ADR 문서 작성

## Test plan
- [ ] 전체 백엔드 테스트 통과 확인 (로컬 BUILD SUCCESSFUL)
- [ ] 로그인 후 토큰 갱신 시 Set-Cookie에 새 Refresh Token이 포함되는지 확인
- [ ] 연쇄 갱신(새 토큰으로 재갱신) 정상 동작 확인
- [ ] 폐기된 토큰 재사용 시 탈취 감지 및 Token Family 전체 무효화 확인
- [ ] Grace Period 내 동시 요청 시 정상 응답 확인
- [ ] 기존 로그인/로그아웃/비밀번호 재설정 플로우 정상 동작 확인