### PR TITLE
chore(devops): Dockerfile 프로필을 빌드 시 환경변수로 주입하도록 변경

### DIFF
--- a/.github/workflows/backend-prod-cd.yaml
+++ b/.github/workflows/backend-prod-cd.yaml
@@ -75,7 +75,7 @@ jobs:
           # Build a docker container and
           # push it to ECR so that it can
           # be deployed to ECS.
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG .
+          docker build --build-arg SPRING_ACTIVE_PROFILE=$SPRING_ACTIVE_PROFILE -t $ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/backend-staging-cd.yaml
+++ b/.github/workflows/backend-staging-cd.yaml
@@ -71,7 +71,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG .
+          docker build --build-arg SPRING_ACTIVE_PROFILE=$SPRING_ACTIVE_PROFILE -t $ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG" >> $GITHUB_OUTPUT
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,7 @@
 FROM eclipse-temurin:21-jdk
 
-ENV SPRING_ACTIVE_PROFILE=prod
+ARG SPRING_ACTIVE_PROFILE=prod
+ENV SPRING_ACTIVE_PROFILE=$SPRING_ACTIVE_PROFILE
 
 ARG JAR_FILE=build/libs/igrus-web-server.jar
 COPY ${JAR_FILE} app.jar


### PR DESCRIPTION
## Summary
- Dockerfile의 `SPRING_ACTIVE_PROFILE`을 하드코딩(`prod`)에서 `ARG`+`ENV` 조합으로 변경하여 빌드 시 외부 주입 가능하도록 수정
- staging/prod CD 워크플로우의 `docker build`에 `--build-arg SPRING_ACTIVE_PROFILE` 추가

## Test plan
- [ ] staging CD 파이프라인 실행 시 GitHub vars의 `SPRING_ACTIVE_PROFILE` 값이 Docker 이미지에 주입되는지 확인
- [ ] prod CD 파이프라인 실행 시 동일하게 동작하는지 확인