### PR TITLE
fix(frontend): 에러 메시지 매핑 개선 및 SweetAlert2 아이콘 스타일 수정

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -301,14 +301,17 @@
   padding: 1rem !important;
 }
 
+/* Tailwind preflight가 border-width: 0으로 리셋하므로 아이콘 원형 테두리 복원 */
 .swal2-icon {
-  width: 2.5em !important;
-  height: 2.5em !important;
-  margin: 0.5em auto !important;
+  transform: scale(0.5) !important;
+  margin: -0.5em auto !important;
+  border-width: 0.25em !important;
+  border-style: solid !important;
 }
 
-.swal2-icon .swal2-icon-content {
-  font-size: 1.5em !important;
+.swal2-icon.swal2-success .swal2-success-ring {
+  border-width: 0.25em !important;
+  border-style: solid !important;
 }
 
 .swal2-title {

--- a/frontend/src/utils/error.ts
+++ b/frontend/src/utils/error.ts
@@ -53,7 +53,6 @@ const HTTP_ERROR_MESSAGES: Record<number, string> = {
   404: '요청한 정보를 찾을 수 없습니다.',
   409: '이미 처리된 요청입니다.',
   410: '삭제된 리소스입니다.',
-  422: '입력값을 확인해주세요.',
   423: '계정이 잠겼습니다.',
   429: '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.',
   500: '서버 오류가 발생했습니다.',
@@ -64,7 +63,6 @@ const HTTP_ERROR_MESSAGES: Record<number, string> = {
 // 백엔드 에러 코드별 메시지 (148개 전체 매핑)
 const API_ERROR_MESSAGES: Record<string, string> = {
   // Common (5개)
-  INVALID_INPUT_VALUE: '입력값이 올바르지 않습니다.',
   METHOD_NOT_ALLOWED: '허용되지 않은 요청 방식입니다.',
   INTERNAL_SERVER_ERROR: '서버 내부 오류가 발생했습니다.',
   INVALID_TYPE_VALUE: '유효하지 않은 타입입니다.',
@@ -250,9 +248,9 @@ export function getErrorMessage(error: unknown): string {
     if (mappedMessage) {
       return mappedMessage;
     }
-    // 백엔드에서 보낸 메시지가 있으면 사용
+    // 백엔드에서 보낸 메시지가 있으면 사용 (필드명 접두사 제거)
     if (error.message) {
-      return error.message;
+      return error.message.replace(/^\w+:\s*/, '');
     }
     // HTTP 상태 코드 기반 기본 메시지
     const httpMessage = HTTP_ERROR_MESSAGES[error.status];


### PR DESCRIPTION
## Summary
- HTTP 422 에러 코드 기본 매핑 제거
- `INVALID_INPUT_VALUE` 에러 코드 매핑 제거하여 백엔드 메시지 직접 표시
- 백엔드 에러 메시지의 필드명 접두사(`studentId:` 등) 자동 제거
- SweetAlert2 아이콘 Tailwind preflight에 의한 border 리셋 복원

## Test plan
- [x] 회원가입 시 유효성 검증 에러 메시지가 백엔드 메시지 그대로 표시되는지 확인
- [x] SweetAlert2 아이콘이 정상 표시되는지 확인
- [x] 프론트엔드 빌드 정상 확인