### PR TITLE
feat(frontend): 모바일 반응형 에디터 및 검색 바 최적화

### DIFF
--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { useUIStore } from "@/stores";
 import SearchBar from "./SearchBar";
 import { getPageTitle } from "@/constants/routes";
 import { formatHeaderDate } from "@/utils";
-import { Menu } from "lucide-react";
+import { Menu, Search } from "lucide-react";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 export default function Header() {
   const location = useLocation();
@@ -12,9 +13,12 @@ export default function Header() {
   const [searchParams] = useSearchParams();
   const { sidebarOpen, toggleSidebar, theme } = useUIStore();
 
+  const isMobile = useIsMobile();
   const pageTitle = getPageTitle(location.pathname);
   const currentDate = formatHeaderDate();
   const isDark = theme === "dark";
+  const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
+  const searchRef = useRef<HTMLDivElement>(null);
 
   // 검색 가능한 페이지 체크
   const searchablePaths = ["/board", "/events"];
@@ -30,6 +34,23 @@ export default function Header() {
     const keyword = searchParams.get("search") || "";
     setSearchKeyword(keyword);
   }, [searchParams]);
+
+  // 페이지 이동 시 모바일 검색 닫기
+  useEffect(() => {
+    setMobileSearchOpen(false);
+  }, [location.pathname]);
+
+  // 바깥 클릭 시 모바일 검색 닫기
+  useEffect(() => {
+    if (!mobileSearchOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
+        setMobileSearchOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [mobileSearchOpen]);
 
   // 검색 처리
   const handleSearch = (keyword: string) => {
@@ -56,41 +77,67 @@ export default function Header() {
       } ${isDark ? "bg-background/80" : "bg-white/80"}`}
     >
       <div className="w-full px-s4 lg:px-s7">
-        {/* 상단 행: 메뉴 + 제목 + 인증 버튼 */}
-        <div className="flex justify-between items-center">
-          {/* 왼쪽: 메뉴 + 제목 */}
-          <div className="flex items-center gap-s3">
-            <button
-              onClick={toggleSidebar}
-              className="lg:hidden p-s2 text-muted-foreground hover:text-primary transition-colors"
-              type="button"
-              aria-label="메뉴 열기"
-              aria-expanded={sidebarOpen}
-            >
-              <Menu size={24} />
-            </button>
-            <div>
-              <h1 className="text-xl lg:text-3xl font-bold capitalize tracking-tight">
-                {pageTitle}
-              </h1>
-              <p className="hidden lg:block text-xs text-muted-foreground mt-s1">
-                {currentDate}
-              </p>
-            </div>
+        {isMobile && mobileSearchOpen && shouldShowSearch ? (
+          /* 모바일 검색 열림 상태: 전체 너비 검색 바 */
+          <div ref={searchRef} className="flex items-center">
+            <SearchBar
+              value={searchKeyword}
+              onChange={setSearchKeyword}
+              onSearch={(keyword) => {
+                handleSearch(keyword);
+                setMobileSearchOpen(false);
+              }}
+              className="flex-1"
+              autoFocus
+            />
           </div>
-
-          {/* 오른쪽: 검색 (검색 가능한 페이지에서만 표시) */}
-          {shouldShowSearch && (
-            <div className="flex items-center">
-              {/* 검색창 (모바일: 작게, 데스크톱: 크게) */}
-              <SearchBar
-                value={searchKeyword}
-                onChange={setSearchKeyword}
-                onSearch={handleSearch}
-              />
+        ) : (
+          /* 기본 레이아웃: 메뉴 + 제목 + 검색 */
+          <div className="flex justify-between items-center">
+            {/* 왼쪽: 메뉴 + 제목 */}
+            <div className="flex items-center gap-s3">
+              <button
+                onClick={toggleSidebar}
+                className="lg:hidden p-s2 text-muted-foreground hover:text-primary transition-colors"
+                type="button"
+                aria-label="메뉴 열기"
+                aria-expanded={sidebarOpen}
+              >
+                <Menu size={24} />
+              </button>
+              <div>
+                <h1 className="text-xl lg:text-3xl font-bold capitalize tracking-tight">
+                  {pageTitle}
+                </h1>
+                <p className="hidden lg:block text-xs text-muted-foreground mt-s1">
+                  {currentDate}
+                </p>
+              </div>
             </div>
-          )}
-        </div>
+
+            {/* 오른쪽: 검색 */}
+            {shouldShowSearch && (
+              isMobile ? (
+                <button
+                  onClick={() => setMobileSearchOpen(true)}
+                  type="button"
+                  className="p-s2 text-muted-foreground hover:text-primary transition-colors"
+                  aria-label="검색"
+                >
+                  <Search size={20} />
+                </button>
+              ) : (
+                <div className="flex items-center">
+                  <SearchBar
+                    value={searchKeyword}
+                    onChange={setSearchKeyword}
+                    onSearch={handleSearch}
+                  />
+                </div>
+              )
+            )}
+          </div>
+        )}
       </div>
     </header>
   );

--- a/frontend/src/components/common/SearchBar.tsx
+++ b/frontend/src/components/common/SearchBar.tsx
@@ -7,6 +7,7 @@ interface SearchBarProps {
   onSearch: (keyword: string) => void;
   className?: string;
   placeholder?: string;
+  autoFocus?: boolean;
 }
 
 export default function SearchBar({
@@ -15,6 +16,7 @@ export default function SearchBar({
   onSearch,
   className = '',
   placeholder = 'Search...',
+  autoFocus = false,
 }: SearchBarProps) {
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -39,8 +41,9 @@ export default function SearchBar({
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        className="border border-gray-400 dark:border-gray-500 rounded-full pl-s7 pr-s10 py-s3 text-sm
-                   w-96 md:w-[450px] lg:w-[500px] xl:w-[600px]
+        autoFocus={autoFocus}
+        className="border border-gray-400 dark:border-gray-500 rounded-full pl-s7 pr-s10 py-s3 text-base md:text-sm
+                   w-full md:w-[450px] lg:w-[500px] xl:w-[600px]
                    bg-background text-foreground focus:outline-none focus:border-primary
                    transition-all focus:xl:w-[700px]"
       />

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useAuth } from './useAuth';
+export { useIsMobile } from './useIsMobile';
 export { usePagination } from './usePagination';
 export { usePermission } from './usePermission';
 export { useToast } from './useToast';

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => window.innerWidth < MOBILE_BREAKPOINT
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isMobile;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -462,3 +462,52 @@
 .dark .wmde-markdown a:hover {
   color: #B3E5E2;
 }
+
+/* ============================================
+   Markdown Editor Mobile Responsive
+   ============================================ */
+
+@media (max-width: 767px) {
+  /* 모바일에서 MDEditor 내장 편집/미리보기 토글 숨김 (커스텀 토글 사용) */
+  .w-md-editor-toolbar li[data-name="edit"],
+  .w-md-editor-toolbar li[data-name="live"],
+  .w-md-editor-toolbar li[data-name="preview"] {
+    display: none !important;
+  }
+
+  /* 모바일 툴바 아이콘 크기 축소 */
+  .w-md-editor-toolbar svg {
+    width: 16px !important;
+    height: 16px !important;
+  }
+
+  /* 모바일 툴바 버튼 패딩 축소 */
+  .w-md-editor-toolbar button {
+    padding: 6px !important;
+  }
+
+  /* 모바일 툴바 구분선 높이 조정 */
+  .w-md-editor-toolbar-divider {
+    height: 28px !important;
+  }
+
+  /* 모바일 에디터 폰트 크기 (16px: iOS 자동 줌 방지) */
+  .w-md-editor-text-pre,
+  .w-md-editor-text-input,
+  .w-md-editor-text {
+    font-size: 16px !important;
+  }
+
+  .wmde-markdown {
+    font-size: 16px !important;
+  }
+
+  /* 모바일 툴바 줄바꿈 허용 */
+  .w-md-editor-toolbar {
+    flex-wrap: wrap !important;
+  }
+
+  .w-md-editor-toolbar ul {
+    flex-wrap: wrap !important;
+  }
+}

--- a/frontend/src/pages/board/PostEditPage.tsx
+++ b/frontend/src/pages/board/PostEditPage.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Save, Image as ImageIcon, Paperclip } from 'lucide-react';
 import { useForm, Controller } from 'react-hook-form';
@@ -9,7 +10,7 @@ import { useUIStore } from '@/stores';
 import { BOARD_CATEGORIES, POST_OPTIONS, BOARD_LABELS, postFormSchema, type PostFormData } from '@/constants/board';
 import type { BoardType } from '@/types/common';
 import { cn } from '@/lib/utils';
-import { useEffect } from 'react';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { useQueryClient } from '@tanstack/react-query';
 
 export default function PostEditPage() {
@@ -17,6 +18,8 @@ export default function PostEditPage() {
   const navigate = useNavigate();
   const { theme } = useUIStore();
   const isDark = theme === 'dark';
+  const isMobile = useIsMobile();
+  const [mobilePreview, setMobilePreview] = useState<'edit' | 'preview'>('edit');
   const queryClient = useQueryClient();
 
   const validBoardType = boardType as BoardType;
@@ -214,7 +217,7 @@ export default function PostEditPage() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <div
           className={cn(
-            'w-full max-w-[1616px] mx-auto p-8 md:p-12 rounded-[2.5rem] border min-h-[80vh] flex flex-col',
+            'w-full max-w-[1616px] mx-auto p-s4 sm:p-8 md:p-12 rounded-r4 sm:rounded-[1.5rem] md:rounded-[2.5rem] border min-h-[60vh] md:min-h-[80vh] flex flex-col',
             isDark ? 'bg-[#1A1A1A] border-white/5' : 'bg-white border-gray-100 shadow-sm'
           )}
         >
@@ -285,7 +288,7 @@ export default function PostEditPage() {
               type="text"
               placeholder="게시글 제목"
               className={cn(
-                'w-full text-4xl font-bold bg-transparent border-none focus:ring-0 focus:outline-none opacity-80',
+                'w-full text-2xl sm:text-3xl md:text-4xl font-bold bg-transparent border-none focus:ring-0 focus:outline-none opacity-80',
                 isDark ? 'text-white placeholder-gray-500' : 'text-black placeholder-gray-500',
                 errors.title && 'border-b-2 border-destructive'
               )}
@@ -297,6 +300,38 @@ export default function PostEditPage() {
 
           {/* Content Markdown Editor */}
           <div className="flex-1 relative mb-s8">
+            {/* 모바일 편집/미리보기 토글 */}
+            {isMobile && (
+              <div className={cn(
+                'flex mb-s3 rounded-lg p-1',
+                isDark ? 'bg-white/5' : 'bg-gray-100'
+              )}>
+                <button
+                  type="button"
+                  onClick={() => setMobilePreview('edit')}
+                  className={cn(
+                    'flex-1 py-2 text-sm font-medium rounded-md transition-all cursor-pointer',
+                    mobilePreview === 'edit'
+                      ? isDark ? 'bg-gray-700 text-foreground shadow-sm' : 'bg-white text-foreground shadow-sm'
+                      : 'text-gray-500'
+                  )}
+                >
+                  편집
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMobilePreview('preview')}
+                  className={cn(
+                    'flex-1 py-2 text-sm font-medium rounded-md transition-all cursor-pointer',
+                    mobilePreview === 'preview'
+                      ? isDark ? 'bg-gray-700 text-foreground shadow-sm' : 'bg-white text-foreground shadow-sm'
+                      : 'text-gray-500'
+                  )}
+                >
+                  미리보기
+                </button>
+              </div>
+            )}
             <Controller
               name="content"
               control={control}
@@ -304,8 +339,8 @@ export default function PostEditPage() {
                 <MDEditor
                   value={field.value}
                   onChange={field.onChange}
-                  preview="live"
-                  height={500}
+                  preview={isMobile ? mobilePreview : 'live'}
+                  height={isMobile ? 300 : 500}
                   data-color-mode={isDark ? 'dark' : 'light'}
                   commandsFilter={(command) => {
                     if (command.name === 'title' || command.name === 'image' || command.name === 'checked-list') {
@@ -325,24 +360,24 @@ export default function PostEditPage() {
           </div>
 
           {/* Bottom Toolbar */}
-          <div className={cn('mt-8 pt-4 border-t flex gap-4', isDark ? 'border-white/5' : 'border-gray-100')}>
+          <div className={cn('mt-s4 sm:mt-8 pt-s3 sm:pt-4 border-t flex gap-s3 sm:gap-4', isDark ? 'border-white/5' : 'border-gray-100')}>
             <button
               type="button"
               className={cn(
-                'p-3 rounded-lg transition cursor-pointer',
+                'p-2 sm:p-3 rounded-lg transition cursor-pointer',
                 isDark ? 'text-gray-400 hover:bg-white/10' : 'text-gray-500 hover:bg-gray-100'
               )}
             >
-              <ImageIcon size={24} />
+              <ImageIcon size={isMobile ? 20 : 24} />
             </button>
             <button
               type="button"
               className={cn(
-                'p-3 rounded-lg transition cursor-pointer',
+                'p-2 sm:p-3 rounded-lg transition cursor-pointer',
                 isDark ? 'text-gray-400 hover:bg-white/10' : 'text-gray-500 hover:bg-gray-100'
               )}
             >
-              <Paperclip size={24} />
+              <Paperclip size={isMobile ? 20 : 24} />
             </button>
             <div className="ml-auto text-xs text-gray-500 flex items-center">
               {content?.length || 0} 글자

--- a/frontend/src/pages/board/PostWritePage.tsx
+++ b/frontend/src/pages/board/PostWritePage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Save, Image as ImageIcon, Paperclip } from 'lucide-react';
 import { useForm, Controller } from 'react-hook-form';
@@ -9,12 +10,15 @@ import { useUIStore } from '@/stores';
 import { BOARD_CATEGORIES, POST_OPTIONS, BOARD_LABELS, postFormSchema, type PostFormData } from '@/constants/board';
 import type { BoardType } from '@/types/common';
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 export default function PostWritePage() {
   const { boardType } = useParams<{ boardType: BoardType }>();
   const navigate = useNavigate();
   const { theme } = useUIStore();
   const isDark = theme === 'dark';
+  const isMobile = useIsMobile();
+  const [mobilePreview, setMobilePreview] = useState<'edit' | 'preview'>('edit');
 
   const validBoardType = boardType as BoardType;
 
@@ -142,7 +146,7 @@ export default function PostWritePage() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <div
           className={cn(
-            'w-full max-w-[1616px] mx-auto p-8 md:p-12 rounded-[2.5rem] border min-h-[80vh] flex flex-col',
+            'w-full max-w-[1616px] mx-auto p-s4 sm:p-8 md:p-12 rounded-r4 sm:rounded-[1.5rem] md:rounded-[2.5rem] border min-h-[60vh] md:min-h-[80vh] flex flex-col',
             isDark ? 'bg-[#1A1A1A] border-white/5' : 'bg-white border-gray-100 shadow-sm'
           )}
         >
@@ -215,7 +219,7 @@ export default function PostWritePage() {
               type="text"
               placeholder="게시글 제목"
               className={cn(
-                'w-full text-4xl font-bold bg-transparent border-none focus:ring-0 focus:outline-none opacity-80',
+                'w-full text-2xl sm:text-3xl md:text-4xl font-bold bg-transparent border-none focus:ring-0 focus:outline-none opacity-80',
                 isDark ? 'text-white placeholder-gray-500' : 'text-black placeholder-gray-500',
                 errors.title && 'border-b-2 border-destructive'
               )}
@@ -227,6 +231,38 @@ export default function PostWritePage() {
 
           {/* Content Markdown Editor */}
           <div className="flex-1 relative mb-s8">
+            {/* 모바일 편집/미리보기 토글 */}
+            {isMobile && (
+              <div className={cn(
+                'flex mb-s3 rounded-lg p-1',
+                isDark ? 'bg-white/5' : 'bg-gray-100'
+              )}>
+                <button
+                  type="button"
+                  onClick={() => setMobilePreview('edit')}
+                  className={cn(
+                    'flex-1 py-2 text-sm font-medium rounded-md transition-all cursor-pointer',
+                    mobilePreview === 'edit'
+                      ? isDark ? 'bg-gray-700 text-foreground shadow-sm' : 'bg-white text-foreground shadow-sm'
+                      : 'text-gray-500'
+                  )}
+                >
+                  편집
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMobilePreview('preview')}
+                  className={cn(
+                    'flex-1 py-2 text-sm font-medium rounded-md transition-all cursor-pointer',
+                    mobilePreview === 'preview'
+                      ? isDark ? 'bg-gray-700 text-foreground shadow-sm' : 'bg-white text-foreground shadow-sm'
+                      : 'text-gray-500'
+                  )}
+                >
+                  미리보기
+                </button>
+              </div>
+            )}
             <Controller
               name="content"
               control={control}
@@ -234,8 +270,8 @@ export default function PostWritePage() {
                 <MDEditor
                   value={field.value}
                   onChange={field.onChange}
-                  preview="live"
-                  height={500}
+                  preview={isMobile ? mobilePreview : 'live'}
+                  height={isMobile ? 300 : 500}
                   data-color-mode={isDark ? 'dark' : 'light'}
                   commandsFilter={(command) => {
                     // 드롭다운 버튼(title), 이미지, 체크리스트 제거
@@ -256,24 +292,24 @@ export default function PostWritePage() {
           </div>
 
           {/* Bottom Toolbar */}
-          <div className={cn('mt-8 pt-4 border-t flex gap-4', isDark ? 'border-white/5' : 'border-gray-100')}>
+          <div className={cn('mt-s4 sm:mt-8 pt-s3 sm:pt-4 border-t flex gap-s3 sm:gap-4', isDark ? 'border-white/5' : 'border-gray-100')}>
             <button
               type="button"
               className={cn(
-                'p-3 rounded-lg transition cursor-pointer',
+                'p-2 sm:p-3 rounded-lg transition cursor-pointer',
                 isDark ? 'text-gray-400 hover:bg-white/10' : 'text-gray-500 hover:bg-gray-100'
               )}
             >
-              <ImageIcon size={24} />
+              <ImageIcon size={isMobile ? 20 : 24} />
             </button>
             <button
               type="button"
               className={cn(
-                'p-3 rounded-lg transition cursor-pointer',
+                'p-2 sm:p-3 rounded-lg transition cursor-pointer',
                 isDark ? 'text-gray-400 hover:bg-white/10' : 'text-gray-500 hover:bg-gray-100'
               )}
             >
-              <Paperclip size={24} />
+              <Paperclip size={isMobile ? 20 : 24} />
             </button>
             <div className="ml-auto text-xs text-gray-500 flex items-center">
               {content?.length || 0} 글자


### PR DESCRIPTION
## Summary
- `useIsMobile` 훅 추가 (768px 브레이크포인트, `matchMedia` 기반)
- 게시글 작성/수정 에디터 모바일 최적화: 편집/미리보기 토글 버튼, 높이 축소(300px), 반응형 패딩·제목·툴바
- 헤더 검색 바 모바일 최적화: 아이콘 토글 + 바깥 클릭 닫기, iOS 자동 확대 방지(16px)
- MDEditor 모바일 CSS 추가 (툴바 축소, 줄바꿈 허용, 내장 토글 숨김)

## Test plan
- [ ] 모바일(375px) 게시글 작성 페이지에서 편집/미리보기 토글 동작 확인
- [ ] 모바일(375px) 게시글 수정 페이지에서 동일 확인
- [ ] 모바일 헤더에서 검색 아이콘 탭 → 전체 너비 검색 바 표시 확인
- [ ] 검색 바 바깥 클릭 시 닫힘 확인
- [ ] iOS에서 검색 입력 시 화면 확대 없음 확인
- [ ] 데스크톱(768px+)에서 기존 동작 유지 확인
- [ ] 다크 모드 정상 동작 확인