### PR TITLE
feat(backend): 학번/이메일 중복 체크 API 추가

### DIFF
--- a/backend/src/main/java/igrus/web/security/auth/password/controller/PasswordAuthController.java
+++ b/backend/src/main/java/igrus/web/security/auth/password/controller/PasswordAuthController.java
@@ -19,6 +19,7 @@ import igrus.web.security.auth.password.dto.request.PasswordLoginRequest;
 import igrus.web.security.auth.password.dto.request.PasswordResetConfirmRequest;
 import igrus.web.security.auth.password.dto.request.PasswordResetRequest;
 import igrus.web.security.auth.password.dto.request.PasswordSignupRequest;
+import igrus.web.security.auth.password.dto.response.DuplicateCheckResponse;
 import igrus.web.security.auth.password.dto.response.PasswordLoginResponse;
 import igrus.web.security.auth.password.dto.response.PasswordSignupResponse;
 import igrus.web.security.auth.password.dto.internal.TokenRotationResult;
@@ -30,6 +31,7 @@ import igrus.web.security.auth.password.service.reset.ValidateResetTokenService;
 import igrus.web.security.auth.password.service.auth.LoginService;
 import igrus.web.security.auth.password.service.auth.LogoutService;
 import igrus.web.security.auth.password.service.auth.RefreshTokenService;
+import igrus.web.security.auth.password.service.signup.CheckDuplicateService;
 import igrus.web.security.auth.password.service.signup.ResendVerificationService;
 import igrus.web.security.auth.password.service.signup.SignupService;
 import igrus.web.security.auth.password.service.signup.VerifyEmailService;
@@ -70,6 +72,7 @@ public class PasswordAuthController {
     private final LogoutService logoutService;
     private final RefreshTokenService refreshTokenService;
     private final SignupService signupService;
+    private final CheckDuplicateService checkDuplicateService;
     private final VerifyEmailService verifyEmailService;
     private final ResendVerificationService resendVerificationService;
     private final RequestPasswordResetService requestPasswordResetService;
@@ -236,6 +239,58 @@ public class PasswordAuthController {
     public ResponseEntity<PasswordSignupResponse> signup(@Valid @RequestBody PasswordSignupRequest request) {
         PasswordSignupResponse response = signupService.signup(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(
+            summary = "학번 중복 체크",
+            description = "학번의 유효성 검사 및 중복 여부를 확인합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용 가능한 학번"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "학번 형식 오류 (8자리 숫자가 아님)"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 가입된 학번"
+            )
+    })
+    @GetMapping("/check-student-id")
+    public ResponseEntity<DuplicateCheckResponse> checkStudentIdDuplicate(
+            @Parameter(description = "확인할 학번 (8자리 숫자)", example = "12345678", required = true)
+            @RequestParam String studentId) {
+        DuplicateCheckResponse response = checkDuplicateService.checkStudentId(studentId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "이메일 중복 체크",
+            description = "이메일의 유효성 검사 및 중복 여부를 확인합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용 가능한 이메일"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "이메일 형식 오류"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 존재하는 이메일"
+            )
+    })
+    @GetMapping("/check-email")
+    public ResponseEntity<DuplicateCheckResponse> checkEmailDuplicate(
+            @Parameter(description = "확인할 이메일", example = "user@example.com", required = true)
+            @RequestParam String email) {
+        DuplicateCheckResponse response = checkDuplicateService.checkEmail(email);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "이메일 인증", description = "이메일로 발송된 인증 코드를 확인합니다.")

--- a/backend/src/main/java/igrus/web/security/auth/password/dto/response/DuplicateCheckResponse.java
+++ b/backend/src/main/java/igrus/web/security/auth/password/dto/response/DuplicateCheckResponse.java
@@ -1,0 +1,20 @@
+package igrus.web.security.auth.password.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "중복 체크 응답")
+public record DuplicateCheckResponse(
+        @Schema(description = "사용 가능 여부", example = "true")
+        boolean available,
+
+        @Schema(description = "안내 메시지", example = "사용 가능한 학번입니다")
+        String message
+) {
+    public static DuplicateCheckResponse studentIdAvailable() {
+        return new DuplicateCheckResponse(true, "사용 가능한 학번입니다");
+    }
+
+    public static DuplicateCheckResponse emailAvailable() {
+        return new DuplicateCheckResponse(true, "사용 가능한 이메일입니다");
+    }
+}

--- a/backend/src/main/java/igrus/web/security/auth/password/service/signup/CheckDuplicateService.java
+++ b/backend/src/main/java/igrus/web/security/auth/password/service/signup/CheckDuplicateService.java
@@ -1,0 +1,64 @@
+package igrus.web.security.auth.password.service.signup;
+
+import igrus.web.security.auth.common.exception.signup.DuplicateEmailException;
+import igrus.web.security.auth.common.exception.signup.DuplicateStudentIdException;
+import igrus.web.security.auth.password.dto.response.DuplicateCheckResponse;
+import igrus.web.user.exception.InvalidEmailException;
+import igrus.web.user.exception.InvalidStudentIdException;
+import igrus.web.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CheckDuplicateService {
+
+    private static final String STUDENT_ID_PATTERN = "^\\d{8}$";
+    private static final String EMAIL_PATTERN = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";
+
+    private final UserRepository userRepository;
+
+    /**
+     * 학번 중복을 확인합니다.
+     * soft-deleted 사용자를 포함하여 중복을 확인합니다.
+     *
+     * @param studentId 확인할 학번
+     * @return 사용 가능 여부 응답
+     * @throws InvalidStudentIdException 학번 형식이 올바르지 않은 경우
+     * @throws DuplicateStudentIdException 이미 가입된 학번인 경우
+     */
+    public DuplicateCheckResponse checkStudentId(String studentId) {
+        if (studentId == null || !studentId.matches(STUDENT_ID_PATTERN)) {
+            throw new InvalidStudentIdException(studentId);
+        }
+
+        if (userRepository.existsByStudentIdIncludingDeleted(studentId)) {
+            throw new DuplicateStudentIdException();
+        }
+
+        return DuplicateCheckResponse.studentIdAvailable();
+    }
+
+    /**
+     * 이메일 중복을 확인합니다.
+     * soft-deleted 사용자를 포함하여 중복을 확인합니다.
+     *
+     * @param email 확인할 이메일
+     * @return 사용 가능 여부 응답
+     * @throws InvalidEmailException 이메일 형식이 올바르지 않은 경우
+     * @throws DuplicateEmailException 이미 존재하는 이메일인 경우
+     */
+    public DuplicateCheckResponse checkEmail(String email) {
+        if (email == null || !email.matches(EMAIL_PATTERN)) {
+            throw new InvalidEmailException(email);
+        }
+
+        if (userRepository.existsByEmailIncludingDeleted(email)) {
+            throw new DuplicateEmailException();
+        }
+
+        return DuplicateCheckResponse.emailAvailable();
+    }
+}

--- a/backend/src/main/java/igrus/web/user/repository/UserRepository.java
+++ b/backend/src/main/java/igrus/web/user/repository/UserRepository.java
@@ -58,6 +58,14 @@ public interface UserRepository extends JpaRepository<User, Long> {
                              @Param("status") UserStatus status,
                              Pageable pageable);
 
+    // === 삭제된 데이터 포함 존재 여부 확인 (native query로 @SQLRestriction 우회) ===
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM users u WHERE u.users_student_id = :studentId", nativeQuery = true)
+    boolean existsByStudentIdIncludingDeleted(@Param("studentId") String studentId);
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM users u WHERE u.users_email = :email", nativeQuery = true)
+    boolean existsByEmailIncludingDeleted(@Param("email") String email);
+
     // === 삭제된 데이터 포함 조회 (관리자용, native query로 @SQLRestriction 우회) ===
 
     @Query(value = "SELECT * FROM users u WHERE u.users_id = :id", nativeQuery = true)

--- a/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerAccountRecoveryTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerAccountRecoveryTest.java
@@ -16,6 +16,7 @@ import igrus.web.security.auth.password.exception.InvalidCredentialsException;
 import igrus.web.security.auth.password.service.reset.RequestPasswordResetService;
 import igrus.web.security.auth.password.service.reset.ResetPasswordService;
 import igrus.web.security.auth.password.service.reset.ValidateResetTokenService;
+import igrus.web.security.auth.password.service.signup.CheckDuplicateService;
 import igrus.web.security.auth.password.service.signup.ResendVerificationService;
 import igrus.web.security.auth.password.service.signup.SignupService;
 import igrus.web.security.auth.password.service.signup.VerifyEmailService;
@@ -74,6 +75,9 @@ class PasswordAuthControllerAccountRecoveryTest {
 
     @MockitoBean
     private SignupService signupService;
+
+    @MockitoBean
+    private CheckDuplicateService checkDuplicateService;
 
     @MockitoBean
     private VerifyEmailService verifyEmailService;

--- a/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerLoginTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerLoginTest.java
@@ -18,6 +18,7 @@ import igrus.web.security.auth.password.exception.InvalidCredentialsException;
 import igrus.web.security.auth.password.service.reset.RequestPasswordResetService;
 import igrus.web.security.auth.password.service.reset.ResetPasswordService;
 import igrus.web.security.auth.password.service.reset.ValidateResetTokenService;
+import igrus.web.security.auth.password.service.signup.CheckDuplicateService;
 import igrus.web.security.auth.password.service.signup.ResendVerificationService;
 import igrus.web.security.auth.password.service.signup.SignupService;
 import igrus.web.security.auth.password.service.signup.VerifyEmailService;
@@ -81,6 +82,9 @@ class PasswordAuthControllerLoginTest {
 
     @MockitoBean
     private SignupService signupService;
+
+    @MockitoBean
+    private CheckDuplicateService checkDuplicateService;
 
     @MockitoBean
     private VerifyEmailService verifyEmailService;

--- a/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerSignupTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerSignupTest.java
@@ -17,6 +17,7 @@ import igrus.web.security.auth.password.dto.response.PasswordSignupResponse;
 import igrus.web.security.auth.password.service.reset.RequestPasswordResetService;
 import igrus.web.security.auth.password.service.reset.ResetPasswordService;
 import igrus.web.security.auth.password.service.reset.ValidateResetTokenService;
+import igrus.web.security.auth.password.service.signup.CheckDuplicateService;
 import igrus.web.security.auth.password.service.signup.ResendVerificationService;
 import igrus.web.security.auth.password.service.signup.SignupService;
 import igrus.web.security.auth.password.service.signup.VerifyEmailService;
@@ -67,6 +68,9 @@ class PasswordAuthControllerSignupTest {
 
     @MockitoBean
     private SignupService signupService;
+
+    @MockitoBean
+    private CheckDuplicateService checkDuplicateService;
 
     @MockitoBean
     private VerifyEmailService verifyEmailService;

--- a/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerTokenTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerTokenTest.java
@@ -14,6 +14,7 @@ import igrus.web.security.auth.password.dto.internal.TokenRotationResult;
 import igrus.web.security.auth.password.service.reset.RequestPasswordResetService;
 import igrus.web.security.auth.password.service.reset.ResetPasswordService;
 import igrus.web.security.auth.password.service.reset.ValidateResetTokenService;
+import igrus.web.security.auth.password.service.signup.CheckDuplicateService;
 import igrus.web.security.auth.password.service.signup.ResendVerificationService;
 import igrus.web.security.auth.password.service.signup.SignupService;
 import igrus.web.security.auth.password.service.signup.VerifyEmailService;
@@ -67,6 +68,9 @@ class PasswordAuthControllerTokenTest {
 
     @MockitoBean
     private SignupService signupService;
+
+    @MockitoBean
+    private CheckDuplicateService checkDuplicateService;
 
     @MockitoBean
     private VerifyEmailService verifyEmailService;

--- a/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerVerificationTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/controller/PasswordAuthControllerVerificationTest.java
@@ -19,6 +19,7 @@ import igrus.web.security.auth.password.dto.response.VerificationResendResponse;
 import igrus.web.security.auth.password.service.reset.RequestPasswordResetService;
 import igrus.web.security.auth.password.service.reset.ResetPasswordService;
 import igrus.web.security.auth.password.service.reset.ValidateResetTokenService;
+import igrus.web.security.auth.password.service.signup.CheckDuplicateService;
 import igrus.web.security.auth.password.service.signup.ResendVerificationService;
 import igrus.web.security.auth.password.service.signup.SignupService;
 import igrus.web.security.auth.password.service.signup.VerifyEmailService;
@@ -67,6 +68,9 @@ class PasswordAuthControllerVerificationTest {
 
     @MockitoBean
     private SignupService signupService;
+
+    @MockitoBean
+    private CheckDuplicateService checkDuplicateService;
 
     @MockitoBean
     private VerifyEmailService verifyEmailService;

--- a/backend/src/test/java/igrus/web/security/auth/password/service/signup/CheckDuplicateServiceTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/password/service/signup/CheckDuplicateServiceTest.java
@@ -1,0 +1,124 @@
+package igrus.web.security.auth.password.service.signup;
+
+import igrus.web.common.ServiceIntegrationTestBase;
+import igrus.web.security.auth.common.exception.signup.DuplicateEmailException;
+import igrus.web.security.auth.common.exception.signup.DuplicateStudentIdException;
+import igrus.web.security.auth.password.dto.response.DuplicateCheckResponse;
+import igrus.web.user.domain.UserRole;
+import igrus.web.user.exception.InvalidEmailException;
+import igrus.web.user.exception.InvalidStudentIdException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("CheckDuplicateService 통합 테스트")
+class CheckDuplicateServiceTest extends ServiceIntegrationTestBase {
+
+    @Autowired
+    private CheckDuplicateService checkDuplicateService;
+
+    @BeforeEach
+    void setUp() {
+        setUpBase();
+    }
+
+    @Nested
+    @DisplayName("학번 중복 체크")
+    class CheckStudentIdTest {
+
+        @Test
+        @DisplayName("사용 가능한 학번이면 available=true 응답")
+        void checkStudentId_WhenAvailable_ReturnsAvailable() {
+            // given
+            String studentId = "20231234";
+
+            // when
+            DuplicateCheckResponse response = checkDuplicateService.checkStudentId(studentId);
+
+            // then
+            assertThat(response.available()).isTrue();
+            assertThat(response.message()).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("이미 가입된 학번이면 DuplicateStudentIdException 발생")
+        void checkStudentId_WhenDuplicate_ThrowsDuplicateException() {
+            // given
+            createAndSaveUser("20231234", "existing@inha.edu", UserRole.ASSOCIATE);
+
+            // when & then
+            assertThatThrownBy(() -> checkDuplicateService.checkStudentId("20231234"))
+                    .isInstanceOf(DuplicateStudentIdException.class);
+        }
+
+        @Test
+        @DisplayName("학번이 8자리 숫자가 아니면 InvalidStudentIdException 발생")
+        void checkStudentId_WhenInvalidFormat_ThrowsInvalidException() {
+            assertThatThrownBy(() -> checkDuplicateService.checkStudentId("1234"))
+                    .isInstanceOf(InvalidStudentIdException.class);
+        }
+
+        @Test
+        @DisplayName("학번이 null이면 InvalidStudentIdException 발생")
+        void checkStudentId_WhenNull_ThrowsInvalidException() {
+            assertThatThrownBy(() -> checkDuplicateService.checkStudentId(null))
+                    .isInstanceOf(InvalidStudentIdException.class);
+        }
+
+        @Test
+        @DisplayName("학번에 문자가 포함되면 InvalidStudentIdException 발생")
+        void checkStudentId_WhenContainsLetters_ThrowsInvalidException() {
+            assertThatThrownBy(() -> checkDuplicateService.checkStudentId("2023abcd"))
+                    .isInstanceOf(InvalidStudentIdException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일 중복 체크")
+    class CheckEmailTest {
+
+        @Test
+        @DisplayName("사용 가능한 이메일이면 available=true 응답")
+        void checkEmail_WhenAvailable_ReturnsAvailable() {
+            // given
+            String email = "newuser@inha.edu";
+
+            // when
+            DuplicateCheckResponse response = checkDuplicateService.checkEmail(email);
+
+            // then
+            assertThat(response.available()).isTrue();
+            assertThat(response.message()).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 이메일이면 DuplicateEmailException 발생")
+        void checkEmail_WhenDuplicate_ThrowsDuplicateException() {
+            // given
+            createAndSaveUser("20231234", "existing@inha.edu", UserRole.ASSOCIATE);
+
+            // when & then
+            assertThatThrownBy(() -> checkDuplicateService.checkEmail("existing@inha.edu"))
+                    .isInstanceOf(DuplicateEmailException.class);
+        }
+
+        @Test
+        @DisplayName("이메일 형식이 올바르지 않으면 InvalidEmailException 발생")
+        void checkEmail_WhenInvalidFormat_ThrowsInvalidException() {
+            assertThatThrownBy(() -> checkDuplicateService.checkEmail("invalid-email"))
+                    .isInstanceOf(InvalidEmailException.class);
+        }
+
+        @Test
+        @DisplayName("이메일이 null이면 InvalidEmailException 발생")
+        void checkEmail_WhenNull_ThrowsInvalidException() {
+            assertThatThrownBy(() -> checkDuplicateService.checkEmail(null))
+                    .isInstanceOf(InvalidEmailException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 회원가입 시 학번/이메일 중복 여부를 사전에 확인할 수 있는 API 추가
- `GET /check-student-id`: 학번 유효성 검사(8자리 숫자) 및 중복 확인
- `GET /check-email`: 이메일 유효성 검사 및 중복 확인
- 삭제된 사용자 포함 중복 체크를 위한 native query 추가 (`@SQLRestriction` 우회)
- `CheckDuplicateService` 및 단위 테스트 추가

## Test plan
- [ ] 유효한 학번으로 중복 체크 시 200 응답 확인
- [ ] 잘못된 형식의 학번으로 요청 시 400 응답 확인
- [ ] 이미 존재하는 학번으로 요청 시 409 응답 확인
- [ ] 유효한 이메일로 중복 체크 시 200 응답 확인
- [ ] 잘못된 형식의 이메일로 요청 시 400 응답 확인
- [ ] 이미 존재하는 이메일로 요청 시 409 응답 확인
- [ ] 삭제된 사용자의 학번/이메일도 중복으로 감지되는지 확인