### PR TITLE
feat(backend): 게시판 목록 API에서 canRead=false 게시판도 반환

### DIFF
--- a/backend/src/main/java/igrus/web/community/board/service/read/GetBoardListService.java
+++ b/backend/src/main/java/igrus/web/community/board/service/read/GetBoardListService.java
@@ -43,7 +43,6 @@ public class GetBoardListService {
                     boolean canWrite = canWriteBoardService.canWrite(board, role);
                     return BoardListResponse.of(board, canRead, canWrite);
                 })
-                .filter(response -> response.canRead())
                 .toList();
     }
 }

--- a/backend/src/test/java/igrus/web/community/board/controller/BoardControllerTest.java
+++ b/backend/src/test/java/igrus/web/community/board/controller/BoardControllerTest.java
@@ -123,9 +123,9 @@ class BoardControllerTest extends ServiceIntegrationTestBase {
                     .andExpect(jsonPath("$[2].name").value("정보공유"));
         }
 
-        @DisplayName("준회원이 게시판 목록 조회 시 공지사항만 반환")
+        @DisplayName("준회원이 게시판 목록 조회 시 모든 게시판 반환 (canRead로 권한 구분)")
         @Test
-        void getBoardList_WithAssociateUser_ReturnsOnlyNotices() throws Exception {
+        void getBoardList_WithAssociateUser_ReturnsAllBoardsWithPermissions() throws Exception {
             // when & then
             mockMvc.perform(get(BASE_URL)
                             .with(withAuth(associateUser))
@@ -133,8 +133,13 @@ class BoardControllerTest extends ServiceIntegrationTestBase {
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$").isArray())
-                    .andExpect(jsonPath("$.length()").value(1))
-                    .andExpect(jsonPath("$[0].code").value("NOTICES"));
+                    .andExpect(jsonPath("$.length()").value(3))
+                    .andExpect(jsonPath("$[0].code").value("NOTICES"))
+                    .andExpect(jsonPath("$[0].canRead").value(true))
+                    .andExpect(jsonPath("$[1].code").value("GENERAL"))
+                    .andExpect(jsonPath("$[1].canRead").value(false))
+                    .andExpect(jsonPath("$[2].code").value("INSIGHT"))
+                    .andExpect(jsonPath("$[2].canRead").value(false));
         }
 
         @DisplayName("비인증 사용자가 접근 시 401 Unauthorized")

--- a/backend/src/test/java/igrus/web/community/board/integration/BoardPermissionIntegrationTest.java
+++ b/backend/src/test/java/igrus/web/community/board/integration/BoardPermissionIntegrationTest.java
@@ -151,9 +151,9 @@ class BoardPermissionIntegrationTest extends ServiceIntegrationTestBase {
                     .andExpect(jsonPath("$.canWrite").value(false));
         }
 
-        @DisplayName("준회원이 게시판 목록 조회 시 읽기 권한 있는 게시판만 반환")
+        @DisplayName("준회원이 게시판 목록 조회 시 모든 게시판 반환 (canRead로 권한 구분)")
         @Test
-        void associate_getBoardList_returnsOnlyAccessibleBoards() throws Exception {
+        void associate_getBoardList_returnsAllBoardsWithPermissions() throws Exception {
             mockMvc.perform(get(BASE_URL)
                             .with(withAuth(associateUser))
                             .with(csrf())
@@ -161,8 +161,13 @@ class BoardPermissionIntegrationTest extends ServiceIntegrationTestBase {
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$").isArray())
-                    .andExpect(jsonPath("$.length()").value(1))
-                    .andExpect(jsonPath("$[0].code").value("NOTICES"));
+                    .andExpect(jsonPath("$.length()").value(3))
+                    .andExpect(jsonPath("$[0].code").value("NOTICES"))
+                    .andExpect(jsonPath("$[0].canRead").value(true))
+                    .andExpect(jsonPath("$[1].code").value("GENERAL"))
+                    .andExpect(jsonPath("$[1].canRead").value(false))
+                    .andExpect(jsonPath("$[2].code").value("INSIGHT"))
+                    .andExpect(jsonPath("$[2].canRead").value(false));
         }
     }
 

--- a/backend/src/test/java/igrus/web/community/board/service/read/GetBoardListServiceTest.java
+++ b/backend/src/test/java/igrus/web/community/board/service/read/GetBoardListServiceTest.java
@@ -78,9 +78,9 @@ class GetBoardListServiceTest {
         assertThat(result.get(2).code()).isEqualTo(BoardCode.INSIGHT.name());
     }
 
-    @DisplayName("준회원(ASSOCIATE)이 게시판 목록 조회 시 읽기 권한 있는 게시판만 반환 (공지사항만)")
+    @DisplayName("준회원(ASSOCIATE)이 게시판 목록 조회 시 모든 게시판 반환 (canRead 값으로 권한 구분)")
     @Test
-    void getBoardList_WithAssociateRole_ReturnsOnlyReadableBoards() {
+    void getBoardList_WithAssociateRole_ReturnsAllBoardsWithPermissions() {
         // given
         UserRole role = UserRole.ASSOCIATE;
         List<Board> boards = List.of(noticesBoard, generalBoard, insightBoard);
@@ -90,14 +90,20 @@ class GetBoardListServiceTest {
         given(canReadBoardService.canRead(eq(generalBoard), eq(role))).willReturn(false);
         given(canReadBoardService.canRead(eq(insightBoard), eq(role))).willReturn(false);
         given(canWriteBoardService.canWrite(eq(noticesBoard), eq(role))).willReturn(false);
+        given(canWriteBoardService.canWrite(eq(generalBoard), eq(role))).willReturn(false);
+        given(canWriteBoardService.canWrite(eq(insightBoard), eq(role))).willReturn(false);
 
         // when
         List<BoardListResponse> result = getBoardListService.getBoardList(role);
 
         // then
-        assertThat(result).hasSize(1);
+        assertThat(result).hasSize(3);
         assertThat(result.get(0).code()).isEqualTo(BoardCode.NOTICES.name());
         assertThat(result.get(0).canRead()).isTrue();
         assertThat(result.get(0).canWrite()).isFalse();
+        assertThat(result.get(1).code()).isEqualTo(BoardCode.GENERAL.name());
+        assertThat(result.get(1).canRead()).isFalse();
+        assertThat(result.get(2).code()).isEqualTo(BoardCode.INSIGHT.name());
+        assertThat(result.get(2).canRead()).isFalse();
     }
 }


### PR DESCRIPTION
## Summary
- 게시판 목록 조회 API(`GET /api/v1/boards`)에서 `canRead=false`인 게시판도 응답에 포함하도록 변경
- 기존: 읽기 권한 없는 게시판은 목록에서 제외 → 변경: 모든 게시판을 `canRead` 값과 함께 반환
- 프론트엔드에서 `canRead` 값을 기반으로 UI 처리(잠금 표시 등) 가능

## Test plan
- [x] `GetBoardListServiceTest` 단위 테스트 통과
- [x] `BoardControllerTest` 통합 테스트 통과
- [x] `BoardPermissionIntegrationTest` 통합 테스트 통과
- [ ] 준회원 로그인 시 모든 게시판이 목록에 표시되고, `canRead=false` 게시판에 적절한 UI 표시 확인