### PR TITLE
[Frontend] staging 환경 검색 엔진 크롤링 차단

### DIFF
--- a/.github/workflows/frontend-staging-cd.yaml
+++ b/.github/workflows/frontend-staging-cd.yaml
@@ -55,6 +55,7 @@ jobs:
           FEATURE_EVENTS: 'true'
           FEATURE_INSTAGRAM: 'false'
           FEATURE_DARK_MODE: 'false'
+          VITE_NOINDEX: 'true'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,7 +14,31 @@ export default defineConfig(({ mode }) => {
     env.VITE_API_TARGET || "https://staging-api.igrus.co.kr:8080";
 
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [
+      react(),
+      tailwindcss(),
+      {
+        name: "staging-noindex",
+        transformIndexHtml(html) {
+          if (env.VITE_NOINDEX === "true") {
+            return html.replace(
+              "</head>",
+              '    <meta name="robots" content="noindex, nofollow">\n  </head>',
+            );
+          }
+          return html;
+        },
+        generateBundle() {
+          if (env.VITE_NOINDEX === "true") {
+            this.emitFile({
+              type: "asset",
+              fileName: "robots.txt",
+              source: "User-agent: *\nDisallow: /\n",
+            });
+          }
+        },
+      },
+    ],
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## 변경 사항

staging 환경에서만 검색 엔진 크롤링을 차단합니다.

- `vite.config.ts`에 인라인 플러그인 추가
  - `VITE_NOINDEX=true`일 때 `index.html`에 `<meta name="robots" content="noindex, nofollow">` 삽입
  - `VITE_NOINDEX=true`일 때 `dist/robots.txt` 생성 (`Disallow: /`)
- `frontend-staging-cd.yaml`에 `VITE_NOINDEX: 'true'` 추가

## 비고

- production CD yaml은 변경 없음 → production 빌드에 영향 없음
- `robots.txt`는 빌드 단계에서 생성되므로 누락 가능성 없음