### PR TITLE
feat(backend): 고정 게시글(Pinned Post) CRUD API 구현

### DIFF
--- a/backend/src/main/java/igrus/web/common/exception/ErrorCode.java
+++ b/backend/src/main/java/igrus/web/common/exception/ErrorCode.java
@@ -159,7 +159,12 @@ public enum ErrorCode {
     EVENT_NOT_IN_REGISTRATION_PERIOD(400, "신청 기간이 아닙니다"),
     EVENT_NOT_EDITABLE(400, "수정 불가능한 상태의 행사입니다"),
     EVENT_INVALID_STATE_TRANSITION(400, "허용되지 않은 행사 상태 변경입니다"),
-    EVENT_TIME_OVERLAP(409, "이미 신청한 다른 행사와 시간이 겹칩니다");
+    EVENT_TIME_OVERLAP(409, "이미 신청한 다른 행사와 시간이 겹칩니다"),
+
+    // Pinned Post (고정 게시글)
+    PINNED_POST_NOT_FOUND(404, "고정 게시글을 찾을 수 없습니다"),
+    PINNED_POST_ALREADY_EXISTS(409, "이미 고정된 게시글입니다"),
+    INVALID_DISPLAY_ORDER(400, "표시 순서는 1 이상이어야 합니다");
 
     private final int status;
     private final String message;

--- a/backend/src/main/java/igrus/web/community/pinnedpost/controller/PinnedPostController.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/controller/PinnedPostController.java
@@ -1,0 +1,158 @@
+package igrus.web.community.pinnedpost.controller;
+
+import igrus.web.common.config.SwaggerConfig;
+import igrus.web.community.pinnedpost.dto.request.CreatePinnedPostRequest;
+import igrus.web.community.pinnedpost.dto.request.UpdateDisplayOrderRequest;
+import igrus.web.community.pinnedpost.dto.response.PinnedPostDetailResponse;
+import igrus.web.community.pinnedpost.dto.response.PinnedPostListResponse;
+import igrus.web.community.pinnedpost.service.read.GetPinnedPostListService;
+import igrus.web.community.pinnedpost.service.write.CreatePinnedPostService;
+import igrus.web.community.pinnedpost.service.write.DeletePinnedPostService;
+import igrus.web.community.pinnedpost.service.write.UpdatePinnedPostDisplayOrderService;
+import igrus.web.security.auth.common.domain.AuthenticatedUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Pinned Post", description = "고정 게시글 API")
+@SecurityRequirement(name = SwaggerConfig.SECURITY_SCHEME_NAME)
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/pinned-posts")
+@RequiredArgsConstructor
+public class PinnedPostController {
+
+    private final CreatePinnedPostService createPinnedPostService;
+    private final GetPinnedPostListService getPinnedPostListService;
+    private final UpdatePinnedPostDisplayOrderService updatePinnedPostDisplayOrderService;
+    private final DeletePinnedPostService deletePinnedPostService;
+
+    @Operation(
+            summary = "게시글 고정",
+            description = "게시글을 메인 페이지에 고정합니다. OPERATOR 이상만 가능합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "고정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PinnedPostDetailResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (OPERATOR 이상 필요)"),
+            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 고정된 게시글")
+    })
+    @PostMapping
+    @PreAuthorize("hasAnyRole('OPERATOR', 'ADMIN')")
+    public ResponseEntity<PinnedPostDetailResponse> createPinnedPost(
+            @Valid @RequestBody CreatePinnedPostRequest request,
+            @AuthenticationPrincipal AuthenticatedUser user
+    ) {
+        log.info("게시글 고정 요청 - postId: {}, displayOrder: {}, userId: {}",
+                request.postId(), request.displayOrder(), user.userId());
+
+        PinnedPostDetailResponse response = createPinnedPostService.createPinnedPost(request, user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(
+            summary = "고정 게시글 목록 조회",
+            description = "메인 페이지에 고정된 모든 게시글을 표시 순서대로 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    useReturnTypeSchema = true
+            )
+    })
+    @GetMapping
+    public ResponseEntity<List<PinnedPostListResponse>> getPinnedPostList() {
+        log.debug("고정 게시글 목록 조회 요청");
+
+        List<PinnedPostListResponse> response = getPinnedPostListService.getPinnedPostList();
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "고정 게시글 표시 순서 변경",
+            description = "고정 게시글의 표시 순서를 변경합니다. OPERATOR 이상만 가능합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "변경 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PinnedPostDetailResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (OPERATOR 이상 필요)"),
+            @ApiResponse(responseCode = "404", description = "고정 게시글을 찾을 수 없음")
+    })
+    @PutMapping("/{id}/display-order")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'ADMIN')")
+    public ResponseEntity<PinnedPostDetailResponse> updateDisplayOrder(
+            @Parameter(description = "고정 게시글 ID", example = "1")
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateDisplayOrderRequest request,
+            @AuthenticationPrincipal AuthenticatedUser user
+    ) {
+        log.info("고정 게시글 순서 변경 요청 - id: {}, newOrder: {}, userId: {}",
+                id, request.displayOrder(), user.userId());
+
+        PinnedPostDetailResponse response = updatePinnedPostDisplayOrderService.updateDisplayOrder(id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "게시글 고정 해제",
+            description = "게시글 고정을 해제합니다. OPERATOR 이상만 가능합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "고정 해제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (OPERATOR 이상 필요)"),
+            @ApiResponse(responseCode = "404", description = "고정 게시글을 찾을 수 없음")
+    })
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('OPERATOR', 'ADMIN')")
+    public ResponseEntity<Void> deletePinnedPost(
+            @Parameter(description = "고정 게시글 ID", example = "1")
+            @PathVariable Long id,
+            @AuthenticationPrincipal AuthenticatedUser user
+    ) {
+        log.info("게시글 고정 해제 요청 - id: {}, userId: {}", id, user.userId());
+
+        deletePinnedPostService.deletePinnedPost(id, user);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/domain/PinnedPost.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/domain/PinnedPost.java
@@ -1,0 +1,107 @@
+package igrus.web.community.pinnedpost.domain;
+
+import igrus.web.common.domain.SoftDeletableEntity;
+import igrus.web.community.pinnedpost.exception.InvalidDisplayOrderException;
+import igrus.web.community.post.domain.Post;
+import igrus.web.user.domain.User;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 고정 게시글 엔티티.
+ * 메인 페이지에 고정할 게시글 정보를 관리합니다.
+ */
+@Entity
+@Table(name = "pinned_posts")
+@AttributeOverrides({
+        @AttributeOverride(name = "createdAt", column = @Column(name = "pinned_posts_created_at", nullable = false, updatable = false)),
+        @AttributeOverride(name = "updatedAt", column = @Column(name = "pinned_posts_updated_at", nullable = false)),
+        @AttributeOverride(name = "createdBy", column = @Column(name = "pinned_posts_created_by", updatable = false)),
+        @AttributeOverride(name = "updatedBy", column = @Column(name = "pinned_posts_updated_by")),
+        @AttributeOverride(name = "deleted", column = @Column(name = "pinned_posts_deleted", nullable = false)),
+        @AttributeOverride(name = "deletedAt", column = @Column(name = "pinned_posts_deleted_at")),
+        @AttributeOverride(name = "deletedBy", column = @Column(name = "pinned_posts_deleted_by"))
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PinnedPost extends SoftDeletableEntity {
+
+    /** 고정 게시글 고유 식별자 */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pinned_posts_id")
+    private Long id;
+
+    /** 고정된 게시글 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pinned_posts_post_id", nullable = false)
+    private Post post;
+
+    /** 표시 순서 (1부터 시작) */
+    @Column(name = "pinned_posts_display_order", nullable = false)
+    private Integer displayOrder;
+
+    /** 고정한 사용자 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pinned_posts_pinned_by", nullable = false)
+    private User pinnedBy;
+
+    /** 낙관적 락을 위한 버전 (동시성 제어) */
+    @Version
+    @Column(name = "pinned_posts_version")
+    private Long version;
+
+    // === 정적 팩토리 메서드 ===
+
+    /**
+     * 고정 게시글을 생성합니다.
+     *
+     * @param post         고정할 게시글
+     * @param pinnedBy     고정한 사용자
+     * @param displayOrder 표시 순서 (1 이상)
+     * @return 생성된 고정 게시글
+     * @throws InvalidDisplayOrderException 표시 순서가 1 미만인 경우
+     */
+    public static PinnedPost create(Post post, User pinnedBy, Integer displayOrder) {
+        validateDisplayOrder(displayOrder);
+        PinnedPost pinnedPost = new PinnedPost();
+        pinnedPost.post = post;
+        pinnedPost.pinnedBy = pinnedBy;
+        pinnedPost.displayOrder = displayOrder;
+        return pinnedPost;
+    }
+
+    // === 비즈니스 메서드 ===
+
+    /**
+     * 표시 순서를 변경합니다.
+     *
+     * @param newOrder 새 표시 순서 (1 이상)
+     * @throws InvalidDisplayOrderException 표시 순서가 1 미만인 경우
+     */
+    public void updateDisplayOrder(Integer newOrder) {
+        validateDisplayOrder(newOrder);
+        this.displayOrder = newOrder;
+    }
+
+    // === Private 검증 메서드 ===
+
+    private static void validateDisplayOrder(Integer order) {
+        if (order == null || order < 1) {
+            throw new InvalidDisplayOrderException(order);
+        }
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/dto/request/CreatePinnedPostRequest.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/dto/request/CreatePinnedPostRequest.java
@@ -1,0 +1,13 @@
+package igrus.web.community.pinnedpost.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record CreatePinnedPostRequest(
+        @NotNull(message = "게시글 ID는 필수입니다")
+        Long postId,
+
+        @NotNull(message = "표시 순서는 필수입니다")
+        @Min(value = 1, message = "표시 순서는 1 이상이어야 합니다")
+        Integer displayOrder
+) {}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/dto/request/UpdateDisplayOrderRequest.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/dto/request/UpdateDisplayOrderRequest.java
@@ -1,0 +1,10 @@
+package igrus.web.community.pinnedpost.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateDisplayOrderRequest(
+        @NotNull(message = "표시 순서는 필수입니다")
+        @Min(value = 1, message = "표시 순서는 1 이상이어야 합니다")
+        Integer displayOrder
+) {}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/dto/response/PinnedPostDetailResponse.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/dto/response/PinnedPostDetailResponse.java
@@ -1,0 +1,34 @@
+package igrus.web.community.pinnedpost.dto.response;
+
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import igrus.web.user.domain.User;
+
+import java.time.Instant;
+
+public record PinnedPostDetailResponse(
+        Long id,
+        Long postId,
+        String postTitle,
+        String boardCode,
+        Integer displayOrder,
+        PinnedByInfo pinnedBy,
+        Instant createdAt
+) {
+    public static PinnedPostDetailResponse from(PinnedPost pinnedPost) {
+        return new PinnedPostDetailResponse(
+                pinnedPost.getId(),
+                pinnedPost.getPost().getId(),
+                pinnedPost.getPost().getTitle(),
+                pinnedPost.getPost().getBoard().getCode().name(),
+                pinnedPost.getDisplayOrder(),
+                PinnedByInfo.from(pinnedPost.getPinnedBy()),
+                pinnedPost.getCreatedAt()
+        );
+    }
+
+    public record PinnedByInfo(Long id, String name) {
+        public static PinnedByInfo from(User user) {
+            return new PinnedByInfo(user.getId(), user.getDisplayName());
+        }
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/dto/response/PinnedPostListResponse.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/dto/response/PinnedPostListResponse.java
@@ -1,0 +1,77 @@
+package igrus.web.community.pinnedpost.dto.response;
+
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import igrus.web.community.post.domain.Post;
+import igrus.web.user.domain.User;
+
+import java.time.Instant;
+
+public record PinnedPostListResponse(
+        Long id,
+        PostInfo post,
+        Integer displayOrder,
+        PinnedByInfo pinnedBy,
+        Instant pinnedAt
+) {
+    public static PinnedPostListResponse from(PinnedPost pinnedPost) {
+        return new PinnedPostListResponse(
+                pinnedPost.getId(),
+                PostInfo.from(pinnedPost.getPost()),
+                pinnedPost.getDisplayOrder(),
+                PinnedByInfo.from(pinnedPost.getPinnedBy()),
+                pinnedPost.getCreatedAt()
+        );
+    }
+
+    public record PostInfo(
+            Long id,
+            String title,
+            String contentPreview,
+            String boardCode,
+            String boardName,
+            AuthorInfo author,
+            int viewCount,
+            int likeCount,
+            int commentCount,
+            Instant createdAt
+    ) {
+        private static final int PREVIEW_MAX_LENGTH = 200;
+
+        public static PostInfo from(Post post) {
+            return new PostInfo(
+                    post.getId(),
+                    post.getTitle(),
+                    truncate(post.getContent(), PREVIEW_MAX_LENGTH),
+                    post.getBoard().getCode().name(),
+                    post.getBoard().getName(),
+                    AuthorInfo.from(post.getAuthor()),
+                    post.getViewCount(),
+                    post.getLikeCount(),
+                    post.getCommentCount(),
+                    post.getCreatedAt()
+            );
+        }
+
+        private static String truncate(String text, int maxLength) {
+            if (text == null || text.length() <= maxLength) {
+                return text;
+            }
+            return text.substring(0, maxLength);
+        }
+    }
+
+    public record AuthorInfo(Long id, String name) {
+        public static AuthorInfo from(User author) {
+            if (author == null) {
+                return new AuthorInfo(null, User.WITHDRAWN_DISPLAY_NAME);
+            }
+            return new AuthorInfo(author.getId(), author.getDisplayName());
+        }
+    }
+
+    public record PinnedByInfo(Long id, String name) {
+        public static PinnedByInfo from(User user) {
+            return new PinnedByInfo(user.getId(), user.getDisplayName());
+        }
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/exception/InvalidDisplayOrderException.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/exception/InvalidDisplayOrderException.java
@@ -1,0 +1,14 @@
+package igrus.web.community.pinnedpost.exception;
+
+import igrus.web.common.exception.CustomBaseException;
+import igrus.web.common.exception.ErrorCode;
+
+/**
+ * 유효하지 않은 표시 순서 값이 입력되었을 때 발생하는 예외.
+ */
+public class InvalidDisplayOrderException extends CustomBaseException {
+
+    public InvalidDisplayOrderException(Integer order) {
+        super(ErrorCode.INVALID_DISPLAY_ORDER, "표시 순서는 1 이상이어야 합니다. 입력된 값: " + order);
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/exception/PinnedPostAlreadyExistsException.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/exception/PinnedPostAlreadyExistsException.java
@@ -1,0 +1,14 @@
+package igrus.web.community.pinnedpost.exception;
+
+import igrus.web.common.exception.CustomBaseException;
+import igrus.web.common.exception.ErrorCode;
+
+/**
+ * 이미 고정된 게시글을 다시 고정하려 할 때 발생하는 예외.
+ */
+public class PinnedPostAlreadyExistsException extends CustomBaseException {
+
+    public PinnedPostAlreadyExistsException(Long postId) {
+        super(ErrorCode.PINNED_POST_ALREADY_EXISTS, "이미 고정된 게시글입니다: " + postId);
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/exception/PinnedPostNotFoundException.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/exception/PinnedPostNotFoundException.java
@@ -1,0 +1,18 @@
+package igrus.web.community.pinnedpost.exception;
+
+import igrus.web.common.exception.CustomBaseException;
+import igrus.web.common.exception.ErrorCode;
+
+/**
+ * 고정 게시글을 찾을 수 없을 때 발생하는 예외.
+ */
+public class PinnedPostNotFoundException extends CustomBaseException {
+
+    public PinnedPostNotFoundException() {
+        super(ErrorCode.PINNED_POST_NOT_FOUND);
+    }
+
+    public PinnedPostNotFoundException(Long id) {
+        super(ErrorCode.PINNED_POST_NOT_FOUND, "고정 게시글을 찾을 수 없습니다: " + id);
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/repository/PinnedPostRepository.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/repository/PinnedPostRepository.java
@@ -1,0 +1,30 @@
+package igrus.web.community.pinnedpost.repository;
+
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PinnedPostRepository extends JpaRepository<PinnedPost, Long> {
+
+    /**
+     * 삭제되지 않은 고정 게시글을 ID로 조회합니다.
+     */
+    Optional<PinnedPost> findByIdAndDeletedFalse(Long id);
+
+    /**
+     * 모든 고정 게시글을 표시 순서대로 조회합니다 (삭제되지 않은 것만).
+     * Post, Author, Board, PinnedBy 정보를 함께 로드합니다.
+     */
+    @EntityGraph(attributePaths = {"post", "post.author", "post.board", "pinnedBy"})
+    List<PinnedPost> findAllByDeletedFalseOrderByDisplayOrderAsc();
+
+    /**
+     * 특정 게시글이 이미 고정되어 있는지 확인합니다 (삭제되지 않은 것만).
+     */
+    boolean existsByPostIdAndDeletedFalse(Long postId);
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/service/read/GetPinnedPostListService.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/service/read/GetPinnedPostListService.java
@@ -1,0 +1,31 @@
+package igrus.web.community.pinnedpost.service.read;
+
+import igrus.web.community.pinnedpost.dto.response.PinnedPostListResponse;
+import igrus.web.community.pinnedpost.repository.PinnedPostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetPinnedPostListService {
+
+    private final PinnedPostRepository pinnedPostRepository;
+
+    /**
+     * 모든 고정 게시글을 표시 순서대로 조회합니다.
+     *
+     * @return 고정 게시글 목록
+     */
+    public List<PinnedPostListResponse> getPinnedPostList() {
+        return pinnedPostRepository.findAllByDeletedFalseOrderByDisplayOrderAsc()
+                .stream()
+                .map(PinnedPostListResponse::from)
+                .toList();
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/service/support/ValidatePinnedPostService.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/service/support/ValidatePinnedPostService.java
@@ -1,0 +1,29 @@
+package igrus.web.community.pinnedpost.service.support;
+
+import igrus.web.community.pinnedpost.exception.PinnedPostAlreadyExistsException;
+import igrus.web.community.pinnedpost.repository.PinnedPostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ValidatePinnedPostService {
+
+    private final PinnedPostRepository pinnedPostRepository;
+
+    /**
+     * 게시글이 이미 고정되어 있는지 검증합니다.
+     *
+     * @param postId 게시글 ID
+     * @throws PinnedPostAlreadyExistsException 이미 고정된 게시글인 경우
+     */
+    public void validateNotAlreadyPinned(Long postId) {
+        if (pinnedPostRepository.existsByPostIdAndDeletedFalse(postId)) {
+            throw new PinnedPostAlreadyExistsException(postId);
+        }
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/service/write/CreatePinnedPostService.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/service/write/CreatePinnedPostService.java
@@ -1,0 +1,58 @@
+package igrus.web.community.pinnedpost.service.write;
+
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import igrus.web.community.pinnedpost.dto.request.CreatePinnedPostRequest;
+import igrus.web.community.pinnedpost.dto.response.PinnedPostDetailResponse;
+import igrus.web.community.pinnedpost.repository.PinnedPostRepository;
+import igrus.web.community.pinnedpost.service.support.ValidatePinnedPostService;
+import igrus.web.community.post.domain.Post;
+import igrus.web.community.post.exception.PostNotFoundException;
+import igrus.web.community.post.repository.PostRepository;
+import igrus.web.security.auth.common.domain.AuthenticatedUser;
+import igrus.web.user.domain.User;
+import igrus.web.user.exception.UserNotFoundException;
+import igrus.web.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreatePinnedPostService {
+
+    private final PinnedPostRepository pinnedPostRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final ValidatePinnedPostService validatePinnedPostService;
+
+    /**
+     * 게시글을 메인 페이지에 고정합니다.
+     *
+     * @param request           고정 게시글 생성 요청
+     * @param authenticatedUser 인증된 사용자 (OPERATOR 이상)
+     * @return 생성된 고정 게시글 응답
+     */
+    public PinnedPostDetailResponse createPinnedPost(
+            CreatePinnedPostRequest request,
+            AuthenticatedUser authenticatedUser
+    ) {
+        Post post = postRepository.findByIdAndDeletedFalse(request.postId())
+                .orElseThrow(() -> new PostNotFoundException(request.postId()));
+
+        validatePinnedPostService.validateNotAlreadyPinned(post.getId());
+
+        User pinnedBy = userRepository.findById(authenticatedUser.userId())
+                .orElseThrow(UserNotFoundException::new);
+
+        PinnedPost pinnedPost = PinnedPost.create(post, pinnedBy, request.displayOrder());
+        PinnedPost saved = pinnedPostRepository.save(pinnedPost);
+
+        log.info("게시글 고정 완료 - postId: {}, displayOrder: {}, pinnedBy: {}",
+                post.getId(), request.displayOrder(), pinnedBy.getId());
+
+        return PinnedPostDetailResponse.from(saved);
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/service/write/DeletePinnedPostService.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/service/write/DeletePinnedPostService.java
@@ -1,0 +1,34 @@
+package igrus.web.community.pinnedpost.service.write;
+
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import igrus.web.community.pinnedpost.exception.PinnedPostNotFoundException;
+import igrus.web.community.pinnedpost.repository.PinnedPostRepository;
+import igrus.web.security.auth.common.domain.AuthenticatedUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeletePinnedPostService {
+
+    private final PinnedPostRepository pinnedPostRepository;
+
+    /**
+     * 고정 게시글을 삭제합니다 (soft delete).
+     *
+     * @param id                고정 게시글 ID
+     * @param authenticatedUser 인증된 사용자 (OPERATOR 이상)
+     */
+    public void deletePinnedPost(Long id, AuthenticatedUser authenticatedUser) {
+        PinnedPost pinnedPost = pinnedPostRepository.findByIdAndDeletedFalse(id)
+                .orElseThrow(() -> new PinnedPostNotFoundException(id));
+
+        pinnedPost.delete(authenticatedUser.userId());
+
+        log.info("고정 게시글 삭제 - id: {}, deletedBy: {}", id, authenticatedUser.userId());
+    }
+}

--- a/backend/src/main/java/igrus/web/community/pinnedpost/service/write/UpdatePinnedPostDisplayOrderService.java
+++ b/backend/src/main/java/igrus/web/community/pinnedpost/service/write/UpdatePinnedPostDisplayOrderService.java
@@ -1,0 +1,38 @@
+package igrus.web.community.pinnedpost.service.write;
+
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import igrus.web.community.pinnedpost.dto.request.UpdateDisplayOrderRequest;
+import igrus.web.community.pinnedpost.dto.response.PinnedPostDetailResponse;
+import igrus.web.community.pinnedpost.exception.PinnedPostNotFoundException;
+import igrus.web.community.pinnedpost.repository.PinnedPostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdatePinnedPostDisplayOrderService {
+
+    private final PinnedPostRepository pinnedPostRepository;
+
+    /**
+     * 고정 게시글의 표시 순서를 변경합니다.
+     *
+     * @param id      고정 게시글 ID
+     * @param request 표시 순서 변경 요청
+     * @return 수정된 고정 게시글 응답
+     */
+    public PinnedPostDetailResponse updateDisplayOrder(Long id, UpdateDisplayOrderRequest request) {
+        PinnedPost pinnedPost = pinnedPostRepository.findByIdAndDeletedFalse(id)
+                .orElseThrow(() -> new PinnedPostNotFoundException(id));
+
+        pinnedPost.updateDisplayOrder(request.displayOrder());
+
+        log.info("고정 게시글 순서 변경 - id: {}, newOrder: {}", id, request.displayOrder());
+
+        return PinnedPostDetailResponse.from(pinnedPost);
+    }
+}

--- a/backend/src/main/java/igrus/web/security/config/ApiSecurityConfig.java
+++ b/backend/src/main/java/igrus/web/security/config/ApiSecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -37,6 +38,9 @@ public class ApiSecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                 // 인증 없이 접근 가능 (SecurityPaths에서 중앙 관리)
                 .requestMatchers(SecurityPaths.PUBLIC_PATHS).permitAll()
+
+                // 고정 게시글 목록 조회 (GET만 공개, POST/PUT/DELETE는 인증 필요)
+                .requestMatchers(HttpMethod.GET, "/api/v1/pinned-posts").permitAll()
 
                 // 학기별 회원 명단 조회 (운영진 이상)
                 .requestMatchers("/api/v1/semesters/**").hasAnyRole("OPERATOR", "ADMIN")

--- a/backend/src/main/resources/db/migration/V33__create_pinned_posts_table.sql
+++ b/backend/src/main/resources/db/migration/V33__create_pinned_posts_table.sql
@@ -1,0 +1,23 @@
+-- 메인 페이지 고정 게시글 테이블
+
+CREATE TABLE pinned_posts (
+    pinned_posts_id BIGINT NOT NULL AUTO_INCREMENT,
+    pinned_posts_post_id BIGINT NOT NULL,
+    pinned_posts_display_order INT NOT NULL,
+    pinned_posts_pinned_by BIGINT NOT NULL,
+    pinned_posts_version BIGINT,
+    pinned_posts_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    pinned_posts_deleted_at TIMESTAMP(6),
+    pinned_posts_deleted_by BIGINT,
+    pinned_posts_created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    pinned_posts_updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    pinned_posts_created_by BIGINT,
+    pinned_posts_updated_by BIGINT,
+    PRIMARY KEY (pinned_posts_id),
+    INDEX idx_pinned_posts_display_order (pinned_posts_display_order),
+    INDEX idx_pinned_posts_deleted (pinned_posts_deleted)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE pinned_posts
+    ADD CONSTRAINT fk_pinned_posts_post FOREIGN KEY (pinned_posts_post_id) REFERENCES posts(posts_id),
+    ADD CONSTRAINT fk_pinned_posts_pinned_by FOREIGN KEY (pinned_posts_pinned_by) REFERENCES users(users_id);

--- a/backend/src/test/java/igrus/web/community/fixture/PinnedPostTestFixture.java
+++ b/backend/src/test/java/igrus/web/community/fixture/PinnedPostTestFixture.java
@@ -1,0 +1,46 @@
+package igrus.web.community.fixture;
+
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import igrus.web.community.pinnedpost.dto.request.CreatePinnedPostRequest;
+import igrus.web.community.pinnedpost.dto.request.UpdateDisplayOrderRequest;
+import igrus.web.community.post.domain.Post;
+import igrus.web.user.domain.User;
+
+import static igrus.web.common.fixture.TestEntityIdAssigner.withId;
+
+/**
+ * PinnedPost 도메인 관련 테스트 픽스처 클래스.
+ */
+public final class PinnedPostTestFixture {
+
+    public static final Long DEFAULT_PINNED_POST_ID = 100L;
+
+    private PinnedPostTestFixture() {
+    }
+
+    // ==================== PinnedPost 생성 (ID 없음) ====================
+
+    public static PinnedPost createPinnedPost(Post post, User pinnedBy, int displayOrder) {
+        return PinnedPost.create(post, pinnedBy, displayOrder);
+    }
+
+    // ==================== PinnedPost 생성 (ID 포함) ====================
+
+    public static PinnedPost pinnedPost(Post post, User pinnedBy, int displayOrder) {
+        return withId(createPinnedPost(post, pinnedBy, displayOrder), DEFAULT_PINNED_POST_ID);
+    }
+
+    public static PinnedPost pinnedPost(Post post, User pinnedBy, int displayOrder, Long id) {
+        return withId(createPinnedPost(post, pinnedBy, displayOrder), id);
+    }
+
+    // ==================== Request DTO 생성 ====================
+
+    public static CreatePinnedPostRequest createRequest(Long postId, int displayOrder) {
+        return new CreatePinnedPostRequest(postId, displayOrder);
+    }
+
+    public static UpdateDisplayOrderRequest updateOrderRequest(int displayOrder) {
+        return new UpdateDisplayOrderRequest(displayOrder);
+    }
+}

--- a/backend/src/test/java/igrus/web/community/pinnedpost/domain/PinnedPostTest.java
+++ b/backend/src/test/java/igrus/web/community/pinnedpost/domain/PinnedPostTest.java
@@ -1,0 +1,125 @@
+package igrus.web.community.pinnedpost.domain;
+
+import igrus.web.community.board.domain.Board;
+import igrus.web.community.pinnedpost.exception.InvalidDisplayOrderException;
+import igrus.web.community.post.domain.Post;
+import igrus.web.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static igrus.web.common.fixture.UserTestFixture.*;
+import static igrus.web.community.fixture.BoardTestFixture.*;
+import static igrus.web.community.fixture.PostTestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PinnedPost 엔티티 단위 테스트")
+class PinnedPostTest {
+
+    private Board board;
+    private User operator;
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        board = generalBoard();
+        operator = createOperatorWithId();
+        post = normalPost(board, createMemberWithId());
+    }
+
+    @Nested
+    @DisplayName("고정 게시글 생성")
+    class Create {
+
+        @Test
+        @DisplayName("유효한 입력으로 고정 게시글 생성 성공")
+        void create_WithValidInputs_Success() {
+            PinnedPost pinnedPost = PinnedPost.create(post, operator, 1);
+
+            assertThat(pinnedPost.getPost()).isEqualTo(post);
+            assertThat(pinnedPost.getPinnedBy()).isEqualTo(operator);
+            assertThat(pinnedPost.getDisplayOrder()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("displayOrder가 0이면 예외 발생")
+        void create_WithZeroOrder_ThrowsException() {
+            assertThatThrownBy(() -> PinnedPost.create(post, operator, 0))
+                    .isInstanceOf(InvalidDisplayOrderException.class);
+        }
+
+        @Test
+        @DisplayName("displayOrder가 음수이면 예외 발생")
+        void create_WithNegativeOrder_ThrowsException() {
+            assertThatThrownBy(() -> PinnedPost.create(post, operator, -1))
+                    .isInstanceOf(InvalidDisplayOrderException.class);
+        }
+
+        @Test
+        @DisplayName("displayOrder가 null이면 예외 발생")
+        void create_WithNullOrder_ThrowsException() {
+            assertThatThrownBy(() -> PinnedPost.create(post, operator, null))
+                    .isInstanceOf(InvalidDisplayOrderException.class);
+        }
+
+        @Test
+        @DisplayName("큰 displayOrder 값으로 생성 성공")
+        void create_WithLargeOrder_Success() {
+            PinnedPost pinnedPost = PinnedPost.create(post, operator, 999);
+
+            assertThat(pinnedPost.getDisplayOrder()).isEqualTo(999);
+        }
+    }
+
+    @Nested
+    @DisplayName("표시 순서 변경")
+    class UpdateDisplayOrder {
+
+        @Test
+        @DisplayName("유효한 순서로 변경 성공")
+        void updateDisplayOrder_WithValidOrder_Success() {
+            PinnedPost pinnedPost = PinnedPost.create(post, operator, 1);
+
+            pinnedPost.updateDisplayOrder(5);
+
+            assertThat(pinnedPost.getDisplayOrder()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("0으로 변경 시 예외 발생")
+        void updateDisplayOrder_WithZero_ThrowsException() {
+            PinnedPost pinnedPost = PinnedPost.create(post, operator, 1);
+
+            assertThatThrownBy(() -> pinnedPost.updateDisplayOrder(0))
+                    .isInstanceOf(InvalidDisplayOrderException.class);
+        }
+
+        @Test
+        @DisplayName("음수로 변경 시 예외 발생")
+        void updateDisplayOrder_WithNegative_ThrowsException() {
+            PinnedPost pinnedPost = PinnedPost.create(post, operator, 1);
+
+            assertThatThrownBy(() -> pinnedPost.updateDisplayOrder(-1))
+                    .isInstanceOf(InvalidDisplayOrderException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Soft Delete")
+    class SoftDelete {
+
+        @Test
+        @DisplayName("삭제 시 deleted 플래그가 true로 변경")
+        void delete_SetsDeletedFlag() {
+            PinnedPost pinnedPost = PinnedPost.create(post, operator, 1);
+
+            pinnedPost.delete(operator.getId());
+
+            assertThat(pinnedPost.isDeleted()).isTrue();
+            assertThat(pinnedPost.getDeletedBy()).isEqualTo(operator.getId());
+            assertThat(pinnedPost.getDeletedAt()).isNotNull();
+        }
+    }
+}

--- a/backend/src/test/java/igrus/web/community/pinnedpost/service/read/GetPinnedPostListServiceTest.java
+++ b/backend/src/test/java/igrus/web/community/pinnedpost/service/read/GetPinnedPostListServiceTest.java
@@ -1,0 +1,112 @@
+package igrus.web.community.pinnedpost.service.read;
+
+import igrus.web.community.board.domain.Board;
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import igrus.web.community.pinnedpost.dto.response.PinnedPostListResponse;
+import igrus.web.community.pinnedpost.repository.PinnedPostRepository;
+import igrus.web.community.post.domain.Post;
+import igrus.web.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static igrus.web.common.fixture.UserTestFixture.*;
+import static igrus.web.community.fixture.BoardTestFixture.*;
+import static igrus.web.community.fixture.PinnedPostTestFixture.*;
+import static igrus.web.community.fixture.PostTestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetPinnedPostListService 단위 테스트")
+class GetPinnedPostListServiceTest {
+
+    @Mock
+    private PinnedPostRepository pinnedPostRepository;
+
+    @InjectMocks
+    private GetPinnedPostListService getPinnedPostListService;
+
+    private Board board;
+    private User member;
+    private User operator;
+
+    @BeforeEach
+    void setUp() {
+        board = generalBoard();
+        member = createMemberWithId();
+        operator = createOperatorWithId();
+    }
+
+    @Nested
+    @DisplayName("고정 게시글 목록 조회")
+    class GetList {
+
+        @Test
+        @DisplayName("표시 순서대로 정렬된 목록 반환")
+        void getPinnedPostList_ReturnsOrderedList() {
+            // given
+            Post post1 = normalPost(board, member, 10L);
+            Post post2 = normalPost(board, member, 11L);
+            Post post3 = normalPost(board, member, 12L);
+
+            PinnedPost pinned1 = pinnedPost(post1, operator, 1, 100L);
+            PinnedPost pinned2 = pinnedPost(post2, operator, 2, 101L);
+            PinnedPost pinned3 = pinnedPost(post3, operator, 3, 102L);
+
+            given(pinnedPostRepository.findAllByDeletedFalseOrderByDisplayOrderAsc())
+                    .willReturn(List.of(pinned1, pinned2, pinned3));
+
+            // when
+            List<PinnedPostListResponse> result = getPinnedPostListService.getPinnedPostList();
+
+            // then
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).displayOrder()).isEqualTo(1);
+            assertThat(result.get(1).displayOrder()).isEqualTo(2);
+            assertThat(result.get(2).displayOrder()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("고정 게시글이 없으면 빈 목록 반환")
+        void getPinnedPostList_WhenEmpty_ReturnsEmptyList() {
+            // given
+            given(pinnedPostRepository.findAllByDeletedFalseOrderByDisplayOrderAsc())
+                    .willReturn(List.of());
+
+            // when
+            List<PinnedPostListResponse> result = getPinnedPostListService.getPinnedPostList();
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("게시글 정보가 응답에 포함됨")
+        void getPinnedPostList_IncludesPostInfo() {
+            // given
+            Post post = normalPost(board, member, 10L);
+            PinnedPost pinned = pinnedPost(post, operator, 1, 100L);
+
+            given(pinnedPostRepository.findAllByDeletedFalseOrderByDisplayOrderAsc())
+                    .willReturn(List.of(pinned));
+
+            // when
+            List<PinnedPostListResponse> result = getPinnedPostListService.getPinnedPostList();
+
+            // then
+            assertThat(result).hasSize(1);
+            PinnedPostListResponse response = result.get(0);
+            assertThat(response.post().id()).isEqualTo(post.getId());
+            assertThat(response.post().title()).isEqualTo(post.getTitle());
+            assertThat(response.post().boardCode()).isEqualTo(board.getCode().name());
+        }
+    }
+}

--- a/backend/src/test/java/igrus/web/community/pinnedpost/service/write/CreatePinnedPostServiceTest.java
+++ b/backend/src/test/java/igrus/web/community/pinnedpost/service/write/CreatePinnedPostServiceTest.java
@@ -1,0 +1,128 @@
+package igrus.web.community.pinnedpost.service.write;
+
+import igrus.web.community.board.domain.Board;
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import igrus.web.community.pinnedpost.dto.request.CreatePinnedPostRequest;
+import igrus.web.community.pinnedpost.dto.response.PinnedPostDetailResponse;
+import igrus.web.community.pinnedpost.exception.PinnedPostAlreadyExistsException;
+import igrus.web.community.pinnedpost.repository.PinnedPostRepository;
+import igrus.web.community.pinnedpost.service.support.ValidatePinnedPostService;
+import igrus.web.community.post.domain.Post;
+import igrus.web.community.post.exception.PostNotFoundException;
+import igrus.web.community.post.repository.PostRepository;
+import igrus.web.security.auth.common.domain.AuthenticatedUser;
+import igrus.web.user.domain.User;
+import igrus.web.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static igrus.web.common.fixture.UserTestFixture.*;
+import static igrus.web.community.fixture.BoardTestFixture.*;
+import static igrus.web.community.fixture.PinnedPostTestFixture.*;
+import static igrus.web.community.fixture.PostTestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreatePinnedPostService 단위 테스트")
+class CreatePinnedPostServiceTest {
+
+    @Mock
+    private PinnedPostRepository pinnedPostRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ValidatePinnedPostService validatePinnedPostService;
+
+    @InjectMocks
+    private CreatePinnedPostService createPinnedPostService;
+
+    private Board board;
+    private User operator;
+    private Post post;
+    private AuthenticatedUser operatorAuth;
+
+    @BeforeEach
+    void setUp() {
+        board = generalBoard();
+        operator = createOperatorWithId();
+        post = normalPost(board, createMemberWithId());
+        operatorAuth = operatorAuth();
+    }
+
+    @Nested
+    @DisplayName("게시글 고정 성공")
+    class CreateSuccess {
+
+        @Test
+        @DisplayName("유효한 요청으로 게시글 고정 성공")
+        void createPinnedPost_WithValidRequest_Success() {
+            // given
+            CreatePinnedPostRequest request = createRequest(post.getId(), 1);
+            given(postRepository.findByIdAndDeletedFalse(post.getId())).willReturn(Optional.of(post));
+            doNothing().when(validatePinnedPostService).validateNotAlreadyPinned(post.getId());
+            given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operator));
+            given(pinnedPostRepository.save(any(PinnedPost.class))).willAnswer(invocation -> {
+                PinnedPost saved = invocation.getArgument(0);
+                return saved;
+            });
+
+            // when
+            PinnedPostDetailResponse response = createPinnedPostService.createPinnedPost(request, operatorAuth);
+
+            // then
+            assertThat(response.postId()).isEqualTo(post.getId());
+            assertThat(response.displayOrder()).isEqualTo(1);
+            verify(pinnedPostRepository).save(any(PinnedPost.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 고정 실패")
+    class CreateFailure {
+
+        @Test
+        @DisplayName("존재하지 않는 게시글이면 예외 발생")
+        void createPinnedPost_PostNotFound_ThrowsException() {
+            // given
+            CreatePinnedPostRequest request = createRequest(999L, 1);
+            given(postRepository.findByIdAndDeletedFalse(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> createPinnedPostService.createPinnedPost(request, operatorAuth))
+                    .isInstanceOf(PostNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("이미 고정된 게시글이면 예외 발생")
+        void createPinnedPost_AlreadyPinned_ThrowsException() {
+            // given
+            CreatePinnedPostRequest request = createRequest(post.getId(), 1);
+            given(postRepository.findByIdAndDeletedFalse(post.getId())).willReturn(Optional.of(post));
+            doThrow(new PinnedPostAlreadyExistsException(post.getId()))
+                    .when(validatePinnedPostService).validateNotAlreadyPinned(post.getId());
+
+            // when & then
+            assertThatThrownBy(() -> createPinnedPostService.createPinnedPost(request, operatorAuth))
+                    .isInstanceOf(PinnedPostAlreadyExistsException.class);
+        }
+    }
+}

--- a/backend/src/test/java/igrus/web/community/pinnedpost/service/write/DeletePinnedPostServiceTest.java
+++ b/backend/src/test/java/igrus/web/community/pinnedpost/service/write/DeletePinnedPostServiceTest.java
@@ -1,0 +1,88 @@
+package igrus.web.community.pinnedpost.service.write;
+
+import igrus.web.community.board.domain.Board;
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import igrus.web.community.pinnedpost.exception.PinnedPostNotFoundException;
+import igrus.web.community.pinnedpost.repository.PinnedPostRepository;
+import igrus.web.community.post.domain.Post;
+import igrus.web.security.auth.common.domain.AuthenticatedUser;
+import igrus.web.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static igrus.web.common.fixture.UserTestFixture.*;
+import static igrus.web.community.fixture.BoardTestFixture.*;
+import static igrus.web.community.fixture.PinnedPostTestFixture.*;
+import static igrus.web.community.fixture.PostTestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeletePinnedPostService 단위 테스트")
+class DeletePinnedPostServiceTest {
+
+    @Mock
+    private PinnedPostRepository pinnedPostRepository;
+
+    @InjectMocks
+    private DeletePinnedPostService deletePinnedPostService;
+
+    private Board board;
+    private User operator;
+    private Post post;
+    private AuthenticatedUser operatorAuth;
+
+    @BeforeEach
+    void setUp() {
+        board = generalBoard();
+        operator = createOperatorWithId();
+        post = normalPost(board, createMemberWithId());
+        operatorAuth = operatorAuth();
+    }
+
+    @Nested
+    @DisplayName("고정 해제 성공")
+    class DeleteSuccess {
+
+        @Test
+        @DisplayName("고정 게시글 soft delete 성공")
+        void deletePinnedPost_Success() {
+            // given
+            PinnedPost pinnedPost = pinnedPost(post, operator, 1);
+            given(pinnedPostRepository.findByIdAndDeletedFalse(pinnedPost.getId()))
+                    .willReturn(Optional.of(pinnedPost));
+
+            // when
+            deletePinnedPostService.deletePinnedPost(pinnedPost.getId(), operatorAuth);
+
+            // then
+            assertThat(pinnedPost.isDeleted()).isTrue();
+            assertThat(pinnedPost.getDeletedBy()).isEqualTo(operatorAuth.userId());
+        }
+    }
+
+    @Nested
+    @DisplayName("고정 해제 실패")
+    class DeleteFailure {
+
+        @Test
+        @DisplayName("존재하지 않는 고정 게시글이면 예외 발생")
+        void deletePinnedPost_NotFound_ThrowsException() {
+            // given
+            given(pinnedPostRepository.findByIdAndDeletedFalse(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> deletePinnedPostService.deletePinnedPost(999L, operatorAuth))
+                    .isInstanceOf(PinnedPostNotFoundException.class);
+        }
+    }
+}

--- a/backend/src/test/java/igrus/web/community/pinnedpost/service/write/UpdatePinnedPostDisplayOrderServiceTest.java
+++ b/backend/src/test/java/igrus/web/community/pinnedpost/service/write/UpdatePinnedPostDisplayOrderServiceTest.java
@@ -1,0 +1,91 @@
+package igrus.web.community.pinnedpost.service.write;
+
+import igrus.web.community.board.domain.Board;
+import igrus.web.community.pinnedpost.domain.PinnedPost;
+import igrus.web.community.pinnedpost.dto.request.UpdateDisplayOrderRequest;
+import igrus.web.community.pinnedpost.dto.response.PinnedPostDetailResponse;
+import igrus.web.community.pinnedpost.exception.PinnedPostNotFoundException;
+import igrus.web.community.pinnedpost.repository.PinnedPostRepository;
+import igrus.web.community.post.domain.Post;
+import igrus.web.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static igrus.web.common.fixture.UserTestFixture.*;
+import static igrus.web.community.fixture.BoardTestFixture.*;
+import static igrus.web.community.fixture.PinnedPostTestFixture.*;
+import static igrus.web.community.fixture.PostTestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdatePinnedPostDisplayOrderService 단위 테스트")
+class UpdatePinnedPostDisplayOrderServiceTest {
+
+    @Mock
+    private PinnedPostRepository pinnedPostRepository;
+
+    @InjectMocks
+    private UpdatePinnedPostDisplayOrderService updatePinnedPostDisplayOrderService;
+
+    private Board board;
+    private User operator;
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        board = generalBoard();
+        operator = createOperatorWithId();
+        post = normalPost(board, createMemberWithId());
+    }
+
+    @Nested
+    @DisplayName("표시 순서 변경 성공")
+    class UpdateSuccess {
+
+        @Test
+        @DisplayName("유효한 순서로 변경 성공")
+        void updateDisplayOrder_WithValidOrder_Success() {
+            // given
+            PinnedPost pinnedPost = pinnedPost(post, operator, 1);
+            given(pinnedPostRepository.findByIdAndDeletedFalse(pinnedPost.getId()))
+                    .willReturn(Optional.of(pinnedPost));
+
+            UpdateDisplayOrderRequest request = updateOrderRequest(5);
+
+            // when
+            PinnedPostDetailResponse response = updatePinnedPostDisplayOrderService
+                    .updateDisplayOrder(pinnedPost.getId(), request);
+
+            // then
+            assertThat(response.displayOrder()).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    @DisplayName("표시 순서 변경 실패")
+    class UpdateFailure {
+
+        @Test
+        @DisplayName("존재하지 않는 고정 게시글이면 예외 발생")
+        void updateDisplayOrder_NotFound_ThrowsException() {
+            // given
+            given(pinnedPostRepository.findByIdAndDeletedFalse(999L)).willReturn(Optional.empty());
+
+            UpdateDisplayOrderRequest request = updateOrderRequest(5);
+
+            // when & then
+            assertThatThrownBy(() -> updatePinnedPostDisplayOrderService.updateDisplayOrder(999L, request))
+                    .isInstanceOf(PinnedPostNotFoundException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 메인 페이지에 고정할 게시글을 관리하는 CRUD API 구현
- 게시글 고정(POST), 목록 조회(GET), 표시 순서 변경(PUT), 고정 해제(DELETE)
- GET 목록 조회만 비인증 공개, 나머지 API는 OPERATOR/ADMIN 권한 필요
- Soft delete, 낙관적 락(@Version), EntityGraph를 활용한 N+1 방지 적용
- 목록 응답에서 게시글 본문을 200자 미리보기로 제한

## Changes
- `pinnedpost/` 패키지: 엔티티, 컨트롤러, 서비스(read/write/support), DTO, 예외, 리포지토리
- `ErrorCode.java`: 고정 게시글 관련 에러 코드 3건 추가
- `ApiSecurityConfig.java`: GET `/api/v1/pinned-posts`만 공개 접근 허용
- `V33__create_pinned_posts_table.sql`: Flyway 마이그레이션
- 도메인 단위 테스트 + 서비스 단위 테스트 (5개 테스트 클래스)

## Test plan
- [x] `./gradlew compileJava` 컴파일 성공
- [x] `./gradlew test --tests "igrus.web.community.pinnedpost.*"` 테스트 통과
- [ ] GET `/api/v1/pinned-posts` 비인증 접근 가능 확인
- [ ] POST `/api/v1/pinned-posts` 비인증 시 401 반환 확인
- [ ] OPERATOR/ADMIN 권한으로 CRUD 정상 동작 확인