### PR TITLE
chore(frontend): Orval API 타입 재생성

### DIFF
--- a/frontend/src/api/model/models/commentResponse.ts
+++ b/frontend/src/api/model/models/commentResponse.ts
@@ -43,7 +43,7 @@ export interface CommentResponse {
   authorName?: string;
   likeCount?: number;
   createdAt?: string;
-  anonymous?: boolean;
   deleted?: boolean;
   likedByMe?: boolean;
+  anonymous?: boolean;
 }

--- a/frontend/src/api/model/models/commentWithRepliesResponse.ts
+++ b/frontend/src/api/model/models/commentWithRepliesResponse.ts
@@ -44,7 +44,7 @@ export interface CommentWithRepliesResponse {
   likeCount?: number;
   createdAt?: string;
   replies?: CommentResponse[];
-  anonymous?: boolean;
   deleted?: boolean;
   likedByMe?: boolean;
+  anonymous?: boolean;
 }

--- a/frontend/src/api/model/models/page.ts
+++ b/frontend/src/api/model/models/page.ts
@@ -39,7 +39,6 @@ import type { SortObject } from './sortObject';
 export interface Page {
   totalElements?: number;
   totalPages?: number;
-  pageable?: PageableObject;
   size?: number;
   content?: unknown[];
   number?: number;
@@ -47,5 +46,6 @@ export interface Page {
   first?: boolean;
   last?: boolean;
   numberOfElements?: number;
+  pageable?: PageableObject;
   empty?: boolean;
 }

--- a/frontend/src/api/model/models/pageAccountStatusChangeHistoryResponse.ts
+++ b/frontend/src/api/model/models/pageAccountStatusChangeHistoryResponse.ts
@@ -40,7 +40,6 @@ import type { SortObject } from './sortObject';
 export interface PageAccountStatusChangeHistoryResponse {
   totalElements?: number;
   totalPages?: number;
-  pageable?: PageableObject;
   size?: number;
   content?: AccountStatusChangeHistoryResponse[];
   number?: number;
@@ -48,5 +47,6 @@ export interface PageAccountStatusChangeHistoryResponse {
   first?: boolean;
   last?: boolean;
   numberOfElements?: number;
+  pageable?: PageableObject;
   empty?: boolean;
 }

--- a/frontend/src/api/model/models/pageDemotedAssociateInfoResponse.ts
+++ b/frontend/src/api/model/models/pageDemotedAssociateInfoResponse.ts
@@ -40,7 +40,6 @@ import type { SortObject } from './sortObject';
 export interface PageDemotedAssociateInfoResponse {
   totalElements?: number;
   totalPages?: number;
-  pageable?: PageableObject;
   size?: number;
   content?: DemotedAssociateInfoResponse[];
   number?: number;
@@ -48,5 +47,6 @@ export interface PageDemotedAssociateInfoResponse {
   first?: boolean;
   last?: boolean;
   numberOfElements?: number;
+  pageable?: PageableObject;
   empty?: boolean;
 }

--- a/frontend/src/api/model/models/pageLoginHistoryResponse.ts
+++ b/frontend/src/api/model/models/pageLoginHistoryResponse.ts
@@ -40,7 +40,6 @@ import type { SortObject } from './sortObject';
 export interface PageLoginHistoryResponse {
   totalElements?: number;
   totalPages?: number;
-  pageable?: PageableObject;
   size?: number;
   content?: LoginHistoryResponse[];
   number?: number;
@@ -48,5 +47,6 @@ export interface PageLoginHistoryResponse {
   first?: boolean;
   last?: boolean;
   numberOfElements?: number;
+  pageable?: PageableObject;
   empty?: boolean;
 }

--- a/frontend/src/api/model/models/pageRegistrationListResponse.ts
+++ b/frontend/src/api/model/models/pageRegistrationListResponse.ts
@@ -40,7 +40,6 @@ import type { SortObject } from './sortObject';
 export interface PageRegistrationListResponse {
   totalElements?: number;
   totalPages?: number;
-  pageable?: PageableObject;
   size?: number;
   content?: RegistrationListResponse[];
   number?: number;
@@ -48,5 +47,6 @@ export interface PageRegistrationListResponse {
   first?: boolean;
   last?: boolean;
   numberOfElements?: number;
+  pageable?: PageableObject;
   empty?: boolean;
 }

--- a/frontend/src/api/model/models/pageRejectedAssociateInfoResponse.ts
+++ b/frontend/src/api/model/models/pageRejectedAssociateInfoResponse.ts
@@ -40,7 +40,6 @@ import type { SortObject } from './sortObject';
 export interface PageRejectedAssociateInfoResponse {
   totalElements?: number;
   totalPages?: number;
-  pageable?: PageableObject;
   size?: number;
   content?: RejectedAssociateInfoResponse[];
   number?: number;
@@ -48,5 +47,6 @@ export interface PageRejectedAssociateInfoResponse {
   first?: boolean;
   last?: boolean;
   numberOfElements?: number;
+  pageable?: PageableObject;
   empty?: boolean;
 }

--- a/frontend/src/api/model/models/pageUserRoleHistoryResponse.ts
+++ b/frontend/src/api/model/models/pageUserRoleHistoryResponse.ts
@@ -40,7 +40,6 @@ import type { UserRoleHistoryResponse } from './userRoleHistoryResponse';
 export interface PageUserRoleHistoryResponse {
   totalElements?: number;
   totalPages?: number;
-  pageable?: PageableObject;
   size?: number;
   content?: UserRoleHistoryResponse[];
   number?: number;
@@ -48,5 +47,6 @@ export interface PageUserRoleHistoryResponse {
   first?: boolean;
   last?: boolean;
   numberOfElements?: number;
+  pageable?: PageableObject;
   empty?: boolean;
 }

--- a/frontend/src/api/model/models/pageableObject.ts
+++ b/frontend/src/api/model/models/pageableObject.ts
@@ -36,10 +36,10 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 import type { SortObject } from './sortObject';
 
 export interface PageableObject {
-  paged?: boolean;
-  pageNumber?: number;
-  pageSize?: number;
   offset?: number;
   sort?: SortObject;
+  paged?: boolean;
   unpaged?: boolean;
+  pageNumber?: number;
+  pageSize?: number;
 }

--- a/frontend/src/api/model/models/sortObject.ts
+++ b/frontend/src/api/model/models/sortObject.ts
@@ -35,7 +35,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
  */
 
 export interface SortObject {
-  sorted?: boolean;
-  empty?: boolean;
   unsorted?: boolean;
+  empty?: boolean;
+  sorted?: boolean;
 }


### PR DESCRIPTION
## Summary
- 백엔드 OpenAPI 스펙에 맞춰 Orval 생성 타입 동기화
- 필드 순서 변경 등 자동 생성 차이 반영

## Test plan
- [ ] 프론트엔드 빌드 정상 확인
- [ ] 기존 API 호출 동작 확인