### PR TITLE
feat(devops): release 워크플로우에 GitHub Release 자동 생성 추가

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,14 @@ jobs:
           git tag ${{ steps.bump.outputs.version }}
           git push origin ${{ steps.bump.outputs.version }}
 
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ steps.bump.outputs.version }} \
+            --title "${{ steps.bump.outputs.version }}" \
+            --generate-notes
+
   deploy-backend:
     name: Deploy Backend
     needs: create-tag


### PR DESCRIPTION
## Summary
- release 워크플로우에서 태그 생성 후 GitHub Release를 자동 생성하도록 추가
- `--generate-notes`로 이전 릴리즈 이후 변경사항 자동 포함