### PR TITLE
feat: 외부인 행사 신청·설문 응답 흐름 보강 및 설문 질문 archive 모델 도입

### DIFF
--- a/backend/src/main/java/igrus/web/survey/dto/response/SurveyDetailResponse.java
+++ b/backend/src/main/java/igrus/web/survey/dto/response/SurveyDetailResponse.java
@@ -20,7 +20,7 @@ import java.util.List;
  * @param deadline       설문 마감일
  * @param createdAt      생성 시각
  * @param updatedAt      수정 시각
- * @param questions      질문 목록 (삭제되지 않은 질문만 포함)
+ * @param questions      질문 목록 (활성 질문만 포함, archived 제외)
  * @param responseCount  제출된 응답 수 (soft-delete 제외)
  */
 public record SurveyDetailResponse(
@@ -45,7 +45,7 @@ public record SurveyDetailResponse(
      */
     public static SurveyDetailResponse from(Survey survey, int responseCount) {
         List<QuestionResponse> questions = survey.getQuestions().stream()
-                .filter(q -> !q.isDeleted())
+                .filter(q -> !q.isArchived())
                 .map(QuestionResponse::from)
                 .toList();
 
@@ -101,16 +101,16 @@ public record SurveyDetailResponse(
                 scaleMax = scaleQ.getScaleMax();
             } else if (question instanceof GridSurveyQuestion gridQ) {
                 options = gridQ.getOptions().stream()
-                        .filter(o -> !o.isDeleted())
+                        .filter(o -> !o.isArchived())
                         .map(OptionResponse::from)
                         .toList();
                 rows = gridQ.getRows().stream()
-                        .filter(r -> !r.isDeleted())
+                        .filter(r -> !r.isArchived())
                         .map(RowResponse::from)
                         .toList();
             } else if (question instanceof OptionSurveyQuestion optionQ) {
                 options = optionQ.getOptions().stream()
-                        .filter(o -> !o.isDeleted())
+                        .filter(o -> !o.isArchived())
                         .map(OptionResponse::from)
                         .toList();
             }

--- a/backend/src/main/java/igrus/web/survey/question/domain/SurveyQuestion.java
+++ b/backend/src/main/java/igrus/web/survey/question/domain/SurveyQuestion.java
@@ -1,6 +1,6 @@
 package igrus.web.survey.question.domain;
 
-import igrus.web.common.domain.SoftDeletableEntity;
+import igrus.web.common.domain.BaseEntity;
 import igrus.web.survey.domain.Survey;
 import igrus.web.survey.exception.SurveyInvalidStateTransitionException;
 import jakarta.persistence.*;
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DiscriminatorFormula;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,6 +23,8 @@ import java.util.List;
  *   <li>{@link OptionSurveyQuestion} - MULTIPLE_CHOICE, CHECKBOX, DROPDOWN</li>
  *   <li>{@link GridSurveyQuestion} - MULTIPLE_CHOICE_GRID, CHECKBOX_GRID</li>
  * </ul>
+ *
+ * <p>응답이 1건이라도 존재하는 질문은 hard delete 대신 archive 처리되어, 과거 응답에서 참조 가능 상태로 유지됩니다.</p>
  */
 @Entity
 @Table(name = "survey_questions")
@@ -36,13 +39,10 @@ import java.util.List;
         @AttributeOverride(name = "createdAt", column = @Column(name = "survey_questions_created_at", nullable = false, updatable = false)),
         @AttributeOverride(name = "updatedAt", column = @Column(name = "survey_questions_updated_at", nullable = false)),
         @AttributeOverride(name = "createdBy", column = @Column(name = "survey_questions_created_by", updatable = false)),
-        @AttributeOverride(name = "updatedBy", column = @Column(name = "survey_questions_updated_by")),
-        @AttributeOverride(name = "deleted", column = @Column(name = "survey_questions_deleted", nullable = false)),
-        @AttributeOverride(name = "deletedAt", column = @Column(name = "survey_questions_deleted_at")),
-        @AttributeOverride(name = "deletedBy", column = @Column(name = "survey_questions_deleted_by"))
+        @AttributeOverride(name = "updatedBy", column = @Column(name = "survey_questions_updated_by"))
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public abstract class SurveyQuestion extends SoftDeletableEntity {
+public abstract class SurveyQuestion extends BaseEntity {
 
     /** 질문 고유 식별자 */
     @Id
@@ -83,6 +83,16 @@ public abstract class SurveyQuestion extends SoftDeletableEntity {
     @Getter
     private int displayOrder;
 
+    /** 아카이브 시각 (null이면 활성 질문, 값이 있으면 폼에서 제외됨) */
+    @Column(name = "survey_questions_archived_at")
+    @Getter
+    private Instant archivedAt;
+
+    /** 아카이브 수행자 ID */
+    @Column(name = "survey_questions_archived_by")
+    @Getter
+    private Long archivedBy;
+
     // === 서브클래스 전용 필드 (JPA 매핑용, getter는 서브클래스에서만 노출) ===
 
     /** 선형 배율 최솟값 (LINEAR_SCALE 유형에서만 사용) */
@@ -93,12 +103,12 @@ public abstract class SurveyQuestion extends SoftDeletableEntity {
     @Column(name = "survey_questions_scale_max")
     protected Integer scaleMax;
 
-    /** 선택지 목록 (MULTIPLE_CHOICE, CHECKBOX, DROPDOWN, 그리드의 열, soft delete 대상이므로 orphanRemoval 미사용) */
+    /** 선택지 목록 (MULTIPLE_CHOICE, CHECKBOX, DROPDOWN, 그리드의 열). archive 대상이므로 orphanRemoval 미사용. */
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
     @OrderBy("displayOrder ASC")
     protected List<SurveyQuestionOption> options = new ArrayList<>();
 
-    /** 그리드 행 목록 (MULTIPLE_CHOICE_GRID, CHECKBOX_GRID에서만 사용, soft delete 대상이므로 orphanRemoval 미사용) */
+    /** 그리드 행 목록 (MULTIPLE_CHOICE_GRID, CHECKBOX_GRID에서만 사용). archive 대상이므로 orphanRemoval 미사용. */
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
     @OrderBy("displayOrder ASC")
     protected List<SurveyQuestionRow> rows = new ArrayList<>();
@@ -140,5 +150,24 @@ public abstract class SurveyQuestion extends SoftDeletableEntity {
         this.description = description;
         this.required = required;
         this.displayOrder = displayOrder;
+    }
+
+    /**
+     * 질문을 아카이브 처리합니다 (응답이 존재할 때 사용).
+     * 아카이브된 질문은 폼·신규 응답 검증에서 제외되지만, 기존 응답·통계에서는 유지됩니다.
+     */
+    public void archive(Long userId) {
+        this.archivedAt = Instant.now();
+        this.archivedBy = userId;
+    }
+
+    /** 아카이브 해제 */
+    public void unarchive() {
+        this.archivedAt = null;
+        this.archivedBy = null;
+    }
+
+    public boolean isArchived() {
+        return archivedAt != null;
     }
 }

--- a/backend/src/main/java/igrus/web/survey/question/domain/SurveyQuestionOption.java
+++ b/backend/src/main/java/igrus/web/survey/question/domain/SurveyQuestionOption.java
@@ -1,15 +1,20 @@
 package igrus.web.survey.question.domain;
 
-import igrus.web.common.domain.SoftDeletableEntity;
+import igrus.web.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
+
 /**
  * 설문 질문 선택지 엔티티.
  * 객관식(MULTIPLE_CHOICE), 체크박스(CHECKBOX), 드롭다운(DROPDOWN) 질문의 보기 항목을 관리합니다.
  * 그리드 유형(MULTIPLE_CHOICE_GRID, CHECKBOX_GRID)에서는 열(Column) 역할을 합니다.
+ *
+ * <p>운영진이 옵션 텍스트를 변경하면 새 옵션이 생성되고 기존 옵션은 archive 처리됩니다.
+ * archive된 옵션은 폼 렌더링·신규 응답 검증에서는 제외되지만, 과거 응답·통계에서는 그대로 유지됩니다.</p>
  */
 @Entity
 @Table(name = "survey_question_options")
@@ -17,14 +22,11 @@ import lombok.NoArgsConstructor;
         @AttributeOverride(name = "createdAt", column = @Column(name = "survey_question_options_created_at", nullable = false, updatable = false)),
         @AttributeOverride(name = "updatedAt", column = @Column(name = "survey_question_options_updated_at", nullable = false)),
         @AttributeOverride(name = "createdBy", column = @Column(name = "survey_question_options_created_by", updatable = false)),
-        @AttributeOverride(name = "updatedBy", column = @Column(name = "survey_question_options_updated_by")),
-        @AttributeOverride(name = "deleted", column = @Column(name = "survey_question_options_deleted", nullable = false)),
-        @AttributeOverride(name = "deletedAt", column = @Column(name = "survey_question_options_deleted_at")),
-        @AttributeOverride(name = "deletedBy", column = @Column(name = "survey_question_options_deleted_by"))
+        @AttributeOverride(name = "updatedBy", column = @Column(name = "survey_question_options_updated_by"))
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SurveyQuestionOption extends SoftDeletableEntity {
+public class SurveyQuestionOption extends BaseEntity {
 
     /** 선택지 고유 식별자 */
     @Id
@@ -44,6 +46,14 @@ public class SurveyQuestionOption extends SoftDeletableEntity {
     /** 표시 순서 (오름차순 정렬) */
     @Column(name = "survey_question_options_display_order", nullable = false)
     private int displayOrder;
+
+    /** 아카이브 시각 (null이면 활성 옵션, 값이 있으면 폼에서 제외됨) */
+    @Column(name = "survey_question_options_archived_at")
+    private Instant archivedAt;
+
+    /** 아카이브 수행자 ID */
+    @Column(name = "survey_question_options_archived_by")
+    private Long archivedBy;
 
     // === Static factory method ===
 
@@ -72,5 +82,24 @@ public class SurveyQuestionOption extends SoftDeletableEntity {
     public void update(String text, int displayOrder) {
         this.text = text;
         this.displayOrder = displayOrder;
+    }
+
+    /**
+     * 선택지를 아카이브 처리합니다 (응답이 존재할 때 사용).
+     * 아카이브된 옵션은 폼·신규 응답 검증에서 제외되지만, 기존 응답과 통계에서는 유지됩니다.
+     */
+    public void archive(Long userId) {
+        this.archivedAt = Instant.now();
+        this.archivedBy = userId;
+    }
+
+    /** 아카이브 해제 */
+    public void unarchive() {
+        this.archivedAt = null;
+        this.archivedBy = null;
+    }
+
+    public boolean isArchived() {
+        return archivedAt != null;
     }
 }

--- a/backend/src/main/java/igrus/web/survey/question/domain/SurveyQuestionRow.java
+++ b/backend/src/main/java/igrus/web/survey/question/domain/SurveyQuestionRow.java
@@ -1,15 +1,19 @@
 package igrus.web.survey.question.domain;
 
-import igrus.web.common.domain.SoftDeletableEntity;
+import igrus.web.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
+
 /**
  * 설문 그리드 질문의 행 엔티티.
  * 객관식 그리드(MULTIPLE_CHOICE_GRID)와 체크박스 그리드(CHECKBOX_GRID) 유형에서만 사용됩니다.
  * 각 행은 하나의 평가 대상 항목을 나타내며, 응답자는 행마다 열(Option)에서 선택합니다.
+ *
+ * <p>운영진이 행을 수정·삭제해도 응답이 존재하면 archive 처리되어, 과거 응답·통계에서 그대로 유지됩니다.</p>
  */
 @Entity
 @Table(name = "survey_question_rows")
@@ -17,14 +21,11 @@ import lombok.NoArgsConstructor;
         @AttributeOverride(name = "createdAt", column = @Column(name = "survey_question_rows_created_at", nullable = false, updatable = false)),
         @AttributeOverride(name = "updatedAt", column = @Column(name = "survey_question_rows_updated_at", nullable = false)),
         @AttributeOverride(name = "createdBy", column = @Column(name = "survey_question_rows_created_by", updatable = false)),
-        @AttributeOverride(name = "updatedBy", column = @Column(name = "survey_question_rows_updated_by")),
-        @AttributeOverride(name = "deleted", column = @Column(name = "survey_question_rows_deleted", nullable = false)),
-        @AttributeOverride(name = "deletedAt", column = @Column(name = "survey_question_rows_deleted_at")),
-        @AttributeOverride(name = "deletedBy", column = @Column(name = "survey_question_rows_deleted_by"))
+        @AttributeOverride(name = "updatedBy", column = @Column(name = "survey_question_rows_updated_by"))
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SurveyQuestionRow extends SoftDeletableEntity {
+public class SurveyQuestionRow extends BaseEntity {
 
     /** 행 고유 식별자 */
     @Id
@@ -44,6 +45,14 @@ public class SurveyQuestionRow extends SoftDeletableEntity {
     /** 표시 순서 (오름차순 정렬) */
     @Column(name = "survey_question_rows_display_order", nullable = false)
     private int displayOrder;
+
+    /** 아카이브 시각 (null이면 활성, 값이 있으면 폼에서 제외됨) */
+    @Column(name = "survey_question_rows_archived_at")
+    private Instant archivedAt;
+
+    /** 아카이브 수행자 ID */
+    @Column(name = "survey_question_rows_archived_by")
+    private Long archivedBy;
 
     // === Static factory method ===
 
@@ -72,5 +81,23 @@ public class SurveyQuestionRow extends SoftDeletableEntity {
     public void update(String label, int displayOrder) {
         this.label = label;
         this.displayOrder = displayOrder;
+    }
+
+    /**
+     * 행을 아카이브 처리합니다 (응답이 존재할 때 사용).
+     */
+    public void archive(Long userId) {
+        this.archivedAt = Instant.now();
+        this.archivedBy = userId;
+    }
+
+    /** 아카이브 해제 */
+    public void unarchive() {
+        this.archivedAt = null;
+        this.archivedBy = null;
+    }
+
+    public boolean isArchived() {
+        return archivedAt != null;
     }
 }

--- a/backend/src/main/java/igrus/web/survey/question/repository/SurveyQuestionOptionRepository.java
+++ b/backend/src/main/java/igrus/web/survey/question/repository/SurveyQuestionOptionRepository.java
@@ -12,18 +12,18 @@ import java.util.Optional;
 public interface SurveyQuestionOptionRepository extends JpaRepository<SurveyQuestionOption, Long> {
 
     /**
-     * 삭제되지 않은 선택지를 ID로 조회합니다.
+     * 활성(아카이브되지 않은) 선택지를 ID로 조회합니다.
      *
      * @param id 선택지 ID
      * @return 선택지 Optional
      */
-    Optional<SurveyQuestionOption> findByIdAndDeletedFalse(Long id);
+    Optional<SurveyQuestionOption> findByIdAndArchivedAtIsNull(Long id);
 
     /**
-     * 특정 질문의 삭제되지 않은 선택지 목록을 표시 순서로 조회합니다.
+     * 특정 질문의 활성 선택지 목록을 표시 순서로 조회합니다.
      *
      * @param questionId 질문 ID
      * @return 선택지 목록
      */
-    List<SurveyQuestionOption> findByQuestionIdAndDeletedFalseOrderByDisplayOrderAsc(Long questionId);
+    List<SurveyQuestionOption> findByQuestionIdAndArchivedAtIsNullOrderByDisplayOrderAsc(Long questionId);
 }

--- a/backend/src/main/java/igrus/web/survey/question/repository/SurveyQuestionRepository.java
+++ b/backend/src/main/java/igrus/web/survey/question/repository/SurveyQuestionRepository.java
@@ -14,31 +14,31 @@ import java.util.Optional;
 public interface SurveyQuestionRepository extends JpaRepository<SurveyQuestion, Long> {
 
     /**
-     * 삭제되지 않은 질문을 ID로 조회합니다.
+     * 활성(아카이브되지 않은) 질문을 ID로 조회합니다.
      *
      * @param id 질문 ID
      * @return 질문 Optional
      */
-    Optional<SurveyQuestion> findByIdAndDeletedFalse(Long id);
+    Optional<SurveyQuestion> findByIdAndArchivedAtIsNull(Long id);
 
     /**
-     * 특정 설문의 삭제되지 않은 질문 목록을 표시 순서로 조회합니다.
+     * 특정 설문의 활성 질문 목록을 표시 순서로 조회합니다.
      *
      * @param surveyId 설문 ID
      * @return 질문 목록
      */
-    List<SurveyQuestion> findBySurveyIdAndDeletedFalseOrderByDisplayOrderAsc(Long surveyId);
+    List<SurveyQuestion> findBySurveyIdAndArchivedAtIsNullOrderByDisplayOrderAsc(Long surveyId);
 
     /**
-     * 특정 설문의 삭제되지 않은 질문 수를 조회합니다.
+     * 특정 설문의 활성 질문 수를 조회합니다.
      *
      * @param surveyId 설문 ID
      * @return 질문 수
      */
-    long countBySurveyIdAndDeletedFalse(Long surveyId);
+    long countBySurveyIdAndArchivedAtIsNull(Long surveyId);
 
     /**
-     * 특정 설문의 삭제되지 않은 질문을 displayOrder 오름차순으로 조회합니다 (options fetch join).
+     * 특정 설문의 활성 질문을 displayOrder 오름차순으로 조회합니다 (options fetch join).
      * N+1 방지를 위해 options를 함께 조회합니다.
      *
      * <p>rows와 동시에 fetch join하면 MultipleBagFetchException이 발생하므로,
@@ -46,27 +46,27 @@ public interface SurveyQuestionRepository extends JpaRepository<SurveyQuestion, 
      * 같은 트랜잭션 내에서 두 쿼리를 순차 호출하면 영속성 컨텍스트가 결과를 병합합니다.
      *
      * @param surveyId 설문 ID
-     * @return 삭제되지 않은 질문 목록 (displayOrder 오름차순)
+     * @return 활성 질문 목록 (displayOrder 오름차순)
      */
     @Query("SELECT DISTINCT q FROM SurveyQuestion q " +
             "LEFT JOIN FETCH q.options " +
             "WHERE q.survey.id = :surveyId " +
-            "AND q.deleted = false " +
+            "AND q.archivedAt IS NULL " +
             "ORDER BY q.displayOrder ASC")
     List<SurveyQuestion> findAllBySurveyIdWithOptions(@Param("surveyId") Long surveyId);
 
     /**
-     * 특정 설문의 삭제되지 않은 질문을 displayOrder 오름차순으로 조회합니다 (rows fetch join).
+     * 특정 설문의 활성 질문을 displayOrder 오름차순으로 조회합니다 (rows fetch join).
      * {@link #findAllBySurveyIdWithOptions(Long)}와 함께 사용하여
      * MultipleBagFetchException을 방지합니다.
      *
      * @param surveyId 설문 ID
-     * @return 삭제되지 않은 질문 목록 (displayOrder 오름차순)
+     * @return 활성 질문 목록 (displayOrder 오름차순)
      */
     @Query("SELECT DISTINCT q FROM SurveyQuestion q " +
             "LEFT JOIN FETCH q.rows " +
             "WHERE q.survey.id = :surveyId " +
-            "AND q.deleted = false " +
+            "AND q.archivedAt IS NULL " +
             "ORDER BY q.displayOrder ASC")
     List<SurveyQuestion> findAllBySurveyIdWithRows(@Param("surveyId") Long surveyId);
 }

--- a/backend/src/main/java/igrus/web/survey/question/repository/SurveyQuestionRowRepository.java
+++ b/backend/src/main/java/igrus/web/survey/question/repository/SurveyQuestionRowRepository.java
@@ -12,18 +12,18 @@ import java.util.Optional;
 public interface SurveyQuestionRowRepository extends JpaRepository<SurveyQuestionRow, Long> {
 
     /**
-     * 삭제되지 않은 행을 ID로 조회합니다.
+     * 활성(아카이브되지 않은) 행을 ID로 조회합니다.
      *
      * @param id 행 ID
      * @return 행 Optional
      */
-    Optional<SurveyQuestionRow> findByIdAndDeletedFalse(Long id);
+    Optional<SurveyQuestionRow> findByIdAndArchivedAtIsNull(Long id);
 
     /**
-     * 특정 질문의 삭제되지 않은 행 목록을 표시 순서로 조회합니다.
+     * 특정 질문의 활성 행 목록을 표시 순서로 조회합니다.
      *
      * @param questionId 질문 ID
      * @return 행 목록
      */
-    List<SurveyQuestionRow> findByQuestionIdAndDeletedFalseOrderByDisplayOrderAsc(Long questionId);
+    List<SurveyQuestionRow> findByQuestionIdAndArchivedAtIsNullOrderByDisplayOrderAsc(Long questionId);
 }

--- a/backend/src/main/java/igrus/web/survey/question/service/SurveyQuestionOptionService.java
+++ b/backend/src/main/java/igrus/web/survey/question/service/SurveyQuestionOptionService.java
@@ -12,6 +12,7 @@ import igrus.web.survey.question.exception.SurveyQuestionTypeNotSupportedExcepti
 import igrus.web.survey.question.repository.SurveyQuestionOptionRepository;
 import igrus.web.survey.question.repository.SurveyQuestionRepository;
 import igrus.web.survey.repository.SurveyRepository;
+import igrus.web.survey.response.repository.SurveyAnswerRepository;
 import igrus.web.user.domain.User;
 import igrus.web.user.exception.UserNotFoundException;
 import igrus.web.user.repository.UserRepository;
@@ -43,6 +44,7 @@ public class SurveyQuestionOptionService {
     private final SurveyRepository surveyRepository;
     private final SurveyQuestionRepository questionRepository;
     private final SurveyQuestionOptionRepository optionRepository;
+    private final SurveyAnswerRepository surveyAnswerRepository;
     private final UserRepository userRepository;
 
     /**
@@ -64,7 +66,7 @@ public class SurveyQuestionOptionService {
         surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(surveyId)
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
 
-        SurveyQuestion question = questionRepository.findByIdAndDeletedFalse(questionId)
+        SurveyQuestion question = questionRepository.findByIdAndArchivedAtIsNull(questionId)
                 .orElseThrow(() -> new SurveyQuestionNotFoundException(questionId));
         validateQuestionBelongsToSurvey(question, surveyId);
 
@@ -79,7 +81,7 @@ public class SurveyQuestionOptionService {
         options.add(option);
 
         return options.stream()
-                .filter(o -> !o.isDeleted())
+                .filter(o -> !o.isArchived())
                 .map(SurveyDetailResponse.OptionResponse::from)
                 .toList();
     }
@@ -104,24 +106,25 @@ public class SurveyQuestionOptionService {
         surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(surveyId)
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
 
-        SurveyQuestion question = questionRepository.findByIdAndDeletedFalse(questionId)
+        SurveyQuestion question = questionRepository.findByIdAndArchivedAtIsNull(questionId)
                 .orElseThrow(() -> new SurveyQuestionNotFoundException(questionId));
         validateQuestionBelongsToSurvey(question, surveyId);
 
-        SurveyQuestionOption option = optionRepository.findByIdAndDeletedFalse(optionId)
+        SurveyQuestionOption option = optionRepository.findByIdAndArchivedAtIsNull(optionId)
                 .orElseThrow(() -> new SurveyOptionNotFoundException(optionId));
         validateOptionBelongsToQuestion(option, questionId);
 
         option.update(request.text(), request.displayOrder());
 
         return getOptionsFromQuestion(question).stream()
-                .filter(o -> !o.isDeleted())
+                .filter(o -> !o.isArchived())
                 .map(SurveyDetailResponse.OptionResponse::from)
                 .toList();
     }
 
     /**
-     * 선택지를 삭제(soft delete)합니다.
+     * 선택지를 삭제합니다.
+     * 응답이 1건이라도 존재하면 archive 처리, 없으면 hard delete합니다.
      *
      * @param surveyId          설문 ID
      * @param questionId        질문 ID
@@ -137,15 +140,19 @@ public class SurveyQuestionOptionService {
         surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(surveyId)
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
 
-        SurveyQuestion question = questionRepository.findByIdAndDeletedFalse(questionId)
+        SurveyQuestion question = questionRepository.findByIdAndArchivedAtIsNull(questionId)
                 .orElseThrow(() -> new SurveyQuestionNotFoundException(questionId));
         validateQuestionBelongsToSurvey(question, surveyId);
 
-        SurveyQuestionOption option = optionRepository.findByIdAndDeletedFalse(optionId)
+        SurveyQuestionOption option = optionRepository.findByIdAndArchivedAtIsNull(optionId)
                 .orElseThrow(() -> new SurveyOptionNotFoundException(optionId));
         validateOptionBelongsToQuestion(option, questionId);
 
-        option.delete(authenticatedUser.userId());
+        if (surveyAnswerRepository.existsBySelectedOptionId(optionId)) {
+            option.archive(authenticatedUser.userId());
+        } else {
+            optionRepository.delete(option);
+        }
     }
 
     /**
@@ -166,12 +173,12 @@ public class SurveyQuestionOptionService {
         surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(surveyId)
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
 
-        SurveyQuestion question = questionRepository.findByIdAndDeletedFalse(questionId)
+        SurveyQuestion question = questionRepository.findByIdAndArchivedAtIsNull(questionId)
                 .orElseThrow(() -> new SurveyQuestionNotFoundException(questionId));
         validateQuestionBelongsToSurvey(question, surveyId);
 
         return getOptionsFromQuestion(question).stream()
-                .filter(o -> !o.isDeleted())
+                .filter(o -> !o.isArchived())
                 .map(SurveyDetailResponse.OptionResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/igrus/web/survey/question/service/SurveyQuestionRowService.java
+++ b/backend/src/main/java/igrus/web/survey/question/service/SurveyQuestionRowService.java
@@ -14,6 +14,7 @@ import igrus.web.survey.question.exception.SurveyRowNotFoundException;
 import igrus.web.survey.question.repository.SurveyQuestionRepository;
 import igrus.web.survey.question.repository.SurveyQuestionRowRepository;
 import igrus.web.survey.repository.SurveyRepository;
+import igrus.web.survey.response.repository.SurveyAnswerRepository;
 import igrus.web.user.domain.User;
 import igrus.web.user.exception.UserNotFoundException;
 import igrus.web.user.repository.UserRepository;
@@ -45,6 +46,7 @@ public class SurveyQuestionRowService {
     private final SurveyRepository surveyRepository;
     private final SurveyQuestionRepository questionRepository;
     private final SurveyQuestionRowRepository rowRepository;
+    private final SurveyAnswerRepository surveyAnswerRepository;
     private final UserRepository userRepository;
 
     /**
@@ -66,7 +68,7 @@ public class SurveyQuestionRowService {
         surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(surveyId)
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
 
-        SurveyQuestion question = questionRepository.findByIdAndDeletedFalse(questionId)
+        SurveyQuestion question = questionRepository.findByIdAndArchivedAtIsNull(questionId)
                 .orElseThrow(() -> new SurveyQuestionNotFoundException(questionId));
         validateQuestionBelongsToSurvey(question, surveyId);
 
@@ -81,7 +83,7 @@ public class SurveyQuestionRowService {
         rows.add(row);
 
         return rows.stream()
-                .filter(r -> !r.isDeleted())
+                .filter(r -> !r.isArchived())
                 .map(SurveyDetailResponse.RowResponse::from)
                 .toList();
     }
@@ -106,24 +108,25 @@ public class SurveyQuestionRowService {
         surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(surveyId)
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
 
-        SurveyQuestion question = questionRepository.findByIdAndDeletedFalse(questionId)
+        SurveyQuestion question = questionRepository.findByIdAndArchivedAtIsNull(questionId)
                 .orElseThrow(() -> new SurveyQuestionNotFoundException(questionId));
         validateQuestionBelongsToSurvey(question, surveyId);
 
-        SurveyQuestionRow row = rowRepository.findByIdAndDeletedFalse(rowId)
+        SurveyQuestionRow row = rowRepository.findByIdAndArchivedAtIsNull(rowId)
                 .orElseThrow(() -> new SurveyRowNotFoundException(rowId));
         validateRowBelongsToQuestion(row, questionId);
 
         row.update(request.label(), request.displayOrder());
 
         return getRowsFromQuestion(question).stream()
-                .filter(r -> !r.isDeleted())
+                .filter(r -> !r.isArchived())
                 .map(SurveyDetailResponse.RowResponse::from)
                 .toList();
     }
 
     /**
-     * 그리드 행을 삭제(soft delete)합니다.
+     * 그리드 행을 삭제합니다.
+     * 응답이 1건이라도 존재하면 archive 처리, 없으면 hard delete합니다.
      *
      * @param surveyId          설문 ID
      * @param questionId        질문 ID
@@ -139,15 +142,19 @@ public class SurveyQuestionRowService {
         surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(surveyId)
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
 
-        SurveyQuestion question = questionRepository.findByIdAndDeletedFalse(questionId)
+        SurveyQuestion question = questionRepository.findByIdAndArchivedAtIsNull(questionId)
                 .orElseThrow(() -> new SurveyQuestionNotFoundException(questionId));
         validateQuestionBelongsToSurvey(question, surveyId);
 
-        SurveyQuestionRow row = rowRepository.findByIdAndDeletedFalse(rowId)
+        SurveyQuestionRow row = rowRepository.findByIdAndArchivedAtIsNull(rowId)
                 .orElseThrow(() -> new SurveyRowNotFoundException(rowId));
         validateRowBelongsToQuestion(row, questionId);
 
-        row.delete(authenticatedUser.userId());
+        if (surveyAnswerRepository.existsBySelectedRowId(rowId)) {
+            row.archive(authenticatedUser.userId());
+        } else {
+            rowRepository.delete(row);
+        }
     }
 
     /**
@@ -168,12 +175,12 @@ public class SurveyQuestionRowService {
         surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(surveyId)
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
 
-        SurveyQuestion question = questionRepository.findByIdAndDeletedFalse(questionId)
+        SurveyQuestion question = questionRepository.findByIdAndArchivedAtIsNull(questionId)
                 .orElseThrow(() -> new SurveyQuestionNotFoundException(questionId));
         validateQuestionBelongsToSurvey(question, surveyId);
 
         return getRowsFromQuestion(question).stream()
-                .filter(r -> !r.isDeleted())
+                .filter(r -> !r.isArchived())
                 .map(SurveyDetailResponse.RowResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/igrus/web/survey/question/service/SurveyQuestionService.java
+++ b/backend/src/main/java/igrus/web/survey/question/service/SurveyQuestionService.java
@@ -13,6 +13,7 @@ import igrus.web.survey.question.exception.SurveyQuestionNotFoundException;
 import igrus.web.survey.question.exception.SurveyQuestionValidationException;
 import igrus.web.survey.question.repository.SurveyQuestionRepository;
 import igrus.web.survey.repository.SurveyRepository;
+import igrus.web.survey.response.repository.SurveyAnswerRepository;
 import igrus.web.user.domain.User;
 import igrus.web.user.exception.UserNotFoundException;
 import igrus.web.user.repository.UserRepository;
@@ -44,6 +45,7 @@ public class SurveyQuestionService {
 
     private final SurveyRepository surveyRepository;
     private final SurveyQuestionRepository questionRepository;
+    private final SurveyAnswerRepository surveyAnswerRepository;
     private final UserRepository userRepository;
 
     private static final int MAX_QUESTIONS = 50;
@@ -66,7 +68,7 @@ public class SurveyQuestionService {
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
         survey.updateStatusIfNeeded(Instant.now());
 
-        long count = questionRepository.countBySurveyIdAndDeletedFalse(surveyId);
+        long count = questionRepository.countBySurveyIdAndArchivedAtIsNull(surveyId);
         if (count >= MAX_QUESTIONS) {
             throw new SurveyQuestionLimitExceededException();
         }
@@ -106,7 +108,7 @@ public class SurveyQuestionService {
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
         survey.updateStatusIfNeeded(Instant.now());
 
-        SurveyQuestion question = questionRepository.findByIdAndDeletedFalse(questionId)
+        SurveyQuestion question = questionRepository.findByIdAndArchivedAtIsNull(questionId)
                 .orElseThrow(() -> new SurveyQuestionNotFoundException(questionId));
         validateQuestionBelongsToSurvey(question, surveyId);
 
@@ -122,7 +124,8 @@ public class SurveyQuestionService {
     }
 
     /**
-     * 질문을 삭제(soft delete)합니다. 모든 상태에서 삭제 가능합니다.
+     * 질문을 삭제합니다. 모든 상태에서 삭제 가능합니다.
+     * 응답이 1건이라도 존재하면 archive 처리, 없으면 hard delete합니다 (자식 옵션·행은 FK CASCADE로 함께 삭제).
      *
      * @param surveyId          설문 ID
      * @param questionId        질문 ID
@@ -136,11 +139,15 @@ public class SurveyQuestionService {
         surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(surveyId)
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
 
-        SurveyQuestion question = questionRepository.findByIdAndDeletedFalse(questionId)
+        SurveyQuestion question = questionRepository.findByIdAndArchivedAtIsNull(questionId)
                 .orElseThrow(() -> new SurveyQuestionNotFoundException(questionId));
         validateQuestionBelongsToSurvey(question, surveyId);
 
-        question.delete(authenticatedUser.userId());
+        if (surveyAnswerRepository.existsByQuestionId(questionId)) {
+            question.archive(authenticatedUser.userId());
+        } else {
+            questionRepository.delete(question);
+        }
     }
 
     /**
@@ -161,7 +168,7 @@ public class SurveyQuestionService {
                 .orElseThrow(() -> new SurveyNotFoundException(surveyId));
 
         return survey.getQuestions().stream()
-                .filter(q -> !q.isDeleted())
+                .filter(q -> !q.isArchived())
                 .map(SurveyDetailResponse.QuestionResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/igrus/web/survey/response/dto/response/SurveyResponseDetailResponse.java
+++ b/backend/src/main/java/igrus/web/survey/response/dto/response/SurveyResponseDetailResponse.java
@@ -20,7 +20,7 @@ public record SurveyResponseDetailResponse(
 
     /**
      * 설문 응답의 답변 목록을 질문별로 그룹핑하여 AnswerResponse 목록으로 변환합니다.
-     * 삭제된 질문의 답변은 제외합니다.
+     * archived 질문의 답변은 제외합니다.
      *
      * @param answers 설문 답변 목록
      * @return 질문별로 그룹핑된 AnswerResponse 목록
@@ -29,7 +29,7 @@ public record SurveyResponseDetailResponse(
         Map<Long, List<SurveyAnswer>> answersByQuestion = new LinkedHashMap<>();
 
         for (SurveyAnswer answer : answers) {
-            if (answer.getQuestion().isDeleted()) {
+            if (answer.getQuestion().isArchived()) {
                 continue;
             }
             answersByQuestion

--- a/backend/src/main/java/igrus/web/survey/response/dto/response/SurveyResponseDetailResponse.java
+++ b/backend/src/main/java/igrus/web/survey/response/dto/response/SurveyResponseDetailResponse.java
@@ -20,7 +20,7 @@ public record SurveyResponseDetailResponse(
 
     /**
      * 설문 응답의 답변 목록을 질문별로 그룹핑하여 AnswerResponse 목록으로 변환합니다.
-     * archived 질문의 답변은 제외합니다.
+     * archived 질문의 답변도 포함되어 과거 응답이 그대로 표시됩니다.
      *
      * @param answers 설문 답변 목록
      * @return 질문별로 그룹핑된 AnswerResponse 목록
@@ -29,9 +29,6 @@ public record SurveyResponseDetailResponse(
         Map<Long, List<SurveyAnswer>> answersByQuestion = new LinkedHashMap<>();
 
         for (SurveyAnswer answer : answers) {
-            if (answer.getQuestion().isArchived()) {
-                continue;
-            }
             answersByQuestion
                     .computeIfAbsent(answer.getQuestion().getId(), k -> new ArrayList<>())
                     .add(answer);

--- a/backend/src/main/java/igrus/web/survey/response/service/SurveyAnswerFactory.java
+++ b/backend/src/main/java/igrus/web/survey/response/service/SurveyAnswerFactory.java
@@ -27,7 +27,7 @@ public class SurveyAnswerFactory {
      */
     public void createAnswers(SurveyResponse response, Survey survey, List<SubmitAnswerRequest> answers) {
         Map<Long, SurveyQuestion> questionMap = survey.getQuestions().stream()
-                .filter(q -> !q.isDeleted())
+                .filter(q -> !q.isArchived())
                 .collect(Collectors.toMap(SurveyQuestion::getId, q -> q));
 
         for (SubmitAnswerRequest answerReq : answers) {
@@ -69,7 +69,7 @@ public class SurveyAnswerFactory {
 
         OptionSurveyQuestion osq = (OptionSurveyQuestion) question;
         Map<Long, SurveyQuestionOption> optionMap = osq.getOptions().stream()
-                .filter(o -> !o.isDeleted())
+                .filter(o -> !o.isArchived())
                 .collect(Collectors.toMap(SurveyQuestionOption::getId, o -> o));
 
         for (Long optionId : answerReq.selectedOptionIds()) {
@@ -91,10 +91,10 @@ public class SurveyAnswerFactory {
 
         GridSurveyQuestion gsq = (GridSurveyQuestion) question;
         Map<Long, SurveyQuestionOption> optionMap = gsq.getOptions().stream()
-                .filter(o -> !o.isDeleted())
+                .filter(o -> !o.isArchived())
                 .collect(Collectors.toMap(SurveyQuestionOption::getId, o -> o));
         Map<Long, SurveyQuestionRow> rowMap = gsq.getRows().stream()
-                .filter(r -> !r.isDeleted())
+                .filter(r -> !r.isArchived())
                 .collect(Collectors.toMap(SurveyQuestionRow::getId, r -> r));
 
         for (SubmitAnswerRequest.GridAnswerRequest ga : answerReq.gridAnswers()) {

--- a/backend/src/main/java/igrus/web/survey/response/service/SurveyAnswerValidator.java
+++ b/backend/src/main/java/igrus/web/survey/response/service/SurveyAnswerValidator.java
@@ -27,9 +27,9 @@ public class SurveyAnswerValidator {
      * @throws SurveyResponseValidationException 검증 실패 시
      */
     public void validate(Survey survey, List<SubmitAnswerRequest> answers) {
-        // 활성 질문만 추출
+        // 활성 질문만 추출 (archived 제외)
         List<SurveyQuestion> activeQuestions = survey.getQuestions().stream()
-                .filter(q -> !q.isDeleted())
+                .filter(q -> !q.isArchived())
                 .toList();
 
         Map<Long, SurveyQuestion> questionMap = activeQuestions.stream()
@@ -86,9 +86,9 @@ public class SurveyAnswerValidator {
         OptionSurveyQuestion osq = (OptionSurveyQuestion) question;
         List<Long> selectedIds = answer.selectedOptionIds();
 
-        // 유효한(삭제되지 않은) 옵션 ID 집합
+        // 유효한(활성) 옵션 ID 집합
         Set<Long> validOptionIds = osq.getOptions().stream()
-                .filter(o -> !o.isDeleted())
+                .filter(o -> !o.isArchived())
                 .map(SurveyQuestionOption::getId)
                 .collect(Collectors.toSet());
 
@@ -157,14 +157,14 @@ public class SurveyAnswerValidator {
     private void validateGridAnswer(SurveyQuestion question, SubmitAnswerRequest answer) {
         GridSurveyQuestion gsq = (GridSurveyQuestion) question;
 
-        // 유효한 옵션/행 ID 집합
+        // 유효한(활성) 옵션/행 ID 집합
         Set<Long> validOptionIds = gsq.getOptions().stream()
-                .filter(o -> !o.isDeleted())
+                .filter(o -> !o.isArchived())
                 .map(SurveyQuestionOption::getId)
                 .collect(Collectors.toSet());
 
         Set<Long> validRowIds = gsq.getRows().stream()
-                .filter(r -> !r.isDeleted())
+                .filter(r -> !r.isArchived())
                 .map(SurveyQuestionRow::getId)
                 .collect(Collectors.toSet());
 

--- a/backend/src/main/java/igrus/web/survey/response/service/SurveyResponseService.java
+++ b/backend/src/main/java/igrus/web/survey/response/service/SurveyResponseService.java
@@ -218,8 +218,8 @@ public class SurveyResponseService {
         List<ExternalSurveyResponse> externalResponses =
                 externalSurveyResponseRepository.findBySurveyId(surveyId);
         if (!externalResponses.isEmpty()) {
+            // archived 질문도 포함: 과거 외부인 응답이 archived 질문을 참조할 수 있음
             Map<Long, SurveyQuestionType> questionTypeMap = survey.getQuestions().stream()
-                    .filter(q -> !q.isArchived())
                     .collect(Collectors.toMap(q -> q.getId(), q -> q.getQuestionType()));
 
             for (ExternalSurveyResponse ext : externalResponses) {

--- a/backend/src/main/java/igrus/web/survey/response/service/SurveyResponseService.java
+++ b/backend/src/main/java/igrus/web/survey/response/service/SurveyResponseService.java
@@ -219,7 +219,7 @@ public class SurveyResponseService {
                 externalSurveyResponseRepository.findBySurveyId(surveyId);
         if (!externalResponses.isEmpty()) {
             Map<Long, SurveyQuestionType> questionTypeMap = survey.getQuestions().stream()
-                    .filter(q -> !q.isDeleted())
+                    .filter(q -> !q.isArchived())
                     .collect(Collectors.toMap(q -> q.getId(), q -> q.getQuestionType()));
 
             for (ExternalSurveyResponse ext : externalResponses) {

--- a/backend/src/main/java/igrus/web/survey/service/SurveyService.java
+++ b/backend/src/main/java/igrus/web/survey/service/SurveyService.java
@@ -376,7 +376,7 @@ public class SurveyService {
      */
     private void validatePublishPreConditions(Survey survey) {
         List<SurveyQuestion> activeQuestions = survey.getQuestions().stream()
-                .filter(q -> !q.isDeleted())
+                .filter(q -> !q.isArchived())
                 .toList();
 
         if (activeQuestions.isEmpty()) {
@@ -405,14 +405,14 @@ public class SurveyService {
                         String.format("질문 '%s'의 최솟값은 최댓값보다 작아야 합니다.", question.getTitle()));
             }
         } else if (question instanceof GridSurveyQuestion gridQ) {
-            long activeOptionCount = gridQ.getOptions().stream().filter(o -> !o.isDeleted()).count();
-            long activeRowCount = gridQ.getRows().stream().filter(r -> !r.isDeleted()).count();
+            long activeOptionCount = gridQ.getOptions().stream().filter(o -> !o.isArchived()).count();
+            long activeRowCount = gridQ.getRows().stream().filter(r -> !r.isArchived()).count();
             if (activeRowCount == 0 || activeOptionCount == 0) {
                 throw new SurveyPublishValidationException(
                         String.format("질문 '%s'에 행과 선택지가 각각 1개 이상 필요합니다.", question.getTitle()));
             }
         } else if (question instanceof OptionSurveyQuestion optionQ) {
-            long activeOptionCount = optionQ.getOptions().stream().filter(o -> !o.isDeleted()).count();
+            long activeOptionCount = optionQ.getOptions().stream().filter(o -> !o.isArchived()).count();
             if (activeOptionCount == 0) {
                 throw new SurveyPublishValidationException(
                         String.format("질문 '%s'에 선택지가 1개 이상 필요합니다.", question.getTitle()));

--- a/backend/src/main/java/igrus/web/survey/statistics/service/SurveyStatisticsService.java
+++ b/backend/src/main/java/igrus/web/survey/statistics/service/SurveyStatisticsService.java
@@ -345,19 +345,17 @@ public class SurveyStatisticsService {
             List<ExternalAnswerData> externalAnswers,
             int totalResponseCount) {
 
-        // 질문의 archived되지 않은 옵션만 조회
+        // archived 옵션도 통계에 포함 (과거 응답의 분포가 누락되지 않도록)
         if (!(question instanceof OptionSurveyQuestion optionQuestion)) {
             throw new SurveyStatisticsAggregationException(
                     "OPTION 질문에 잘못된 질문 유형: questionId=" + question.getId()
                             + ", actualType=" + question.getClass().getSimpleName());
         }
-        List<SurveyQuestionOption> activeOptions = optionQuestion.getOptions().stream()
-                .filter(option -> !option.isArchived())
-                .toList();
+        List<SurveyQuestionOption> allOptions = optionQuestion.getOptions();
 
         // 옵션별 선택 수 집계
         Map<Long, Integer> optionCounts = new HashMap<>();
-        for (SurveyQuestionOption option : activeOptions) {
+        for (SurveyQuestionOption option : allOptions) {
             optionCounts.put(option.getId(), 0);
         }
         for (SurveyAnswer answer : answers) {
@@ -379,8 +377,8 @@ public class SurveyStatisticsService {
             }
         }
 
-        // 옵션별 통계 생성
-        List<OptionStatisticsItem> optionItems = activeOptions.stream()
+        // 옵션별 통계 생성 (archived 옵션도 포함)
+        List<OptionStatisticsItem> optionItems = allOptions.stream()
                 .map(option -> new OptionStatisticsItem(
                         option.getId(),
                         option.getText(),
@@ -408,18 +406,15 @@ public class SurveyStatisticsService {
                     "GRID 질문에 잘못된 질문 유형: questionId=" + question.getId()
                             + ", actualType=" + question.getClass().getSimpleName());
         }
-        List<SurveyQuestionOption> activeOptions = gridQuestion.getOptions().stream()
-                .filter(option -> !option.isArchived())
-                .toList();
-        List<SurveyQuestionRow> activeRows = gridQuestion.getRows().stream()
-                .filter(row -> !row.isArchived())
-                .toList();
+        // archived 옵션·행도 통계에 포함
+        List<SurveyQuestionOption> allOptions = gridQuestion.getOptions();
+        List<SurveyQuestionRow> allRows = gridQuestion.getRows();
 
         // 행별 옵션별 선택 수 집계: Map<rowId, Map<optionId, count>>
         Map<Long, Map<Long, Integer>> rowOptionCounts = new HashMap<>();
-        for (SurveyQuestionRow row : activeRows) {
+        for (SurveyQuestionRow row : allRows) {
             Map<Long, Integer> optionCounts = new LinkedHashMap<>();
-            for (SurveyQuestionOption option : activeOptions) {
+            for (SurveyQuestionOption option : allOptions) {
                 optionCounts.put(option.getId(), 0);
             }
             rowOptionCounts.put(row.getId(), optionCounts);
@@ -452,11 +447,11 @@ public class SurveyStatisticsService {
             }
         }
 
-        // 행별 통계 생성
-        List<GridRowStatistics> rowStatistics = activeRows.stream()
+        // 행별 통계 생성 (archived 행/옵션도 포함)
+        List<GridRowStatistics> rowStatistics = allRows.stream()
                 .map(row -> {
                     Map<Long, Integer> optionCounts = rowOptionCounts.getOrDefault(row.getId(), Map.of());
-                    List<OptionStatisticsItem> optionItems = activeOptions.stream()
+                    List<OptionStatisticsItem> optionItems = allOptions.stream()
                             .map(option -> new OptionStatisticsItem(
                                     option.getId(),
                                     option.getText(),

--- a/backend/src/main/java/igrus/web/survey/statistics/service/SurveyStatisticsService.java
+++ b/backend/src/main/java/igrus/web/survey/statistics/service/SurveyStatisticsService.java
@@ -345,14 +345,14 @@ public class SurveyStatisticsService {
             List<ExternalAnswerData> externalAnswers,
             int totalResponseCount) {
 
-        // 질문의 삭제되지 않은 옵션만 조회
+        // 질문의 archived되지 않은 옵션만 조회
         if (!(question instanceof OptionSurveyQuestion optionQuestion)) {
             throw new SurveyStatisticsAggregationException(
                     "OPTION 질문에 잘못된 질문 유형: questionId=" + question.getId()
                             + ", actualType=" + question.getClass().getSimpleName());
         }
         List<SurveyQuestionOption> activeOptions = optionQuestion.getOptions().stream()
-                .filter(option -> !option.isDeleted())
+                .filter(option -> !option.isArchived())
                 .toList();
 
         // 옵션별 선택 수 집계
@@ -409,10 +409,10 @@ public class SurveyStatisticsService {
                             + ", actualType=" + question.getClass().getSimpleName());
         }
         List<SurveyQuestionOption> activeOptions = gridQuestion.getOptions().stream()
-                .filter(option -> !option.isDeleted())
+                .filter(option -> !option.isArchived())
                 .toList();
         List<SurveyQuestionRow> activeRows = gridQuestion.getRows().stream()
-                .filter(row -> !row.isDeleted())
+                .filter(row -> !row.isArchived())
                 .toList();
 
         // 행별 옵션별 선택 수 집계: Map<rowId, Map<optionId, count>>

--- a/backend/src/main/resources/db/migration/V54__replace_survey_question_soft_delete_with_archived_at.sql
+++ b/backend/src/main/resources/db/migration/V54__replace_survey_question_soft_delete_with_archived_at.sql
@@ -1,0 +1,81 @@
+-- survey_questions, survey_question_options, survey_question_rows 의
+-- soft-delete 컬럼을 archived_at 모델로 교체합니다.
+--
+-- 배경:
+--   기존 soft-delete는 "폼에서 빠짐"과 "삭제됨"을 동일 플래그로 표현하여
+--   과거 응답이 가리키는 옵션이 폼 조회 시 사라져 미응답으로 보이는 문제가 있었습니다.
+--   archived_at 모델로 의미를 분리하면, 응답이 있으면 archive(보존), 없으면 hard delete가 가능합니다.
+--   hard delete 시 자식 옵션·행은 FK ON DELETE CASCADE로 함께 정리됩니다.
+
+-- 1. archived_at, archived_by 컬럼 추가
+ALTER TABLE survey_questions
+    ADD COLUMN survey_questions_archived_at TIMESTAMP(6) NULL,
+    ADD COLUMN survey_questions_archived_by BIGINT NULL;
+
+ALTER TABLE survey_question_options
+    ADD COLUMN survey_question_options_archived_at TIMESTAMP(6) NULL,
+    ADD COLUMN survey_question_options_archived_by BIGINT NULL;
+
+ALTER TABLE survey_question_rows
+    ADD COLUMN survey_question_rows_archived_at TIMESTAMP(6) NULL,
+    ADD COLUMN survey_question_rows_archived_by BIGINT NULL;
+
+-- 2. 기존 soft-deleted 데이터를 archived로 이전 (timestamp 보존)
+UPDATE survey_questions
+    SET survey_questions_archived_at = COALESCE(survey_questions_deleted_at, survey_questions_updated_at),
+        survey_questions_archived_by = survey_questions_deleted_by
+    WHERE survey_questions_deleted = TRUE;
+
+UPDATE survey_question_options
+    SET survey_question_options_archived_at = COALESCE(survey_question_options_deleted_at, survey_question_options_updated_at),
+        survey_question_options_archived_by = survey_question_options_deleted_by
+    WHERE survey_question_options_deleted = TRUE;
+
+UPDATE survey_question_rows
+    SET survey_question_rows_archived_at = COALESCE(survey_question_rows_deleted_at, survey_question_rows_updated_at),
+        survey_question_rows_archived_by = survey_question_rows_deleted_by
+    WHERE survey_question_rows_deleted = TRUE;
+
+-- 3. soft-delete 컬럼 제거
+ALTER TABLE survey_questions
+    DROP COLUMN survey_questions_deleted,
+    DROP COLUMN survey_questions_deleted_at,
+    DROP COLUMN survey_questions_deleted_by;
+
+ALTER TABLE survey_question_options
+    DROP COLUMN survey_question_options_deleted,
+    DROP COLUMN survey_question_options_deleted_at,
+    DROP COLUMN survey_question_options_deleted_by;
+
+ALTER TABLE survey_question_rows
+    DROP COLUMN survey_question_rows_deleted,
+    DROP COLUMN survey_question_rows_deleted_at,
+    DROP COLUMN survey_question_rows_deleted_by;
+
+-- 4. hard-delete 시 자식 cascade를 위해 FK 재정의
+--    (응답이 없는 질문 hard-delete 시 자식 옵션·행도 함께 삭제됨)
+--    survey_answers → survey_questions/options/rows FK는 RESTRICT 유지
+--    (hard-delete는 응답 없을 때만 호출되므로 트리거되지 않음)
+ALTER TABLE survey_question_options
+    DROP FOREIGN KEY fk_survey_question_options_question;
+ALTER TABLE survey_question_options
+    ADD CONSTRAINT fk_survey_question_options_question
+    FOREIGN KEY (survey_question_options_question_id)
+    REFERENCES survey_questions(survey_questions_id)
+    ON DELETE CASCADE;
+
+ALTER TABLE survey_question_rows
+    DROP FOREIGN KEY fk_survey_question_rows_question;
+ALTER TABLE survey_question_rows
+    ADD CONSTRAINT fk_survey_question_rows_question
+    FOREIGN KEY (survey_question_rows_question_id)
+    REFERENCES survey_questions(survey_questions_id)
+    ON DELETE CASCADE;
+
+-- 5. archived 조회 성능을 위한 인덱스 (NULL이 아닌 archived_at 행 검색)
+CREATE INDEX idx_survey_questions_archived_at
+    ON survey_questions(survey_questions_archived_at);
+CREATE INDEX idx_survey_question_options_archived_at
+    ON survey_question_options(survey_question_options_archived_at);
+CREATE INDEX idx_survey_question_rows_archived_at
+    ON survey_question_rows(survey_question_rows_archived_at);

--- a/backend/src/test/java/igrus/web/event/service/EventWithSurveyServiceTest.java
+++ b/backend/src/test/java/igrus/web/event/service/EventWithSurveyServiceTest.java
@@ -114,7 +114,7 @@ class EventWithSurveyServiceTest extends ServiceIntegrationTestBase {
             assertThat(surveyRepository.findById(response.surveyId())).isPresent();
 
             // 질문 2개가 생성되었는지 확인
-            assertThat(questionRepository.findBySurveyIdAndDeletedFalseOrderByDisplayOrderAsc(response.surveyId())).hasSize(2);
+            assertThat(questionRepository.findBySurveyIdAndArchivedAtIsNullOrderByDisplayOrderAsc(response.surveyId())).hasSize(2);
         }
 
         @Test
@@ -126,7 +126,7 @@ class EventWithSurveyServiceTest extends ServiceIntegrationTestBase {
 
             // then - 옵션 lazy loading을 위해 트랜잭션 내에서 검증
             transactionTemplate.execute(status -> {
-                var questions = questionRepository.findBySurveyIdAndDeletedFalseOrderByDisplayOrderAsc(response.surveyId());
+                var questions = questionRepository.findBySurveyIdAndArchivedAtIsNullOrderByDisplayOrderAsc(response.surveyId());
                 assertThat(questions).hasSize(2);
 
                 // 첫 번째 질문: 단답형 (TEXT)

--- a/backend/src/test/java/igrus/web/survey/question/domain/SurveyQuestionTest.java
+++ b/backend/src/test/java/igrus/web/survey/question/domain/SurveyQuestionTest.java
@@ -232,7 +232,7 @@ class SurveyQuestionTest {
             Survey survey = createSurvey();
             OptionSurveyQuestion question = createMultipleChoiceQuestion(survey, 1);
             assertThat(question.getOptions()).isNotEmpty();
-            assertThat(question.getOptions().stream().filter(o -> !o.isDeleted()).count()).isGreaterThanOrEqualTo(1);
+            assertThat(question.getOptions().stream().filter(o -> !o.isArchived()).count()).isGreaterThanOrEqualTo(1);
         }
 
         @DisplayName("QST-034: MULTIPLE_CHOICE_GRID 행 0개 -> 발행 시 구성 미충족")
@@ -267,8 +267,8 @@ class SurveyQuestionTest {
             Survey survey = createSurvey();
             GridSurveyQuestion question = createGridQuestion(survey, 1);
 
-            long activeOptionCount = question.getOptions().stream().filter(o -> !o.isDeleted()).count();
-            long activeRowCount = question.getRows().stream().filter(r -> !r.isDeleted()).count();
+            long activeOptionCount = question.getOptions().stream().filter(o -> !o.isArchived()).count();
+            long activeRowCount = question.getRows().stream().filter(r -> !r.isArchived()).count();
 
             assertThat(activeOptionCount).isGreaterThanOrEqualTo(1);
             assertThat(activeRowCount).isGreaterThanOrEqualTo(1);
@@ -297,8 +297,8 @@ class SurveyQuestionTest {
             SurveyQuestionRow row = SurveyQuestionRow.create(question, "행 1", 1);
             question.addRow(row);
 
-            long activeOptionCount = question.getOptions().stream().filter(o -> !o.isDeleted()).count();
-            long activeRowCount = question.getRows().stream().filter(r -> !r.isDeleted()).count();
+            long activeOptionCount = question.getOptions().stream().filter(o -> !o.isArchived()).count();
+            long activeRowCount = question.getRows().stream().filter(r -> !r.isArchived()).count();
 
             assertThat(activeOptionCount).isEqualTo(1);
             assertThat(activeRowCount).isEqualTo(1);
@@ -510,97 +510,97 @@ class SurveyQuestionTest {
         }
     }
 
-    // ==================== 3.7 Soft Delete ====================
+    // ==================== 3.7 Archive ====================
 
     @Nested
-    @DisplayName("Soft Delete")
-    class SoftDelete {
+    @DisplayName("Archive")
+    class Archive {
 
-        @DisplayName("QST-060: 질문 soft delete 후 deleted=true")
+        @DisplayName("QST-060: 질문 archive 후 archivedAt 설정")
         @Test
-        void deleteQuestion_SoftDelete_Success() {
+        void archiveQuestion_Success() {
             Survey survey = createSurvey();
             TextSurveyQuestion question = TextSurveyQuestion.create(survey, SurveyQuestionType.SHORT_ANSWER,
                     "질문", null, false, 1);
 
-            question.delete(1L);
+            question.archive(1L);
 
-            assertThat(question.isDeleted()).isTrue();
+            assertThat(question.isArchived()).isTrue();
         }
 
-        @DisplayName("QST-062: 선택지 soft delete 후 deleted=true")
+        @DisplayName("QST-062: 선택지 archive 후 archivedAt 설정")
         @Test
-        void deleteOption_SoftDelete_Success() {
+        void archiveOption_Success() {
             Survey survey = createSurvey();
             OptionSurveyQuestion question = OptionSurveyQuestion.create(survey, SurveyQuestionType.MULTIPLE_CHOICE,
                     "질문", null, false, 1);
             SurveyQuestionOption option = SurveyQuestionOption.create(question, "선택지", 1);
 
-            option.delete(1L);
+            option.archive(1L);
 
-            assertThat(option.isDeleted()).isTrue();
+            assertThat(option.isArchived()).isTrue();
         }
 
-        @DisplayName("QST-063: 행 soft delete 후 deleted=true")
+        @DisplayName("QST-063: 행 archive 후 archivedAt 설정")
         @Test
-        void deleteRow_SoftDelete_Success() {
+        void archiveRow_Success() {
             Survey survey = createSurvey();
             GridSurveyQuestion question = GridSurveyQuestion.create(survey, SurveyQuestionType.MULTIPLE_CHOICE_GRID,
                     "질문", null, false, 1);
             SurveyQuestionRow row = SurveyQuestionRow.create(question, "행", 1);
 
-            row.delete(1L);
+            row.archive(1L);
 
-            assertThat(row.isDeleted()).isTrue();
+            assertThat(row.isArchived()).isTrue();
         }
 
-        @DisplayName("삭제된 질문은 활성 질문 필터링 시 제외됨")
+        @DisplayName("archived 질문은 활성 질문 필터링 시 제외됨")
         @Test
-        void deletedQuestion_FilteredOut() {
+        void archivedQuestion_FilteredOut() {
             Survey survey = createSurvey();
             TextSurveyQuestion active = TextSurveyQuestion.create(survey, SurveyQuestionType.SHORT_ANSWER,
                     "활성 질문", null, false, 1);
-            TextSurveyQuestion deleted = TextSurveyQuestion.create(survey, SurveyQuestionType.SHORT_ANSWER,
-                    "삭제 질문", null, false, 2);
+            TextSurveyQuestion archived = TextSurveyQuestion.create(survey, SurveyQuestionType.SHORT_ANSWER,
+                    "archive 질문", null, false, 2);
             survey.getQuestions().add(active);
-            survey.getQuestions().add(deleted);
-            deleted.delete(1L);
+            survey.getQuestions().add(archived);
+            archived.archive(1L);
 
-            long activeCount = survey.getQuestions().stream().filter(q -> !q.isDeleted()).count();
+            long activeCount = survey.getQuestions().stream().filter(q -> !q.isArchived()).count();
 
             assertThat(activeCount).isEqualTo(1);
         }
 
-        @DisplayName("삭제된 선택지는 활성 선택지 필터링 시 제외됨")
+        @DisplayName("archived 선택지는 활성 선택지 필터링 시 제외됨")
         @Test
-        void deletedOption_FilteredOut() {
+        void archivedOption_FilteredOut() {
             Survey survey = createSurvey();
             OptionSurveyQuestion question = OptionSurveyQuestion.create(survey, SurveyQuestionType.MULTIPLE_CHOICE,
                     "질문", null, false, 1);
             SurveyQuestionOption active = SurveyQuestionOption.create(question, "활성", 1);
-            SurveyQuestionOption deleted = SurveyQuestionOption.create(question, "삭제", 2);
+            SurveyQuestionOption archived = SurveyQuestionOption.create(question, "archived", 2);
             question.addOption(active);
-            question.addOption(deleted);
-            deleted.delete(1L);
+            question.addOption(archived);
+            archived.archive(1L);
 
-            long activeCount = question.getOptions().stream().filter(o -> !o.isDeleted()).count();
+            long activeCount = question.getOptions().stream().filter(o -> !o.isArchived()).count();
 
             assertThat(activeCount).isEqualTo(1);
         }
 
-        @DisplayName("삭제된 행은 활성 행 필터링 시 제외됨")
+        @DisplayName("archived 행은 활성 행 필터링 시 제외됨")
         @Test
-        void deletedRow_FilteredOut() {
+        void archivedRow_FilteredOut() {
             Survey survey = createSurvey();
             GridSurveyQuestion question = GridSurveyQuestion.create(survey, SurveyQuestionType.MULTIPLE_CHOICE_GRID,
                     "질문", null, false, 1);
             SurveyQuestionRow active = SurveyQuestionRow.create(question, "활성", 1);
-            SurveyQuestionRow deleted = SurveyQuestionRow.create(question, "삭제", 2);
+            SurveyQuestionRow archived = SurveyQuestionRow.create(question, "archived", 2);
             question.addRow(active);
-            question.addRow(deleted);
-            deleted.delete(1L);
+            question.addRow(archived);
+            archived.archive(1L);
 
-            long activeCount = question.getRows().stream().filter(r -> !r.isDeleted()).count();
+            long activeCount = question.getRows().stream().filter(r -> !r.isArchived()).count();
 
             assertThat(activeCount).isEqualTo(1);
         }

--- a/backend/src/test/java/igrus/web/survey/question/service/SurveyQuestionOptionServiceTest.java
+++ b/backend/src/test/java/igrus/web/survey/question/service/SurveyQuestionOptionServiceTest.java
@@ -12,6 +12,7 @@ import igrus.web.survey.question.exception.SurveyQuestionNotFoundException;
 import igrus.web.survey.question.repository.SurveyQuestionOptionRepository;
 import igrus.web.survey.question.repository.SurveyQuestionRepository;
 import igrus.web.survey.repository.SurveyRepository;
+import igrus.web.survey.response.repository.SurveyAnswerRepository;
 import igrus.web.user.domain.User;
 import igrus.web.user.exception.UserNotFoundException;
 import igrus.web.user.repository.UserRepository;
@@ -57,6 +58,9 @@ class SurveyQuestionOptionServiceTest {
     private SurveyQuestionOptionRepository optionRepository;
 
     @Mock
+    private SurveyAnswerRepository surveyAnswerRepository;
+
+    @Mock
     private UserRepository userRepository;
 
     @InjectMocks
@@ -97,7 +101,7 @@ class SurveyQuestionOptionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
             given(optionRepository.save(any(SurveyQuestionOption.class)))
                     .willAnswer(invocation -> invocation.getArgument(0));
@@ -136,7 +140,7 @@ class SurveyQuestionOptionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -158,7 +162,7 @@ class SurveyQuestionOptionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
 
             // when & then
@@ -216,9 +220,9 @@ class SurveyQuestionOptionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
-            given(optionRepository.findByIdAndDeletedFalse(OPTION_ID))
+            given(optionRepository.findByIdAndArchivedAtIsNull(OPTION_ID))
                     .willReturn(Optional.of(option));
 
             // when
@@ -244,9 +248,9 @@ class SurveyQuestionOptionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
-            given(optionRepository.findByIdAndDeletedFalse(OPTION_ID))
+            given(optionRepository.findByIdAndArchivedAtIsNull(OPTION_ID))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -274,9 +278,9 @@ class SurveyQuestionOptionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
-            given(optionRepository.findByIdAndDeletedFalse(OPTION_ID))
+            given(optionRepository.findByIdAndArchivedAtIsNull(OPTION_ID))
                     .willReturn(Optional.of(option));
 
             // when & then
@@ -294,7 +298,7 @@ class SurveyQuestionOptionServiceTest {
 
         @DisplayName("운영진 선택지 삭제(soft delete) 성공")
         @Test
-        void deleteOption_ByOperator_Success() {
+        void deleteOption_ByOperator_WithAnswers_Archives() {
             // given
             Survey survey = createSurveyWithId();
             SurveyQuestion question = withId(
@@ -307,16 +311,47 @@ class SurveyQuestionOptionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
-            given(optionRepository.findByIdAndDeletedFalse(OPTION_ID))
+            given(optionRepository.findByIdAndArchivedAtIsNull(OPTION_ID))
                     .willReturn(Optional.of(option));
+            given(surveyAnswerRepository.existsBySelectedOptionId(OPTION_ID)).willReturn(true);
 
             // when
             optionService.deleteOption(DEFAULT_SURVEY_ID, QUESTION_ID, OPTION_ID, operatorAuth);
 
             // then
-            assertThat(option.isDeleted()).isTrue();
+            assertThat(option.isArchived()).isTrue();
+            verify(optionRepository, org.mockito.Mockito.never()).delete(option);
+        }
+
+        @DisplayName("응답이 없는 선택지 삭제 시 hard delete")
+        @Test
+        void deleteOption_ByOperator_NoAnswers_HardDeletes() {
+            // given
+            Survey survey = createSurveyWithId();
+            SurveyQuestion question = withId(
+                    OptionSurveyQuestion.create(survey, SurveyQuestionType.MULTIPLE_CHOICE, "질문", null, false, 1),
+                    QUESTION_ID);
+            SurveyQuestionOption option = withId(
+                    SurveyQuestionOption.create(question, "선택지", 1),
+                    OPTION_ID);
+
+            given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
+            given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
+                    .willReturn(Optional.of(survey));
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
+                    .willReturn(Optional.of(question));
+            given(optionRepository.findByIdAndArchivedAtIsNull(OPTION_ID))
+                    .willReturn(Optional.of(option));
+            given(surveyAnswerRepository.existsBySelectedOptionId(OPTION_ID)).willReturn(false);
+
+            // when
+            optionService.deleteOption(DEFAULT_SURVEY_ID, QUESTION_ID, OPTION_ID, operatorAuth);
+
+            // then
+            verify(optionRepository).delete(option);
+            assertThat(option.isArchived()).isFalse();
         }
 
         @DisplayName("존재하지 않는 선택지 삭제 시 SurveyOptionNotFoundException")
@@ -331,9 +366,9 @@ class SurveyQuestionOptionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
-            given(optionRepository.findByIdAndDeletedFalse(OPTION_ID))
+            given(optionRepository.findByIdAndArchivedAtIsNull(OPTION_ID))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -377,7 +412,7 @@ class SurveyQuestionOptionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
 
             // when
@@ -388,24 +423,24 @@ class SurveyQuestionOptionServiceTest {
             assertThat(result).hasSize(2);
         }
 
-        @DisplayName("삭제된 선택지는 목록에서 제외")
+        @DisplayName("archived 선택지는 목록에서 제외")
         @Test
-        void getOptionList_ExcludesDeletedOptions() {
+        void getOptionList_ExcludesArchivedOptions() {
             // given
             Survey survey = createSurveyWithId();
             OptionSurveyQuestion question = withId(
                     OptionSurveyQuestion.create(survey, SurveyQuestionType.MULTIPLE_CHOICE, "질문", null, false, 1),
                     QUESTION_ID);
             SurveyQuestionOption activeOption = SurveyQuestionOption.create(question, "활성 선택지", 1);
-            SurveyQuestionOption deletedOption = SurveyQuestionOption.create(question, "삭제된 선택지", 2);
-            deletedOption.delete(operatorAuth.userId());
+            SurveyQuestionOption archivedOption = SurveyQuestionOption.create(question, "archived 선택지", 2);
+            archivedOption.archive(operatorAuth.userId());
             question.addOption(activeOption);
-            question.addOption(deletedOption);
+            question.addOption(archivedOption);
 
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
 
             // when

--- a/backend/src/test/java/igrus/web/survey/question/service/SurveyQuestionRowServiceTest.java
+++ b/backend/src/test/java/igrus/web/survey/question/service/SurveyQuestionRowServiceTest.java
@@ -12,6 +12,7 @@ import igrus.web.survey.question.exception.SurveyRowNotFoundException;
 import igrus.web.survey.question.repository.SurveyQuestionRepository;
 import igrus.web.survey.question.repository.SurveyQuestionRowRepository;
 import igrus.web.survey.repository.SurveyRepository;
+import igrus.web.survey.response.repository.SurveyAnswerRepository;
 import igrus.web.user.domain.User;
 import igrus.web.user.exception.UserNotFoundException;
 import igrus.web.user.repository.UserRepository;
@@ -57,6 +58,9 @@ class SurveyQuestionRowServiceTest {
     private SurveyQuestionRowRepository rowRepository;
 
     @Mock
+    private SurveyAnswerRepository surveyAnswerRepository;
+
+    @Mock
     private UserRepository userRepository;
 
     @InjectMocks
@@ -97,7 +101,7 @@ class SurveyQuestionRowServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
             given(rowRepository.save(any(SurveyQuestionRow.class)))
                     .willAnswer(invocation -> invocation.getArgument(0));
@@ -136,7 +140,7 @@ class SurveyQuestionRowServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -158,7 +162,7 @@ class SurveyQuestionRowServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
 
             // when & then
@@ -216,9 +220,9 @@ class SurveyQuestionRowServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
-            given(rowRepository.findByIdAndDeletedFalse(ROW_ID))
+            given(rowRepository.findByIdAndArchivedAtIsNull(ROW_ID))
                     .willReturn(Optional.of(row));
 
             // when
@@ -244,9 +248,9 @@ class SurveyQuestionRowServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
-            given(rowRepository.findByIdAndDeletedFalse(ROW_ID))
+            given(rowRepository.findByIdAndArchivedAtIsNull(ROW_ID))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -274,9 +278,9 @@ class SurveyQuestionRowServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
-            given(rowRepository.findByIdAndDeletedFalse(ROW_ID))
+            given(rowRepository.findByIdAndArchivedAtIsNull(ROW_ID))
                     .willReturn(Optional.of(row));
 
             // when & then
@@ -294,7 +298,7 @@ class SurveyQuestionRowServiceTest {
 
         @DisplayName("운영진 행 삭제(soft delete) 성공")
         @Test
-        void deleteRow_ByOperator_Success() {
+        void deleteRow_ByOperator_WithAnswers_Archives() {
             // given
             Survey survey = createSurveyWithId();
             SurveyQuestion question = withId(
@@ -307,16 +311,47 @@ class SurveyQuestionRowServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
-            given(rowRepository.findByIdAndDeletedFalse(ROW_ID))
+            given(rowRepository.findByIdAndArchivedAtIsNull(ROW_ID))
                     .willReturn(Optional.of(row));
+            given(surveyAnswerRepository.existsBySelectedRowId(ROW_ID)).willReturn(true);
 
             // when
             rowService.deleteRow(DEFAULT_SURVEY_ID, QUESTION_ID, ROW_ID, operatorAuth);
 
             // then
-            assertThat(row.isDeleted()).isTrue();
+            assertThat(row.isArchived()).isTrue();
+            verify(rowRepository, org.mockito.Mockito.never()).delete(row);
+        }
+
+        @DisplayName("응답이 없는 행 삭제 시 hard delete")
+        @Test
+        void deleteRow_ByOperator_NoAnswers_HardDeletes() {
+            // given
+            Survey survey = createSurveyWithId();
+            SurveyQuestion question = withId(
+                    GridSurveyQuestion.create(survey, SurveyQuestionType.MULTIPLE_CHOICE_GRID, "그리드 질문", null, false, 1),
+                    QUESTION_ID);
+            SurveyQuestionRow row = withId(
+                    SurveyQuestionRow.create(question, "행", 1),
+                    ROW_ID);
+
+            given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
+            given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
+                    .willReturn(Optional.of(survey));
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
+                    .willReturn(Optional.of(question));
+            given(rowRepository.findByIdAndArchivedAtIsNull(ROW_ID))
+                    .willReturn(Optional.of(row));
+            given(surveyAnswerRepository.existsBySelectedRowId(ROW_ID)).willReturn(false);
+
+            // when
+            rowService.deleteRow(DEFAULT_SURVEY_ID, QUESTION_ID, ROW_ID, operatorAuth);
+
+            // then
+            verify(rowRepository).delete(row);
+            assertThat(row.isArchived()).isFalse();
         }
 
         @DisplayName("존재하지 않는 행 삭제 시 SurveyRowNotFoundException")
@@ -331,9 +366,9 @@ class SurveyQuestionRowServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
-            given(rowRepository.findByIdAndDeletedFalse(ROW_ID))
+            given(rowRepository.findByIdAndArchivedAtIsNull(ROW_ID))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -375,7 +410,7 @@ class SurveyQuestionRowServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
 
             // when
@@ -386,24 +421,24 @@ class SurveyQuestionRowServiceTest {
             assertThat(result).hasSize(2);
         }
 
-        @DisplayName("삭제된 행은 목록에서 제외")
+        @DisplayName("archived 행은 목록에서 제외")
         @Test
-        void getRowList_ExcludesDeletedRows() {
+        void getRowList_ExcludesArchivedRows() {
             // given
             Survey survey = createSurveyWithId();
             GridSurveyQuestion question = withId(
                     GridSurveyQuestion.create(survey, SurveyQuestionType.MULTIPLE_CHOICE_GRID, "그리드 질문", null, false, 1),
                     QUESTION_ID);
             SurveyQuestionRow activeRow = SurveyQuestionRow.create(question, "활성 행", 1);
-            SurveyQuestionRow deletedRow = SurveyQuestionRow.create(question, "삭제된 행", 2);
-            deletedRow.delete(operatorAuth.userId());
+            SurveyQuestionRow archivedRow = SurveyQuestionRow.create(question, "archived 행", 2);
+            archivedRow.archive(operatorAuth.userId());
             question.addRow(activeRow);
-            question.addRow(deletedRow);
+            question.addRow(archivedRow);
 
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
 
             // when

--- a/backend/src/test/java/igrus/web/survey/question/service/SurveyQuestionServiceTest.java
+++ b/backend/src/test/java/igrus/web/survey/question/service/SurveyQuestionServiceTest.java
@@ -12,6 +12,7 @@ import igrus.web.survey.question.exception.SurveyQuestionLimitExceededException;
 import igrus.web.survey.question.exception.SurveyQuestionNotFoundException;
 import igrus.web.survey.question.repository.SurveyQuestionRepository;
 import igrus.web.survey.repository.SurveyRepository;
+import igrus.web.survey.response.repository.SurveyAnswerRepository;
 import igrus.web.user.domain.User;
 import igrus.web.user.exception.UserNotFoundException;
 import igrus.web.user.repository.UserRepository;
@@ -54,6 +55,9 @@ class SurveyQuestionServiceTest {
     private SurveyQuestionRepository questionRepository;
 
     @Mock
+    private SurveyAnswerRepository surveyAnswerRepository;
+
+    @Mock
     private UserRepository userRepository;
 
     @InjectMocks
@@ -91,7 +95,7 @@ class SurveyQuestionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.countBySurveyIdAndDeletedFalse(DEFAULT_SURVEY_ID)).willReturn(0L);
+            given(questionRepository.countBySurveyIdAndArchivedAtIsNull(DEFAULT_SURVEY_ID)).willReturn(0L);
             given(questionRepository.save(any(SurveyQuestion.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
@@ -113,7 +117,7 @@ class SurveyQuestionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.countBySurveyIdAndDeletedFalse(DEFAULT_SURVEY_ID)).willReturn(50L);
+            given(questionRepository.countBySurveyIdAndArchivedAtIsNull(DEFAULT_SURVEY_ID)).willReturn(50L);
 
             // when & then
             assertThatThrownBy(() -> surveyQuestionService.createQuestion(DEFAULT_SURVEY_ID, request, operatorAuth))
@@ -187,7 +191,7 @@ class SurveyQuestionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
 
             // when
@@ -211,7 +215,7 @@ class SurveyQuestionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -236,7 +240,7 @@ class SurveyQuestionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
 
             // when & then
@@ -267,9 +271,9 @@ class SurveyQuestionServiceTest {
     @DisplayName("질문 삭제")
     class DeleteQuestion {
 
-        @DisplayName("SVC-QST-008: 운영진 질문 삭제(soft delete) 성공")
+        @DisplayName("SVC-QST-008: 응답이 있는 질문 삭제 시 archive 처리")
         @Test
-        void deleteQuestion_ByOperator_Success() {
+        void deleteQuestion_WithAnswers_Archives() {
             // given
             Survey survey = createSurveyWithId();
             SurveyQuestion question = withId(
@@ -279,14 +283,40 @@ class SurveyQuestionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
+            given(surveyAnswerRepository.existsByQuestionId(QUESTION_ID)).willReturn(true);
 
             // when
             surveyQuestionService.deleteQuestion(DEFAULT_SURVEY_ID, QUESTION_ID, operatorAuth);
 
             // then
-            assertThat(question.isDeleted()).isTrue();
+            assertThat(question.isArchived()).isTrue();
+            verify(questionRepository, org.mockito.Mockito.never()).delete(question);
+        }
+
+        @DisplayName("응답이 없는 질문 삭제 시 hard delete")
+        @Test
+        void deleteQuestion_NoAnswers_HardDeletes() {
+            // given
+            Survey survey = createSurveyWithId();
+            SurveyQuestion question = withId(
+                    TextSurveyQuestion.create(survey, SurveyQuestionType.SHORT_ANSWER, "질문", null, false, 1),
+                    QUESTION_ID);
+
+            given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
+            given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
+                    .willReturn(Optional.of(survey));
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
+                    .willReturn(Optional.of(question));
+            given(surveyAnswerRepository.existsByQuestionId(QUESTION_ID)).willReturn(false);
+
+            // when
+            surveyQuestionService.deleteQuestion(DEFAULT_SURVEY_ID, QUESTION_ID, operatorAuth);
+
+            // then
+            verify(questionRepository).delete(question);
+            assertThat(question.isArchived()).isFalse();
         }
 
         @DisplayName("SVC-QST-009: 질문이 다른 설문에 소속된 경우 SurveyAccessDeniedException")
@@ -302,7 +332,7 @@ class SurveyQuestionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.of(question));
 
             // when & then
@@ -319,7 +349,7 @@ class SurveyQuestionServiceTest {
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))
                     .willReturn(Optional.of(survey));
-            given(questionRepository.findByIdAndDeletedFalse(QUESTION_ID))
+            given(questionRepository.findByIdAndArchivedAtIsNull(QUESTION_ID))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -369,18 +399,18 @@ class SurveyQuestionServiceTest {
             assertThat(result).hasSize(2);
         }
 
-        @DisplayName("SVC-QST-011: 삭제된 질문은 목록에서 제외")
+        @DisplayName("SVC-QST-011: archived 질문은 목록에서 제외")
         @Test
-        void getQuestionList_ExcludesDeletedQuestions() {
+        void getQuestionList_ExcludesArchivedQuestions() {
             // given
             Survey survey = createSurveyWithId();
             SurveyQuestion activeQuestion = TextSurveyQuestion.create(survey, SurveyQuestionType.SHORT_ANSWER,
                     "활성 질문", null, false, 1);
-            SurveyQuestion deletedQuestion = TextSurveyQuestion.create(survey, SurveyQuestionType.SHORT_ANSWER,
-                    "삭제된 질문", null, false, 2);
-            deletedQuestion.delete(operatorAuth.userId());
+            SurveyQuestion archivedQuestion = TextSurveyQuestion.create(survey, SurveyQuestionType.SHORT_ANSWER,
+                    "archived 질문", null, false, 2);
+            archivedQuestion.archive(operatorAuth.userId());
             survey.getQuestions().add(activeQuestion);
-            survey.getQuestions().add(deletedQuestion);
+            survey.getQuestions().add(archivedQuestion);
 
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))

--- a/backend/src/test/java/igrus/web/survey/response/service/SurveyAnswerFactoryTest.java
+++ b/backend/src/test/java/igrus/web/survey/response/service/SurveyAnswerFactoryTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
@@ -196,13 +195,13 @@ class SurveyAnswerFactoryTest {
     }
 
     @Test
-    @DisplayName("삭제된 질문은 questionMap에서 제외됨")
-    void createAnswers_DeletedQuestion_Excluded() {
+    @DisplayName("archived 질문은 questionMap에서 제외됨")
+    void createAnswers_ArchivedQuestion_Excluded() {
         // given
         Survey survey = withId(createPublishedAndOpenSurvey(), DEFAULT_SURVEY_ID);
         TextSurveyQuestion question = createShortAnswerQuestion(survey, 1);
         withId(question, 100L);
-        ReflectionTestUtils.setField(question, "deleted", true); // 질문 삭제
+        question.archive(1L); // 질문 archive
         survey.getQuestions().add(question);
 
         SurveyResponse response = createMockResponse(survey);

--- a/backend/src/test/java/igrus/web/survey/response/service/SurveyAnswerValidatorTest.java
+++ b/backend/src/test/java/igrus/web/survey/response/service/SurveyAnswerValidatorTest.java
@@ -212,15 +212,15 @@ class SurveyAnswerValidatorTest {
                     .isInstanceOf(SurveyResponseValidationException.class);
         }
 
-        @DisplayName("삭제된 옵션 ID로 응답 시 실패")
+        @DisplayName("archived 옵션 ID로 응답 시 실패")
         @Test
-        void validate_DeletedOptionId_ThrowsException() {
+        void validate_ArchivedOptionId_ThrowsException() {
             Survey survey = withId(createPublishedAndOpenSurvey(), DEFAULT_SURVEY_ID);
             OptionSurveyQuestion question = createMultipleChoiceQuestion(survey, 1);
             withId(question, 100L);
             SurveyQuestionOption option = question.getOptions().getFirst();
             withId(option, 200L);
-            option.delete(1L); // soft delete
+            option.archive(1L);
             survey.getQuestions().add(question);
 
             List<SubmitAnswerRequest> answers = List.of(
@@ -516,33 +516,33 @@ class SurveyAnswerValidatorTest {
                     .doesNotThrowAnyException();
         }
 
-        @DisplayName("삭제된 질문에 대한 응답은 무시됨")
+        @DisplayName("archived 질문에 대한 응답은 무시됨")
         @Test
-        void validate_DeletedQuestionIgnored_Success() {
+        void validate_ArchivedQuestionIgnored_Success() {
             Survey survey = withId(createPublishedAndOpenSurvey(), DEFAULT_SURVEY_ID);
             TextSurveyQuestion question = createShortAnswerQuestion(survey, 1);
             makeRequired(question);
             withId(question, 100L);
-            question.delete(1L); // soft delete
+            question.archive(1L);
             survey.getQuestions().add(question);
 
-            // 삭제된 질문이므로 필수여도 응답 안 해도 됨
+            // archived 질문이므로 필수여도 응답 안 해도 됨
             List<SubmitAnswerRequest> answers = List.of();
 
             assertThatCode(() -> validator.validate(survey, answers))
                     .doesNotThrowAnyException();
         }
 
-        @DisplayName("삭제된 질문 ID로 답변 제출 시 실패 (R2-007)")
+        @DisplayName("archived 질문 ID로 답변 제출 시 실패 (R2-007)")
         @Test
-        void validate_DeletedQuestionIdAnswer_ThrowsException() {
+        void validate_ArchivedQuestionIdAnswer_ThrowsException() {
             Survey survey = withId(createPublishedAndOpenSurvey(), DEFAULT_SURVEY_ID);
             TextSurveyQuestion question = createShortAnswerQuestion(survey, 1);
             withId(question, 100L);
-            question.delete(1L); // soft delete
+            question.archive(1L);
             survey.getQuestions().add(question);
 
-            // 삭제된 질문의 ID로 답변을 제출하면 활성 질문 맵에 없으므로 "존재하지 않는 질문" 예외
+            // archived 질문의 ID로 답변을 제출하면 활성 질문 맵에 없으므로 "존재하지 않는 질문" 예외
             List<SubmitAnswerRequest> answers = List.of(
                     new SubmitAnswerRequest(100L, "답변", null, null, null)
             );

--- a/backend/src/test/java/igrus/web/survey/response/service/SurveyResponseServiceTest.java
+++ b/backend/src/test/java/igrus/web/survey/response/service/SurveyResponseServiceTest.java
@@ -605,9 +605,9 @@ class SurveyResponseServiceTest {
                     .isInstanceOf(SurveyResponseNotFoundException.class);
         }
 
-        @DisplayName("archived된 질문의 답변은 제외")
+        @DisplayName("archived 질문의 답변도 응답 조회에 포함됨")
         @Test
-        void getMyResponse_ExcludesArchivedQuestionAnswers() {
+        void getMyResponse_IncludesArchivedQuestionAnswers() {
             // given
             Survey survey = withId(createPublishedAndOpenSurvey(), DEFAULT_SURVEY_ID);
             TextSurveyQuestion question1 = createShortAnswerQuestion(survey, 1);
@@ -632,9 +632,10 @@ class SurveyResponseServiceTest {
             SurveyResponseDetailResponse result = surveyResponseService.getMyResponse(
                     DEFAULT_SURVEY_ID, memberAuth);
 
-            // then
-            assertThat(result.answers()).hasSize(1);
-            assertThat(result.answers().getFirst().questionId()).isEqualTo(100L);
+            // then: archived 질문의 답변도 historical record로 포함됨
+            assertThat(result.answers()).hasSize(2);
+            assertThat(result.answers()).extracting(SurveyResponseDetailResponse.AnswerResponse::questionId)
+                    .containsExactlyInAnyOrder(100L, 101L);
         }
 
         @DisplayName("accessLevel이 OPERATOR로 변경된 설문에서 MEMBER가 본인 응답 조회 가능")

--- a/backend/src/test/java/igrus/web/survey/response/service/SurveyResponseServiceTest.java
+++ b/backend/src/test/java/igrus/web/survey/response/service/SurveyResponseServiceTest.java
@@ -605,9 +605,9 @@ class SurveyResponseServiceTest {
                     .isInstanceOf(SurveyResponseNotFoundException.class);
         }
 
-        @DisplayName("삭제된 질문의 답변은 제외")
+        @DisplayName("archived된 질문의 답변은 제외")
         @Test
-        void getMyResponse_ExcludesDeletedQuestionAnswers() {
+        void getMyResponse_ExcludesArchivedQuestionAnswers() {
             // given
             Survey survey = withId(createPublishedAndOpenSurvey(), DEFAULT_SURVEY_ID);
             TextSurveyQuestion question1 = createShortAnswerQuestion(survey, 1);
@@ -616,7 +616,7 @@ class SurveyResponseServiceTest {
 
             TextSurveyQuestion question2 = createShortAnswerQuestion(survey, 2);
             withId(question2, 101L);
-            question2.delete(1L); // soft delete
+            question2.archive(1L);
             survey.getQuestions().add(question2);
 
             SurveyResponse existingResponse = SurveyResponse.create(survey, memberUser);

--- a/backend/src/test/java/igrus/web/survey/service/SurveyServiceTest.java
+++ b/backend/src/test/java/igrus/web/survey/service/SurveyServiceTest.java
@@ -376,14 +376,14 @@ class SurveyServiceTest {
                     .isInstanceOf(SurveyPublishValidationException.class);
         }
 
-        @DisplayName("모든 질문이 soft delete된 경우 SurveyPublishValidationException")
+        @DisplayName("모든 질문이 archived인 경우 SurveyPublishValidationException")
         @Test
-        void publishSurvey_AllQuestionsDeleted_ThrowsValidationException() {
+        void publishSurvey_AllQuestionsArchived_ThrowsValidationException() {
             // given
             Survey survey = createSurveyWithId();
-            SurveyQuestion deletedQuestion = createShortAnswerQuestion(survey, 1);
-            deletedQuestion.delete(operatorAuth.userId());
-            survey.getQuestions().add(deletedQuestion);
+            SurveyQuestion archivedQuestion = createShortAnswerQuestion(survey, 1);
+            archivedQuestion.archive(operatorAuth.userId());
+            survey.getQuestions().add(archivedQuestion);
 
             given(userRepository.findById(operatorAuth.userId())).willReturn(Optional.of(operatorUser));
             given(surveyRepository.findByIdAndDeletedFalseAndTrashedAtIsNull(DEFAULT_SURVEY_ID))

--- a/backend/src/test/java/igrus/web/survey/statistics/service/SurveyStatisticsServiceTest.java
+++ b/backend/src/test/java/igrus/web/survey/statistics/service/SurveyStatisticsServiceTest.java
@@ -1565,20 +1565,20 @@ class SurveyStatisticsServiceTest {
         }
     }
 
-    // ==================== TASK-018: soft delete 통계 (TC-STAT-080~083) ====================
+    // ==================== TASK-018: archived 통계 (TC-STAT-080~083) ====================
 
     @Nested
-    @DisplayName("soft delete된 질문/선택지/행은 통계에서 제외")
-    class SoftDeleteStatistics {
+    @DisplayName("archived된 질문/선택지/행은 통계에서 제외")
+    class ArchivedStatistics {
 
-        @DisplayName("TC-STAT-080: soft delete된 질문은 통계에서 제외")
+        @DisplayName("TC-STAT-080: archived된 질문은 통계에서 제외")
         @Test
-        void getSurveyStatistics_WithSoftDeletedQuestion_ExcludedFromStatistics() {
-            // given - 삭제된 질문과 활성 질문 각 1개
-            OptionSurveyQuestion deletedQuestion = OptionSurveyQuestion.create(
-                    survey, SurveyQuestionType.MULTIPLE_CHOICE, "삭제된 질문", null, true, 0);
-            withId(deletedQuestion, 100L);
-            deletedQuestion.delete(DEFAULT_OPERATOR_ID);
+        void getSurveyStatistics_WithArchivedQuestion_ExcludedFromStatistics() {
+            // given - archived 질문과 활성 질문 각 1개
+            OptionSurveyQuestion archivedQuestion = OptionSurveyQuestion.create(
+                    survey, SurveyQuestionType.MULTIPLE_CHOICE, "archived 질문", null, true, 0);
+            withId(archivedQuestion, 100L);
+            archivedQuestion.archive(DEFAULT_OPERATOR_ID);
 
             OptionSurveyQuestion activeQuestion = OptionSurveyQuestion.create(
                     survey, SurveyQuestionType.MULTIPLE_CHOICE, "활성 질문", null, true, 1);
@@ -1593,21 +1593,21 @@ class SurveyStatisticsServiceTest {
                     OptionSurveyAnswer.create(r1, activeQuestion, optA)
             );
 
-            // 삭제된 질문은 Repository에서 이미 필터링되므로 activeQuestion만 전달
+            // archived된 질문은 Repository에서 이미 필터링되므로 activeQuestion만 전달
             setUpMocks(List.of(r1), List.of(activeQuestion), answers);
 
             // when
             SurveyStatisticsResponse result = surveyStatisticsService.getSurveyStatistics(
                     DEFAULT_SURVEY_ID, DEFAULT_OPERATOR_ID);
 
-            // then - 삭제된 질문은 통계에 포함되지 않음
+            // then - archived 질문은 통계에 포함되지 않음
             assertThat(result.questionStatistics()).hasSize(1);
             assertThat(result.questionStatistics().getFirst().questionId()).isEqualTo(200L);
         }
 
-        @DisplayName("TC-STAT-081: soft delete된 선택지는 통계에서 제외")
+        @DisplayName("TC-STAT-081: archived된 선택지는 통계에서 제외")
         @Test
-        void getSurveyStatistics_WithSoftDeletedOption_ExcludedFromStatistics() {
+        void getSurveyStatistics_WithArchivedOption_ExcludedFromStatistics() {
             // given
             OptionSurveyQuestion mcQuestion = OptionSurveyQuestion.create(
                     survey, SurveyQuestionType.MULTIPLE_CHOICE, "MC 질문", null, true, 0);
@@ -1619,7 +1619,7 @@ class SurveyStatisticsServiceTest {
             withId(optB, 102L);
             SurveyQuestionOption optC = SurveyQuestionOption.create(mcQuestion, "C", 3);
             withId(optC, 103L);
-            optC.delete(DEFAULT_OPERATOR_ID); // C를 soft delete
+            optC.archive(DEFAULT_OPERATOR_ID); // C를 archive
 
             mcQuestion.addOption(optA);
             mcQuestion.addOption(optB);
@@ -1647,7 +1647,7 @@ class SurveyStatisticsServiceTest {
             SurveyStatisticsResponse result = surveyStatisticsService.getSurveyStatistics(
                     DEFAULT_SURVEY_ID, DEFAULT_OPERATOR_ID);
 
-            // then - 삭제된 선택지 C는 통계에 포함되지 않음
+            // then - archived된 선택지 C는 통계에 포함되지 않음
             QuestionStatisticsResponse mcStat = result.questionStatistics().getFirst();
             List<OptionStatisticsItem> options = mcStat.optionStatistics().options();
             assertThat(options).hasSize(2); // A, B만
@@ -1663,9 +1663,9 @@ class SurveyStatisticsServiceTest {
             assertThat(itemB.count()).isEqualTo(1);
         }
 
-        @DisplayName("TC-STAT-082: soft delete된 행은 통계에서 제외")
+        @DisplayName("TC-STAT-082: archived된 행은 통계에서 제외")
         @Test
-        void getSurveyStatistics_WithSoftDeletedRow_ExcludedFromStatistics() {
+        void getSurveyStatistics_WithArchivedRow_ExcludedFromStatistics() {
             // given
             GridSurveyQuestion gridQuestion = GridSurveyQuestion.create(
                     survey, SurveyQuestionType.MULTIPLE_CHOICE_GRID, "GRID 질문", null, true, 0);
@@ -1680,7 +1680,7 @@ class SurveyStatisticsServiceTest {
 
             SurveyQuestionRow rowMath = SurveyQuestionRow.create(gridQuestion, "수학", 1);
             withId(rowMath, 201L);
-            rowMath.delete(DEFAULT_OPERATOR_ID); // 수학 행 soft delete
+            rowMath.archive(DEFAULT_OPERATOR_ID); // 수학 행 archive
 
             SurveyQuestionRow rowEnglish = SurveyQuestionRow.create(gridQuestion, "영어", 2);
             withId(rowEnglish, 202L);
@@ -1704,7 +1704,7 @@ class SurveyStatisticsServiceTest {
             SurveyStatisticsResponse result = surveyStatisticsService.getSurveyStatistics(
                     DEFAULT_SURVEY_ID, DEFAULT_OPERATOR_ID);
 
-            // then - 삭제된 수학 행은 통계에서 제외
+            // then - archived된 수학 행은 통계에서 제외
             GridQuestionStatistics gridStats = result.questionStatistics().getFirst().gridStatistics();
             assertThat(gridStats).isNotNull();
             assertThat(gridStats.rows()).hasSize(1); // 영어만
@@ -1721,9 +1721,9 @@ class SurveyStatisticsServiceTest {
             assertThat(engDissatisfied.count()).isZero();
         }
 
-        @DisplayName("TC-STAT-083: 모든 선택지가 soft delete된 질문 - 빈 옵션 목록")
+        @DisplayName("TC-STAT-083: 모든 선택지가 archived된 질문 - 빈 옵션 목록")
         @Test
-        void getSurveyStatistics_WithAllOptionsSoftDeleted_ReturnsEmptyOptionList() {
+        void getSurveyStatistics_WithAllOptionsArchived_ReturnsEmptyOptionList() {
             // given
             OptionSurveyQuestion mcQuestion = OptionSurveyQuestion.create(
                     survey, SurveyQuestionType.MULTIPLE_CHOICE, "MC 질문", null, true, 0);
@@ -1731,10 +1731,10 @@ class SurveyStatisticsServiceTest {
 
             SurveyQuestionOption optA = SurveyQuestionOption.create(mcQuestion, "A", 1);
             withId(optA, 101L);
-            optA.delete(DEFAULT_OPERATOR_ID);
+            optA.archive(DEFAULT_OPERATOR_ID);
             SurveyQuestionOption optB = SurveyQuestionOption.create(mcQuestion, "B", 2);
             withId(optB, 102L);
-            optB.delete(DEFAULT_OPERATOR_ID);
+            optB.archive(DEFAULT_OPERATOR_ID);
 
             mcQuestion.addOption(optA);
             mcQuestion.addOption(optB);
@@ -1753,7 +1753,7 @@ class SurveyStatisticsServiceTest {
             SurveyStatisticsResponse result = surveyStatisticsService.getSurveyStatistics(
                     DEFAULT_SURVEY_ID, DEFAULT_OPERATOR_ID);
 
-            // then - 모든 선택지가 삭제되었으므로 빈 옵션 목록
+            // then - 모든 선택지가 archived되었으므로 빈 옵션 목록
             QuestionStatisticsResponse mcStat = result.questionStatistics().getFirst();
             assertThat(mcStat.optionStatistics().options()).isEmpty();
         }

--- a/backend/src/test/java/igrus/web/survey/statistics/service/SurveyStatisticsServiceTest.java
+++ b/backend/src/test/java/igrus/web/survey/statistics/service/SurveyStatisticsServiceTest.java
@@ -1565,13 +1565,13 @@ class SurveyStatisticsServiceTest {
         }
     }
 
-    // ==================== TASK-018: archived 통계 (TC-STAT-080~083) ====================
+    // ==================== TASK-018: archive 통계 (TC-STAT-080~083) ====================
 
     @Nested
-    @DisplayName("archived된 질문/선택지/행은 통계에서 제외")
-    class ArchivedStatistics {
+    @DisplayName("archive된 옵션/행은 통계에 포함되고, archive된 질문은 통계에서 제외")
+    class ArchiveStatistics {
 
-        @DisplayName("TC-STAT-080: archived된 질문은 통계에서 제외")
+        @DisplayName("TC-STAT-080: archived 질문은 통계에서 제외 (질문 단위 archive는 폼·통계 모두에서 제외)")
         @Test
         void getSurveyStatistics_WithArchivedQuestion_ExcludedFromStatistics() {
             // given - archived 질문과 활성 질문 각 1개
@@ -1593,7 +1593,7 @@ class SurveyStatisticsServiceTest {
                     OptionSurveyAnswer.create(r1, activeQuestion, optA)
             );
 
-            // archived된 질문은 Repository에서 이미 필터링되므로 activeQuestion만 전달
+            // archived 질문은 Repository.findAllBySurveyIdWithOptions에서 필터링되므로 activeQuestion만 전달
             setUpMocks(List.of(r1), List.of(activeQuestion), answers);
 
             // when
@@ -1605,9 +1605,9 @@ class SurveyStatisticsServiceTest {
             assertThat(result.questionStatistics().getFirst().questionId()).isEqualTo(200L);
         }
 
-        @DisplayName("TC-STAT-081: archived된 선택지는 통계에서 제외")
+        @DisplayName("TC-STAT-081: archived 선택지도 통계에 포함됨 (과거 응답의 분포 보존)")
         @Test
-        void getSurveyStatistics_WithArchivedOption_ExcludedFromStatistics() {
+        void getSurveyStatistics_WithArchivedOption_IncludedInStatistics() {
             // given
             OptionSurveyQuestion mcQuestion = OptionSurveyQuestion.create(
                     survey, SurveyQuestionType.MULTIPLE_CHOICE, "MC 질문", null, true, 0);
@@ -1647,25 +1647,28 @@ class SurveyStatisticsServiceTest {
             SurveyStatisticsResponse result = surveyStatisticsService.getSurveyStatistics(
                     DEFAULT_SURVEY_ID, DEFAULT_OPERATOR_ID);
 
-            // then - archived된 선택지 C는 통계에 포함되지 않음
+            // then - archived 선택지 C도 통계에 포함됨 (count=2)
             QuestionStatisticsResponse mcStat = result.questionStatistics().getFirst();
             List<OptionStatisticsItem> options = mcStat.optionStatistics().options();
-            assertThat(options).hasSize(2); // A, B만
+            assertThat(options).hasSize(3); // A, B, C 모두 포함
 
             assertThat(options.stream().map(OptionStatisticsItem::optionId).toList())
-                    .containsExactly(101L, 102L);
+                    .containsExactly(101L, 102L, 103L);
 
             OptionStatisticsItem itemA = options.stream()
                     .filter(o -> o.optionId().equals(101L)).findFirst().orElseThrow();
             OptionStatisticsItem itemB = options.stream()
                     .filter(o -> o.optionId().equals(102L)).findFirst().orElseThrow();
+            OptionStatisticsItem itemC = options.stream()
+                    .filter(o -> o.optionId().equals(103L)).findFirst().orElseThrow();
             assertThat(itemA.count()).isEqualTo(3);
             assertThat(itemB.count()).isEqualTo(1);
+            assertThat(itemC.count()).isEqualTo(2);
         }
 
-        @DisplayName("TC-STAT-082: archived된 행은 통계에서 제외")
+        @DisplayName("TC-STAT-082: archived 행도 통계에 포함됨 (과거 응답의 분포 보존)")
         @Test
-        void getSurveyStatistics_WithArchivedRow_ExcludedFromStatistics() {
+        void getSurveyStatistics_WithArchivedRow_IncludedInStatistics() {
             // given
             GridSurveyQuestion gridQuestion = GridSurveyQuestion.create(
                     survey, SurveyQuestionType.MULTIPLE_CHOICE_GRID, "GRID 질문", null, true, 0);
@@ -1704,15 +1707,24 @@ class SurveyStatisticsServiceTest {
             SurveyStatisticsResponse result = surveyStatisticsService.getSurveyStatistics(
                     DEFAULT_SURVEY_ID, DEFAULT_OPERATOR_ID);
 
-            // then - archived된 수학 행은 통계에서 제외
+            // then - archived 수학 행도 통계에 포함됨
             GridQuestionStatistics gridStats = result.questionStatistics().getFirst().gridStatistics();
             assertThat(gridStats).isNotNull();
-            assertThat(gridStats.rows()).hasSize(1); // 영어만
+            assertThat(gridStats.rows()).hasSize(2); // 수학, 영어 모두
 
-            GridRowStatistics englishRow = gridStats.rows().getFirst();
-            assertThat(englishRow.rowId()).isEqualTo(202L);
+            GridRowStatistics mathRow = gridStats.rows().stream()
+                    .filter(r -> r.rowId().equals(201L)).findFirst().orElseThrow();
+            assertThat(mathRow.rowLabel()).isEqualTo("수학");
+            OptionStatisticsItem mathSatisfied = mathRow.options().stream()
+                    .filter(o -> o.optionId().equals(101L)).findFirst().orElseThrow();
+            OptionStatisticsItem mathDissatisfied = mathRow.options().stream()
+                    .filter(o -> o.optionId().equals(102L)).findFirst().orElseThrow();
+            assertThat(mathSatisfied.count()).isEqualTo(1);
+            assertThat(mathDissatisfied.count()).isEqualTo(1);
+
+            GridRowStatistics englishRow = gridStats.rows().stream()
+                    .filter(r -> r.rowId().equals(202L)).findFirst().orElseThrow();
             assertThat(englishRow.rowLabel()).isEqualTo("영어");
-
             OptionStatisticsItem engSatisfied = englishRow.options().stream()
                     .filter(o -> o.optionId().equals(101L)).findFirst().orElseThrow();
             OptionStatisticsItem engDissatisfied = englishRow.options().stream()
@@ -1721,9 +1733,9 @@ class SurveyStatisticsServiceTest {
             assertThat(engDissatisfied.count()).isZero();
         }
 
-        @DisplayName("TC-STAT-083: 모든 선택지가 archived된 질문 - 빈 옵션 목록")
+        @DisplayName("TC-STAT-083: 모든 선택지가 archived여도 과거 응답 분포는 통계에 포함됨")
         @Test
-        void getSurveyStatistics_WithAllOptionsArchived_ReturnsEmptyOptionList() {
+        void getSurveyStatistics_WithAllOptionsArchived_IncludesAllInStatistics() {
             // given
             OptionSurveyQuestion mcQuestion = OptionSurveyQuestion.create(
                     survey, SurveyQuestionType.MULTIPLE_CHOICE, "MC 질문", null, true, 0);
@@ -1753,9 +1765,12 @@ class SurveyStatisticsServiceTest {
             SurveyStatisticsResponse result = surveyStatisticsService.getSurveyStatistics(
                     DEFAULT_SURVEY_ID, DEFAULT_OPERATOR_ID);
 
-            // then - 모든 선택지가 archived되었으므로 빈 옵션 목록
+            // then - archived 선택지도 분포에 그대로 노출됨
             QuestionStatisticsResponse mcStat = result.questionStatistics().getFirst();
-            assertThat(mcStat.optionStatistics().options()).isEmpty();
+            List<OptionStatisticsItem> options = mcStat.optionStatistics().options();
+            assertThat(options).hasSize(2);
+            assertThat(options.stream().map(OptionStatisticsItem::count).toList())
+                    .containsExactly(1, 1);
         }
     }
 


### PR DESCRIPTION
## Summary
- 외부인 행사 신청 흐름 관련 백엔드/프론트엔드 보강 (관리자 응답 목록·신청자 페이지에 외부인 응답 표시, 행사 이미지 공개 다운로드 URL)
- Event 엔티티 연관관계 정리 및 이미지 공개 다운로드 API 추가
- 설문 질문/옵션/행의 soft-delete를 `archived_at` 기반 archive 모델로 교체하고, archived 데이터를 통계와 응답 상세에서 historical record로 노출

## 주요 변경
### 외부인 응답·행사 이미지 (75efd876, aeff3f5e, 20441efb, eb67138c)
- Event 엔티티 연관관계 변경 및 이미지 공개 다운로드 API 추가
- 행사 이미지 공개 다운로드 URL OpenAPI 스펙 + 프론트엔드 연동
- 관리자 설문 응답 API가 외부인(`ExternalSurveyResponse`) 응답을 포함
- 신청자 관리 페이지에서 외부인 설문 응답 표시

### 설문 질문 archive 모델 (099e233c, 9d599fbd)
기존 soft-delete는 "폼에서 빠짐"과 "삭제됨"을 동일 플래그로 표현해 과거 응답이 가리키는 옵션이 폼 조회 시 사라지는 문제가 있었음. archive 모델로 의미를 분리해 응답이 1건이라도 있으면 archive(보존), 없으면 hard delete하도록 변경.

- `V54` 마이그레이션: `deleted_*` 컬럼 → `archived_at/by` 컬럼, FK `ON DELETE CASCADE` 재정의
- `SurveyQuestion/Option/Row`: `SoftDeletableEntity` → `BaseEntity`, `archive/unarchive/isArchived` 도입
- 리포지토리·서비스: `findByIdAndArchivedAtIsNull` 등으로 변경, `SurveyAnswerRepository.existsBy*`로 archive vs hard-delete 분기
- 통계: archived 옵션·행도 분포에 포함하여 과거 응답 보존
- 응답 상세: archived 질문에 대한 답변도 historical record로 노출

## 알려진 한계
- 외부인 응답이 답변을 JSON으로 저장하는 구조라 `existsByQuestionId/SelectedOptionId/SelectedRowId`로는 외부 응답의 참조를 검출하지 못함. 회원 응답 없이 외부 응답만 존재하는 질문/옵션/행은 hard delete될 수 있어 후속 PR에서 보강 예정.

## Test plan
- [ ] 백엔드 survey/event 관련 단위·통합 테스트 통과 (`./gradlew test`)
- [ ] V54 마이그레이션이 기존 soft-deleted 데이터를 archived로 보존하는지 확인
- [ ] archive된 옵션이 폼에서는 사라지고 통계·응답 상세에는 유지되는지 수동 확인
- [ ] 관리자 응답 목록·신청자 관리 페이지에서 외부인 응답이 정상 표시되는지 수동 확인
- [ ] 행사 이미지 공개 다운로드 URL이 비인증 사용자에게도 동작하는지 확인