### PR TITLE
chore: CD 파이프라인에 행사/인스타그램 피처 플래그 추가

### DIFF
--- a/.github/workflows/frontend-prod-cd.yaml
+++ b/.github/workflows/frontend-prod-cd.yaml
@@ -55,6 +55,8 @@ jobs:
           FEATURE_COMMUNITY: 'false'
           FEATURE_SEARCH: 'false'
           FEATURE_PROFILE_EDIT: 'false'
+          FEATURE_EVENTS: 'false'
+          FEATURE_INSTAGRAM: 'false'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/frontend-staging-cd.yaml
+++ b/.github/workflows/frontend-staging-cd.yaml
@@ -52,6 +52,8 @@ jobs:
           FEATURE_COMMUNITY: 'false'
           FEATURE_SEARCH: 'false'
           FEATURE_PROFILE_EDIT: 'false'
+          FEATURE_EVENTS: 'false'
+          FEATURE_INSTAGRAM: 'false'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary
- staging/prod CD 빌드 시 FEATURE_EVENTS, FEATURE_INSTAGRAM 플래그를 false로 설정
- 배포 환경에서 행사/인스타그램 섹션이 비활성화