### PR TITLE
chore(devops): GitHub Actions 시크릿을 vars로 마이그레이션

### DIFF
--- a/.github/workflows/frontend-prod-cd.yaml
+++ b/.github/workflows/frontend-prod-cd.yaml
@@ -21,6 +21,9 @@ jobs:
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_FRONTEND_GITHUB_ACTIONS_ROLE_ARN: ${{ vars.AWS_FRONTEND_GITHUB_ACTIONS_ROLE_ARN }}
+      VITE_API_URL: ${{ vars.VITE_API_URL }}
+      S3_BUCKET_NAME: ${{ vars.S3_BUCKET_NAME }}
+      CF_DISTRIBUTION_ID: ${{ vars.CF_DISTRIBUTION_ID }}
     defaults:
       run:
         working-directory: frontend
@@ -47,7 +50,7 @@ jobs:
       - name: Build project
         run: pnpm build
         env:
-          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_API_URL: ${{ env.VITE_API_URL }}
           VITE_APP_VERSION: ${{ inputs.version || github.ref_name }}
           FEATURE_COMMUNITY: 'false'
           FEATURE_SEARCH: 'false'
@@ -61,10 +64,10 @@ jobs:
 
       - name: Deploy to S3
         run: |
-          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET_NAME }} --delete
+          aws s3 sync ./dist s3://${{ env.S3_BUCKET_NAME }} --delete
 
       - name: Invalidate CloudFront
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} \
+            --distribution-id ${{ env.CF_DISTRIBUTION_ID }} \
             --paths "/index.html"

--- a/.github/workflows/frontend-staging-cd.yaml
+++ b/.github/workflows/frontend-staging-cd.yaml
@@ -19,6 +19,9 @@ jobs:
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_FRONTEND_GITHUB_ACTIONS_ROLE_ARN: ${{ vars.AWS_FRONTEND_GITHUB_ACTIONS_ROLE_ARN }}
+      VITE_API_URL: ${{ vars.VITE_API_URL }}
+      S3_BUCKET_NAME: ${{ vars.S3_BUCKET_NAME }}
+      CF_DISTRIBUTION_ID: ${{ vars.CF_DISTRIBUTION_ID }}
     defaults:
       run:
         working-directory: frontend
@@ -45,7 +48,7 @@ jobs:
       - name: Build project
         run: pnpm build
         env:
-          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_API_URL: ${{ env.VITE_API_URL }}
           FEATURE_COMMUNITY: 'false'
           FEATURE_SEARCH: 'false'
           FEATURE_PROFILE_EDIT: 'false'
@@ -58,10 +61,10 @@ jobs:
 
       - name: Deploy to S3
         run: |
-          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET_NAME }} --delete
+          aws s3 sync ./dist s3://${{ env.S3_BUCKET_NAME }} --delete
 
       - name: Invalidate CloudFront
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} \
+            --distribution-id ${{ env.CF_DISTRIBUTION_ID }} \
             --paths "/index.html"


### PR DESCRIPTION
## Summary
- 프론트엔드 CD 워크플로우(prod, staging)에서 `secrets`를 `vars`로 마이그레이션
- VITE_API_URL, S3_BUCKET_NAME, CF_DISTRIBUTION_ID를 job-level env로 통합