### PR TITLE
fix(backend): 스테이징 쿠키 도메인을 상위 도메인으로 변경

### DIFF
--- a/backend/src/main/resources/application-staging.yml
+++ b/backend/src/main/resources/application-staging.yml
@@ -38,7 +38,7 @@ app:
   cookie:
     secure: true
     same-site: Lax
-    domain: staging.igrus.co.kr
+    domain: igrus.co.kr
   frontend-url: https://staging.igrus.co.kr
   webhook:
     baebdung-i:


### PR DESCRIPTION
## Summary
- 스테이징 환경 쿠키 도메인을 `staging.igrus.co.kr`에서 `igrus.co.kr`로 변경