### PR TITLE
ci(frontend): 프론트엔드 CD 워크플로우에 feature flag 환경변수 주입

### DIFF
--- a/.github/workflows/frontend-prod-cd.yaml
+++ b/.github/workflows/frontend-prod-cd.yaml
@@ -37,6 +37,9 @@ jobs:
         run: pnpm build
         env:
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          FEATURE_COMMUNITY: 'false'
+          FEATURE_SEARCH: 'false'
+          FEATURE_PROFILE_EDIT: 'false'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary
- 프론트엔드 CD 워크플로우 빌드 시 feature flag 환경변수 직접 주입
- 기존에 `.env.local`에만 있던 flag가 배포 환경에 미적용되던 문제 해결

## Test plan
- [x] GitHub Actions 빌드 시 feature flag 환경변수 정상 주입 확인
- [x] 배포된 사이트에서 커뮤니티 게시판 비활성화 확인
- [x] 프론트엔드 빌드 정상 확인