### PR TITLE
feat(backend): 뱁둥이봇 웹훅 요청에 재학 상태 정보 추가

### DIFF
--- a/backend/src/main/java/igrus/web/webhook/baebdungi/dto/BaebdungiSubmissionRequest.java
+++ b/backend/src/main/java/igrus/web/webhook/baebdungi/dto/BaebdungiSubmissionRequest.java
@@ -1,5 +1,6 @@
 package igrus.web.webhook.baebdungi.dto;
 
+import igrus.web.user.domain.EnrollmentStatus;
 import igrus.web.user.domain.Gender;
 import igrus.web.user.domain.User;
 
@@ -35,7 +36,7 @@ public record BaebdungiSubmissionRequest(
                 user.getPhoneNumber(),
                 convertGender(user.getGender()),
                 convertGrade(user.getGrade()),
-                null,
+                convertEnrollmentStatus(user.getEnrollmentStatus()),
                 "네",
                 user.getCreatedAt() != null ? user.getCreatedAt().toString() : null
         );
@@ -48,6 +49,17 @@ public record BaebdungiSubmissionRequest(
         return switch (gender) {
             case MALE -> "남";
             case FEMALE -> "여";
+        };
+    }
+
+    private static String convertEnrollmentStatus(EnrollmentStatus enrollmentStatus) {
+        if (enrollmentStatus == null) {
+            return null;
+        }
+        return switch (enrollmentStatus) {
+            case ENROLLED -> "재학";
+            case GENERAL_LEAVE -> "휴학(일반)";
+            case MILITARY_LEAVE -> "휴학(군)";
         };
     }
 

--- a/backend/src/test/java/igrus/web/webhook/baebdungi/dto/BaebdungiSubmissionRequestTest.java
+++ b/backend/src/test/java/igrus/web/webhook/baebdungi/dto/BaebdungiSubmissionRequestTest.java
@@ -40,7 +40,7 @@ class BaebdungiSubmissionRequestTest {
         assertThat(request.phone()).isEqualTo("010-1234-5678");
         assertThat(request.gender()).isEqualTo("남");
         assertThat(request.grade()).isEqualTo("2학년");
-        assertThat(request.enrollmentStatus()).isNull();
+        assertThat(request.enrollmentStatus()).isEqualTo("재학");
         assertThat(request.hasPaid()).isEqualTo("네");
         assertThat(request.submittedAt()).isEqualTo("2025-03-15T10:30:00Z");
     }
@@ -63,6 +63,44 @@ class BaebdungiSubmissionRequestTest {
         // then
         assertThat(request.gender()).isEqualTo("여");
         assertThat(request.grade()).isEqualTo("1학년");
+    }
+
+    @Test
+    @DisplayName("GENERAL_LEAVE가 '휴학(일반)'으로 변환된다")
+    void fromUser_GeneralLeave_ConvertedCorrectly() {
+        // given
+        User user = User.create(
+                "20231237", "박민수", "test4@inha.edu",
+                "010-1111-2222", "컴퓨터공학과", null,
+                List.of(), Gender.MALE, 2,
+                EnrollmentStatus.GENERAL_LEAVE,
+                List.of(), null, null, null
+        );
+
+        // when
+        BaebdungiSubmissionRequest request = BaebdungiSubmissionRequest.fromUser(user);
+
+        // then
+        assertThat(request.enrollmentStatus()).isEqualTo("휴학(일반)");
+    }
+
+    @Test
+    @DisplayName("MILITARY_LEAVE가 '휴학(군)'으로 변환된다")
+    void fromUser_MilitaryLeave_ConvertedCorrectly() {
+        // given
+        User user = User.create(
+                "20231238", "최대한", "test5@inha.edu",
+                "010-3333-4444", "정보통신공학과", null,
+                List.of(), Gender.MALE, 3,
+                EnrollmentStatus.MILITARY_LEAVE,
+                List.of(), null, null, null
+        );
+
+        // when
+        BaebdungiSubmissionRequest request = BaebdungiSubmissionRequest.fromUser(user);
+
+        // then
+        assertThat(request.enrollmentStatus()).isEqualTo("휴학(군)");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `BaebdungiSubmissionRequest.fromUser()`에서 `enrollmentStatus`를 `null` 대신 User 엔티티의 실제 값을 한글로 변환하여 전송
  - `ENROLLED` → `"재학"`, `GENERAL_LEAVE` → `"휴학(일반)"`, `MILITARY_LEAVE` → `"휴학(군)"`
- 기존 `convertGender`, `convertGrade` 패턴과 동일한 `convertEnrollmentStatus` 변환 메서드 추가

Closes #347

## Test plan
- [x] `BaebdungiSubmissionRequestTest` 단위 테스트 통과 확인
- [x] ENROLLED, GENERAL_LEAVE, MILITARY_LEAVE 각각의 변환 테스트 케이스 추가 및 통과