### PR TITLE
fix(backend): 인증 코드 재발송 rate limit 5분에서 1분으로 변경

### DIFF
--- a/backend/src/main/java/igrus/web/security/auth/password/service/signup/ResendVerificationService.java
+++ b/backend/src/main/java/igrus/web/security/auth/password/service/signup/ResendVerificationService.java
@@ -36,12 +36,12 @@ public class ResendVerificationService {
      *
      * @param request 재발송 요청 정보
      * @return 재발송 완료 응답
-     * @throws VerificationResendRateLimitedException 5분 내 재발송 요청 시
+     * @throws VerificationResendRateLimitedException 1분 내 재발송 요청 시
      */
     public VerificationResendResponse resendVerification(ResendVerificationRequest request) {
         log.info("인증 코드 재발송 요청: email={}", request.email());
 
-        // Rate Limiting 체크: 5분 내 재발송 기록 확인
+        // Rate Limiting 체크: 1분 내 재발송 기록 확인
         Instant cutoffTime = Instant.now().minusSeconds(resendRateLimitSeconds);
         if (emailVerificationRepository.existsByEmailAndVerifiedFalseAndCreatedAtAfter(
                 request.email(), cutoffTime)) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -27,6 +27,6 @@ app:
     verification-code-expiry: 600000    # 10분
     verification-max-attempts: 5
     password-reset-expiry: 1800000      # 30분
-    resend-rate-limit-seconds: 300      # 5분
+    resend-rate-limit-seconds: 60       # 1분
   cleanup:
     unverified-user-retention-hours: 24 # 24시간


### PR DESCRIPTION
## Summary
- 이메일 인증 코드 재발송 rate limit을 5분에서 1분으로 변경
- `resend-rate-limit-seconds` 설정값: 300 → 60
- `ResendVerificationService` 주석 업데이트

## Test plan
- [ ] 인증 코드 재발송 후 1분 이내 재요청 시 rate limit 에러 확인
- [ ] 1분 경과 후 재발송 정상 동작 확인