### PR TITLE
refactor(frontend): 문의 페이지 리디자인

### DIFF
--- a/frontend/src/components/feature/inquiry/InquiryForm.tsx
+++ b/frontend/src/components/feature/inquiry/InquiryForm.tsx
@@ -27,7 +27,6 @@ export default function InquiryForm({ onSubmit, loading = false }: InquiryFormPr
 
   return (
     <Card className="py-5 px-11 rounded-[2.5rem] border bg-card shadow-xl">
-      <h3 className="text-h3">문의하기</h3>
       <form onSubmit={handleSubmit} className="space-y-6">
         <div>
           <label className="block text-c1 font-bold text-muted-foreground uppercase tracking-widest mb-2">

--- a/frontend/src/pages/inquiry/InquiryHistoryPage.tsx
+++ b/frontend/src/pages/inquiry/InquiryHistoryPage.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { useUIStore } from '@/stores/uiStore';
+import { useGetMyInquiries } from '@/api/model/inquiry/inquiry';
+import type { PageInquiryListResponse } from '@/api/model/models';
+import InquiryListItem from '@/components/feature/inquiry/InquiryListItem';
+import { cn } from '@/lib/utils';
+import type { Inquiry } from '@/types/entities';
+
+export default function InquiryHistoryPage() {
+  const { theme } = useUIStore();
+  const isDark = theme === 'dark';
+  const [currentPage] = useState(1);
+
+  const { data: response, isLoading } = useGetMyInquiries({
+    page: currentPage - 1,
+    size: 10,
+  });
+
+  // Blob 타입 우회하여 실제 데이터 추출
+  const inquiriesData = response?.data ? (response.data as unknown as PageInquiryListResponse) : null;
+  const inquiries: Inquiry[] = inquiriesData?.content?.map((item) => ({
+    id: item.id?.toString() || '',
+    inquiryNumber: `INQ-${item.id}`,
+    category: item.type || 'GENERAL',
+    title: item.title || '',
+    content: item.content || '',
+    status: item.status || 'PENDING',
+    createdAt: item.createdAt || '',
+    answeredAt: item.reply?.createdAt,
+    answer: item.reply?.content,
+  })) || [];
+
+  return (
+    <div className="animate-in fade-in duration-500">
+      <section>
+        <div className="mb-s6">
+          <h3
+            className={cn(
+              'text-2xl font-bold transition-colors',
+              isDark ? 'text-white' : 'text-black'
+            )}
+          >
+            문의 내역
+          </h3>
+          <p className="text-gray-500 text-sm">
+            제출한 문의의 처리 현황을 확인하세요.
+          </p>
+        </div>
+
+        <div className="space-y-s4">
+          {isLoading ? (
+            <div className="flex items-center justify-center min-h-[27rem]">
+              <div className="text-center text-muted-foreground">로딩 중...</div>
+            </div>
+          ) : inquiries.length === 0 ? (
+            <div className="flex items-center justify-center min-h-[27rem]">
+              <div className="text-center text-muted-foreground">
+                문의 내역이 없습니다.
+              </div>
+            </div>
+          ) : (
+            inquiries.map((inquiry) => (
+              <InquiryListItem key={inquiry.id} inquiry={inquiry} />
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/inquiry/InquiryPage.tsx
+++ b/frontend/src/pages/inquiry/InquiryPage.tsx
@@ -1,16 +1,8 @@
-import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { useUIStore } from '@/stores/uiStore';
-import {
-  useGetMyInquiries,
-  useCreateMemberInquiry,
-} from '@/api/model/inquiry/inquiry';
-import type { PageInquiryListResponse, CreateInquiryResponse } from '@/api/model/models';
+import { useCreateMemberInquiry } from '@/api/model/inquiry/inquiry';
 import InquiryForm from '@/components/feature/inquiry/InquiryForm';
-import InquiryListItem from '@/components/feature/inquiry/InquiryListItem';
 import { cn } from '@/lib/utils';
-import type { Inquiry } from '@/types/entities';
-
-type ViewType = 'form' | 'history';
 
 // 문의 유형 매핑 (UI → API)
 const TYPE_MAPPING: Record<string, string> = {
@@ -24,21 +16,13 @@ const TYPE_MAPPING: Record<string, string> = {
 export default function InquiryPage() {
   const { theme } = useUIStore();
   const isDark = theme === 'dark';
-  const [view, setView] = useState<ViewType>('form');
-  const [currentPage, setCurrentPage] = useState(1);
-
-  // 문의 목록 조회 (페이지네이션: 0-based)
-  const { data: response, isLoading, refetch } = useGetMyInquiries({
-    page: currentPage - 1,
-    size: 10,
-  });
+  const navigate = useNavigate();
 
   // 문의 작성
   const createMutation = useCreateMemberInquiry();
 
   const handleSubmit = async (data: { type: string; title: string; content: string }) => {
     try {
-      // UI의 type을 API의 type으로 변환
       const apiType = TYPE_MAPPING[data.type] || 'GENERAL';
 
       await createMutation.mutateAsync({
@@ -50,90 +34,42 @@ export default function InquiryPage() {
       });
 
       alert('문의가 제출되었습니다.');
-
-      // 문의 목록 새로고침
-      refetch();
-
-      // 문의 내역 보기로 전환
-      setView('history');
+      navigate('/inquiry/history');
     } catch (error) {
       console.error('문의 제출 실패:', error);
       alert('문의 제출에 실패했습니다. 다시 시도해주세요.');
     }
   };
 
-  // Blob 타입 우회하여 실제 데이터 추출
-  const inquiriesData = response?.data ? (response.data as unknown as PageInquiryListResponse) : null;
-  const inquiries: Inquiry[] = inquiriesData?.content?.map((item) => ({
-    id: item.id?.toString() || '',
-    inquiryNumber: `INQ-${item.id}`,
-    category: item.type || 'GENERAL',
-    title: item.title || '',
-    content: item.content || '',
-    status: item.status || 'PENDING',
-    createdAt: item.createdAt || '',
-    answeredAt: item.reply?.createdAt,
-    answer: item.reply?.content,
-  })) || [];
-
   return (
-    <div className="flex items-start justify-center pt-s7">
-      <div className="max-w-3xl w-full animate-in slide-in-from-bottom-8 duration-500">
-        {/* View Toggle Buttons */}
-        <div className="flex gap-s4 mb-s5">
-        <button
-          type="button"
-          onClick={() => setView('form')}
-          className={cn(
-            'flex-1 py-s3 rounded-r4 font-bold transition-all border cursor-pointer text-xs',
-            view === 'form'
-              ? 'bg-primary text-primary-foreground border-primary'
-              : isDark
-                ? 'bg-white/5 border-border text-muted-foreground'
-                : 'bg-muted border-border text-muted-foreground'
-          )}
-        >
-          새 문의 작성
-        </button>
-        <button
-          type="button"
-          onClick={() => setView('history')}
-          className={cn(
-            'flex-1 py-s3 rounded-r4 font-bold transition-all border cursor-pointer text-xs',
-            view === 'history'
-              ? 'bg-primary text-primary-foreground border-primary'
-              : isDark
-                ? 'bg-white/5 border-border text-muted-foreground'
-                : 'bg-muted border-border text-muted-foreground'
-          )}
-        >
-          문의 내역 보기
-        </button>
-      </div>
-
-      {/* Content */}
-      {view === 'form' ? (
-        <InquiryForm onSubmit={handleSubmit} loading={createMutation.isPending} />
-      ) : (
-        <div className="space-y-s4">
-          {isLoading ? (
-            <div className="flex items-center justify-center min-h-[27rem]">
-              <div className="text-center text-muted-foreground">로딩 중...</div>
-            </div>
-          ) : inquiries.length === 0 ? (
-            <div className="flex items-center justify-center min-h-[27rem]">
-              <div className="text-center text-muted-foreground">
-                문의 내역이 없습니다.
-              </div>
-            </div>
-          ) : (
-            inquiries.map((inquiry) => (
-              <InquiryListItem key={inquiry.id} inquiry={inquiry} />
-            ))
-          )}
+    <div className="animate-in fade-in duration-500">
+      {/* Section Header */}
+      <section>
+        <div className="flex justify-between items-center mb-s6">
+          <div>
+            <h3
+              className={cn(
+                'text-2xl font-bold transition-colors',
+                isDark ? 'text-white' : 'text-black'
+              )}
+            >
+              문의하기
+            </h3>
+            <p className="text-gray-500 text-sm">
+              궁금한 점이나 건의사항을 남겨주세요.
+            </p>
+          </div>
+          <Link
+            to="/inquiry/history"
+            className="text-sm text-gray-400 hover:text-[#03A69E] transition"
+          >
+            문의 내역 보기
+          </Link>
         </div>
-      )}
-      </div>
+
+        {/* Inquiry Form */}
+        <InquiryForm onSubmit={handleSubmit} loading={createMutation.isPending} />
+      </section>
     </div>
   );
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -26,6 +26,7 @@ import EventEditPage from '@/pages/event/EventEditPage';
 
 // 문의
 import InquiryPage from '@/pages/inquiry/InquiryPage';
+import InquiryHistoryPage from '@/pages/inquiry/InquiryHistoryPage';
 import InquiryLookupPage from '@/pages/inquiry/InquiryLookupPage';
 
 // 법적 페이지
@@ -54,6 +55,7 @@ const routes: RouteObject[] = [
       { path: 'forgot-password', element: <ForgotPasswordPage /> },
       { path: 'reset-password', element: <ResetPasswordPage /> },
       { path: 'inquiry', element: <InquiryPage /> },
+      { path: 'inquiry/history', element: <InquiryHistoryPage /> },
       { path: 'inquiry/lookup', element: <InquiryLookupPage /> },
 
       // 법적 페이지


### PR DESCRIPTION
## Summary
- 문의하기 페이지의 탭 기반 UI를 홈 화면의 "주요 게시글" 섹션과 유사한 레이아웃으로 변경
- 문의 내역을 별도 페이지(`/inquiry/history`)로 분리하여 라우트 추가
- InquiryForm 카드 내 중복 "문의하기" 제목 제거

## Test plan
- [ ] `/inquiry` 접속 → "문의하기" 섹션 헤더 + "문의 내역 보기" 링크 + 문의 폼 확인
- [ ] "문의 내역 보기" 클릭 → `/inquiry/history`로 이동하여 문의 내역 페이지 표시 확인
- [ ] 다크/라이트 테마 전환 시 스타일 정상 적용 확인
- [ ] 문의 제출 성공 시 `/inquiry/history`로 네비게이션 확인