### PR TITLE
fix(survey): 옵션 수정 시 과거 응답이 미응답으로 표시되는 문제

### DIFF
--- a/backend/src/main/java/igrus/web/survey/response/controller/AdminSurveyResponseController.java
+++ b/backend/src/main/java/igrus/web/survey/response/controller/AdminSurveyResponseController.java
@@ -5,6 +5,8 @@ import igrus.web.generated.api.AdminSurveyResponseApi;
 import igrus.web.generated.model.ApiAdminSurveyResponseListItem;
 import igrus.web.generated.model.ApiAnswerResponse;
 import igrus.web.generated.model.ApiGridAnswerResponse;
+import igrus.web.generated.model.ApiSelectedOptionResponse;
+import igrus.web.generated.model.ApiSelectedRowResponse;
 import igrus.web.security.auth.common.domain.AuthenticatedUser;
 import igrus.web.survey.response.dto.response.AdminSurveyResponseListItem;
 import igrus.web.survey.response.dto.response.SurveyResponseDetailResponse;
@@ -57,14 +59,32 @@ public class AdminSurveyResponseController implements AdminSurveyResponseApi {
                 .questionId(a.questionId())
                 .questionType(ApiAnswerResponse.QuestionTypeEnum.fromValue(a.questionType().name()))
                 .textValue(a.textValue())
-                .selectedOptionIds(a.selectedOptionIds())
+                .selectedOptions(mapSelectedOptions(a.selectedOptions()))
                 .numericValue(a.numericValue())
                 .gridAnswers(a.gridAnswers() != null
                         ? a.gridAnswers().stream()
                         .map(g -> new ApiGridAnswerResponse()
-                                .rowId(g.rowId())
-                                .selectedOptionIds(g.selectedOptionIds()))
+                                .row(mapSelectedRow(g.row()))
+                                .selectedOptions(mapSelectedOptions(g.selectedOptions())))
                         .toList()
                         : null);
+    }
+
+    private List<ApiSelectedOptionResponse> mapSelectedOptions(
+            List<SurveyResponseDetailResponse.SelectedOptionResponse> selectedOptions) {
+        if (selectedOptions == null) {
+            return null;
+        }
+        return selectedOptions.stream()
+                .map(o -> new ApiSelectedOptionResponse().id(o.id()).text(o.text()))
+                .toList();
+    }
+
+    private ApiSelectedRowResponse mapSelectedRow(
+            SurveyResponseDetailResponse.SelectedRowResponse row) {
+        if (row == null) {
+            return null;
+        }
+        return new ApiSelectedRowResponse().id(row.id()).label(row.label());
     }
 }

--- a/backend/src/main/java/igrus/web/survey/response/controller/SurveyAnonymousResponseController.java
+++ b/backend/src/main/java/igrus/web/survey/response/controller/SurveyAnonymousResponseController.java
@@ -3,6 +3,8 @@ package igrus.web.survey.response.controller;
 import igrus.web.generated.api.SurveyAnonymousResponseApi;
 import igrus.web.generated.model.ApiAnswerResponse;
 import igrus.web.generated.model.ApiGridAnswerResponse;
+import igrus.web.generated.model.ApiSelectedOptionResponse;
+import igrus.web.generated.model.ApiSelectedRowResponse;
 import igrus.web.generated.model.ApiSubmitSurveyResponseRequest;
 import igrus.web.generated.model.ApiSurveyResponseDetailResponse;
 import igrus.web.survey.response.dto.request.SubmitAnswerRequest;
@@ -68,16 +70,34 @@ public class SurveyAnonymousResponseController implements SurveyAnonymousRespons
                                 .questionType(ApiAnswerResponse.QuestionTypeEnum.fromValue(
                                         a.questionType().name()))
                                 .textValue(a.textValue())
-                                .selectedOptionIds(a.selectedOptionIds())
+                                .selectedOptions(mapSelectedOptions(a.selectedOptions()))
                                 .numericValue(a.numericValue())
                                 .gridAnswers(a.gridAnswers() != null
                                         ? a.gridAnswers().stream()
                                         .map(g -> new ApiGridAnswerResponse()
-                                                .rowId(g.rowId())
-                                                .selectedOptionIds(g.selectedOptionIds()))
+                                                .row(mapSelectedRow(g.row()))
+                                                .selectedOptions(mapSelectedOptions(g.selectedOptions())))
                                         .toList()
                                         : null))
                         .toList())
                 .createdAt(result.createdAt());
+    }
+
+    private List<ApiSelectedOptionResponse> mapSelectedOptions(
+            List<SurveyResponseDetailResponse.SelectedOptionResponse> selectedOptions) {
+        if (selectedOptions == null) {
+            return null;
+        }
+        return selectedOptions.stream()
+                .map(o -> new ApiSelectedOptionResponse().id(o.id()).text(o.text()))
+                .toList();
+    }
+
+    private ApiSelectedRowResponse mapSelectedRow(
+            SurveyResponseDetailResponse.SelectedRowResponse row) {
+        if (row == null) {
+            return null;
+        }
+        return new ApiSelectedRowResponse().id(row.id()).label(row.label());
     }
 }

--- a/backend/src/main/java/igrus/web/survey/response/controller/SurveyResponseController.java
+++ b/backend/src/main/java/igrus/web/survey/response/controller/SurveyResponseController.java
@@ -4,6 +4,8 @@ import igrus.web.common.util.SecurityUtils;
 import igrus.web.generated.api.SurveyResponseApi;
 import igrus.web.generated.model.ApiAnswerResponse;
 import igrus.web.generated.model.ApiGridAnswerResponse;
+import igrus.web.generated.model.ApiSelectedOptionResponse;
+import igrus.web.generated.model.ApiSelectedRowResponse;
 import igrus.web.generated.model.ApiSubmitSurveyResponseRequest;
 import igrus.web.generated.model.ApiSurveyResponseDetailResponse;
 import igrus.web.security.auth.common.domain.AuthenticatedUser;
@@ -104,16 +106,34 @@ public class SurveyResponseController implements SurveyResponseApi {
                                 .questionType(ApiAnswerResponse.QuestionTypeEnum.fromValue(
                                         a.questionType().name()))
                                 .textValue(a.textValue())
-                                .selectedOptionIds(a.selectedOptionIds())
+                                .selectedOptions(mapSelectedOptions(a.selectedOptions()))
                                 .numericValue(a.numericValue())
                                 .gridAnswers(a.gridAnswers() != null
                                         ? a.gridAnswers().stream()
                                         .map(g -> new ApiGridAnswerResponse()
-                                                .rowId(g.rowId())
-                                                .selectedOptionIds(g.selectedOptionIds()))
+                                                .row(mapSelectedRow(g.row()))
+                                                .selectedOptions(mapSelectedOptions(g.selectedOptions())))
                                         .toList()
                                         : null))
                         .toList())
                 .createdAt(result.createdAt());
+    }
+
+    private List<ApiSelectedOptionResponse> mapSelectedOptions(
+            List<SurveyResponseDetailResponse.SelectedOptionResponse> selectedOptions) {
+        if (selectedOptions == null) {
+            return null;
+        }
+        return selectedOptions.stream()
+                .map(o -> new ApiSelectedOptionResponse().id(o.id()).text(o.text()))
+                .toList();
+    }
+
+    private ApiSelectedRowResponse mapSelectedRow(
+            SurveyResponseDetailResponse.SelectedRowResponse row) {
+        if (row == null) {
+            return null;
+        }
+        return new ApiSelectedRowResponse().id(row.id()).label(row.label());
     }
 }

--- a/backend/src/main/java/igrus/web/survey/response/dto/response/SurveyResponseDetailResponse.java
+++ b/backend/src/main/java/igrus/web/survey/response/dto/response/SurveyResponseDetailResponse.java
@@ -1,6 +1,8 @@
 package igrus.web.survey.response.dto.response;
 
 import igrus.web.survey.question.domain.SurveyQuestion;
+import igrus.web.survey.question.domain.SurveyQuestionOption;
+import igrus.web.survey.question.domain.SurveyQuestionRow;
 import igrus.web.survey.question.domain.SurveyQuestionType;
 import igrus.web.survey.response.domain.*;
 
@@ -51,11 +53,31 @@ public record SurveyResponseDetailResponse(
         );
     }
 
+    /**
+     * 응답에 선택된 옵션 (id + 표시용 text).
+     * archived 옵션도 응답 보존을 위해 텍스트가 채워집니다.
+     */
+    public record SelectedOptionResponse(Long id, String text) {
+        public static SelectedOptionResponse from(SurveyQuestionOption option) {
+            return new SelectedOptionResponse(option.getId(), option.getText());
+        }
+    }
+
+    /**
+     * 응답에 선택된 그리드 행 (id + 표시용 label).
+     * archived 행도 응답 보존을 위해 라벨이 채워집니다.
+     */
+    public record SelectedRowResponse(Long id, String label) {
+        public static SelectedRowResponse from(SurveyQuestionRow row) {
+            return new SelectedRowResponse(row.getId(), row.getLabel());
+        }
+    }
+
     public record AnswerResponse(
             Long questionId,
             SurveyQuestionType questionType,
             String textValue,
-            List<Long> selectedOptionIds,
+            List<SelectedOptionResponse> selectedOptions,
             Integer numericValue,
             List<GridAnswerResponse> gridAnswers
     ) {
@@ -76,7 +98,7 @@ public record SurveyResponseDetailResponse(
                         question.getId(), type,
                         null,
                         answers.stream()
-                                .map(a -> ((OptionSurveyAnswer) a).getSelectedOption().getId())
+                                .map(a -> SelectedOptionResponse.from(((OptionSurveyAnswer) a).getSelectedOption()))
                                 .toList(),
                         null, null
                 );
@@ -87,16 +109,22 @@ public record SurveyResponseDetailResponse(
                         null
                 );
                 case "GRID" -> {
-                    // 행별로 그룹핑
-                    Map<Long, List<Long>> optionsByRow = new LinkedHashMap<>();
+                    // 행별로 그룹핑 (행 ID 기준, 행 엔티티는 첫 답변에서 추출)
+                    Map<Long, SurveyQuestionRow> rowsById = new LinkedHashMap<>();
+                    Map<Long, List<SelectedOptionResponse>> optionsByRow = new LinkedHashMap<>();
                     for (SurveyAnswer a : answers) {
                         GridSurveyAnswer ga = (GridSurveyAnswer) a;
+                        SurveyQuestionRow row = ga.getSelectedRow();
+                        rowsById.putIfAbsent(row.getId(), row);
                         optionsByRow
-                                .computeIfAbsent(ga.getSelectedRow().getId(), k -> new ArrayList<>())
-                                .add(ga.getSelectedOption().getId());
+                                .computeIfAbsent(row.getId(), k -> new ArrayList<>())
+                                .add(SelectedOptionResponse.from(ga.getSelectedOption()));
                     }
                     List<GridAnswerResponse> gridAnswers = optionsByRow.entrySet().stream()
-                            .map(e -> new GridAnswerResponse(e.getKey(), e.getValue()))
+                            .map(e -> new GridAnswerResponse(
+                                    SelectedRowResponse.from(rowsById.get(e.getKey())),
+                                    e.getValue()
+                            ))
                             .toList();
                     yield new AnswerResponse(
                             question.getId(), type,
@@ -109,8 +137,8 @@ public record SurveyResponseDetailResponse(
     }
 
     public record GridAnswerResponse(
-            Long rowId,
-            List<Long> selectedOptionIds
+            SelectedRowResponse row,
+            List<SelectedOptionResponse> selectedOptions
     ) {
     }
 }

--- a/backend/src/main/java/igrus/web/survey/response/service/SurveyResponseService.java
+++ b/backend/src/main/java/igrus/web/survey/response/service/SurveyResponseService.java
@@ -15,6 +15,10 @@ import igrus.web.survey.domain.Survey;
 import igrus.web.survey.domain.SurveyAccessLevel;
 import igrus.web.survey.domain.SurveyResponseStatus;
 import igrus.web.survey.exception.SurveyNotFoundException;
+import igrus.web.survey.question.domain.GridSurveyQuestion;
+import igrus.web.survey.question.domain.OptionSurveyQuestion;
+import igrus.web.survey.question.domain.SurveyQuestionOption;
+import igrus.web.survey.question.domain.SurveyQuestionRow;
 import igrus.web.survey.question.domain.SurveyQuestionType;
 import igrus.web.survey.repository.SurveyRepository;
 import igrus.web.survey.response.domain.SurveyResponse;
@@ -218,9 +222,11 @@ public class SurveyResponseService {
         List<ExternalSurveyResponse> externalResponses =
                 externalSurveyResponseRepository.findBySurveyId(surveyId);
         if (!externalResponses.isEmpty()) {
-            // archived 질문도 포함: 과거 외부인 응답이 archived 질문을 참조할 수 있음
+            // archived 질문/옵션/행도 포함: 과거 외부인 응답이 archived 데이터를 참조할 수 있음
             Map<Long, SurveyQuestionType> questionTypeMap = survey.getQuestions().stream()
                     .collect(Collectors.toMap(q -> q.getId(), q -> q.getQuestionType()));
+            Map<Long, SurveyQuestionOption> optionMap = buildOptionMap(survey);
+            Map<Long, SurveyQuestionRow> rowMap = buildRowMap(survey);
 
             for (ExternalSurveyResponse ext : externalResponses) {
                 try {
@@ -229,7 +235,7 @@ public class SurveyResponseService {
                     List<SurveyResponseDetailResponse.AnswerResponse> answerResponses =
                             parsedAnswers.stream()
                                     .filter(a -> questionTypeMap.containsKey(a.questionId()))
-                                    .map(a -> convertExternalAnswer(a, questionTypeMap))
+                                    .map(a -> convertExternalAnswer(a, questionTypeMap, optionMap, rowMap))
                                     .toList();
                     result.add(AdminSurveyResponseListItem.fromExternal(ext, answerResponses));
                 } catch (JsonProcessingException e) {
@@ -332,25 +338,94 @@ public class SurveyResponseService {
     /**
      * 외부인 설문 응답의 개별 답변을 AnswerResponse로 변환합니다.
      * SubmitAnswerRequest에는 questionType이 없으므로 questionTypeMap에서 조회합니다.
+     * optionMap/rowMap은 archived 항목을 포함하여 과거 응답의 텍스트를 복원합니다.
+     * hard-delete된 항목은 map에 없으므로 fallback 텍스트를 사용합니다.
      */
     private SurveyResponseDetailResponse.AnswerResponse convertExternalAnswer(
-            SubmitAnswerRequest answer, Map<Long, SurveyQuestionType> questionTypeMap) {
+            SubmitAnswerRequest answer,
+            Map<Long, SurveyQuestionType> questionTypeMap,
+            Map<Long, SurveyQuestionOption> optionMap,
+            Map<Long, SurveyQuestionRow> rowMap) {
         SurveyQuestionType questionType = questionTypeMap.get(answer.questionId());
+
+        List<SurveyResponseDetailResponse.SelectedOptionResponse> selectedOptions = null;
+        if (answer.selectedOptionIds() != null && !answer.selectedOptionIds().isEmpty()) {
+            selectedOptions = answer.selectedOptionIds().stream()
+                    .map(id -> resolveOption(id, optionMap))
+                    .toList();
+        }
+
         List<SurveyResponseDetailResponse.GridAnswerResponse> gridAnswers = null;
         if (answer.gridAnswers() != null && !answer.gridAnswers().isEmpty()) {
             gridAnswers = answer.gridAnswers().stream()
                     .map(g -> new SurveyResponseDetailResponse.GridAnswerResponse(
-                            g.rowId(), g.selectedOptionIds()))
+                            resolveRow(g.rowId(), rowMap),
+                            g.selectedOptionIds().stream()
+                                    .map(id -> resolveOption(id, optionMap))
+                                    .toList()))
                     .toList();
         }
+
         return new SurveyResponseDetailResponse.AnswerResponse(
                 answer.questionId(),
                 questionType,
                 answer.textValue(),
-                answer.selectedOptionIds(),
+                selectedOptions,
                 answer.numericValue(),
                 gridAnswers
         );
+    }
+
+    private SurveyResponseDetailResponse.SelectedOptionResponse resolveOption(
+            Long optionId, Map<Long, SurveyQuestionOption> optionMap) {
+        SurveyQuestionOption option = optionMap.get(optionId);
+        if (option == null) {
+            return new SurveyResponseDetailResponse.SelectedOptionResponse(optionId, "(삭제된 선택지)");
+        }
+        return SurveyResponseDetailResponse.SelectedOptionResponse.from(option);
+    }
+
+    private SurveyResponseDetailResponse.SelectedRowResponse resolveRow(
+            Long rowId, Map<Long, SurveyQuestionRow> rowMap) {
+        SurveyQuestionRow row = rowMap.get(rowId);
+        if (row == null) {
+            return new SurveyResponseDetailResponse.SelectedRowResponse(rowId, "(삭제된 행)");
+        }
+        return SurveyResponseDetailResponse.SelectedRowResponse.from(row);
+    }
+
+    /**
+     * 설문의 모든 옵션(archived 포함)을 ID로 인덱싱한 맵을 빌드합니다.
+     */
+    private Map<Long, SurveyQuestionOption> buildOptionMap(Survey survey) {
+        Map<Long, SurveyQuestionOption> map = new java.util.HashMap<>();
+        for (var question : survey.getQuestions()) {
+            if (question instanceof OptionSurveyQuestion optionQ) {
+                for (SurveyQuestionOption option : optionQ.getOptions()) {
+                    map.put(option.getId(), option);
+                }
+            } else if (question instanceof GridSurveyQuestion gridQ) {
+                for (SurveyQuestionOption option : gridQ.getOptions()) {
+                    map.put(option.getId(), option);
+                }
+            }
+        }
+        return map;
+    }
+
+    /**
+     * 설문의 모든 그리드 행(archived 포함)을 ID로 인덱싱한 맵을 빌드합니다.
+     */
+    private Map<Long, SurveyQuestionRow> buildRowMap(Survey survey) {
+        Map<Long, SurveyQuestionRow> map = new java.util.HashMap<>();
+        for (var question : survey.getQuestions()) {
+            if (question instanceof GridSurveyQuestion gridQ) {
+                for (SurveyQuestionRow row : gridQ.getRows()) {
+                    map.put(row.getId(), row);
+                }
+            }
+        }
+        return map;
     }
 
     private static final String SURVEY_RESPONSE_UNIQUE_CONSTRAINT = "uk_survey_responses_survey_user";

--- a/backend/src/test/java/igrus/web/survey/response/service/SurveyResponseServiceTest.java
+++ b/backend/src/test/java/igrus/web/survey/response/service/SurveyResponseServiceTest.java
@@ -605,6 +605,40 @@ class SurveyResponseServiceTest {
                     .isInstanceOf(SurveyResponseNotFoundException.class);
         }
 
+        @DisplayName("archived 옵션의 텍스트도 응답에 포함되어 표시됨")
+        @Test
+        void getMyResponse_IncludesArchivedOptionText() {
+            // given: 옵션 1개를 archive 처리한 상태에서 그 옵션을 선택한 응답이 존재
+            Survey survey = withId(createPublishedAndOpenSurvey(), DEFAULT_SURVEY_ID);
+            OptionSurveyQuestion question = OptionSurveyQuestion.create(
+                    survey, SurveyQuestionType.MULTIPLE_CHOICE, "질문", null, false, 1);
+            withId(question, 100L);
+            SurveyQuestionOption archivedOption = SurveyQuestionOption.create(question, "원래 옵션", 1);
+            withId(archivedOption, 200L);
+            archivedOption.archive(1L);
+            question.addOption(archivedOption);
+            survey.getQuestions().add(question);
+
+            SurveyResponse existingResponse = SurveyResponse.create(survey, memberUser);
+            withId(existingResponse, 1L);
+            existingResponse.addAnswer(OptionSurveyAnswer.create(existingResponse, question, archivedOption));
+
+            given(userRepository.findById(DEFAULT_MEMBER_ID)).willReturn(Optional.of(memberUser));
+            given(surveyResponseRepository.findBySurveyIdAndUserIdWithAnswers(DEFAULT_SURVEY_ID, DEFAULT_MEMBER_ID))
+                    .willReturn(Optional.of(existingResponse));
+
+            // when
+            SurveyResponseDetailResponse result = surveyResponseService.getMyResponse(
+                    DEFAULT_SURVEY_ID, memberAuth);
+
+            // then: archived 옵션의 텍스트가 응답에 포함되어 "미응답"으로 표시되지 않음
+            assertThat(result.answers()).hasSize(1);
+            SurveyResponseDetailResponse.AnswerResponse answer = result.answers().getFirst();
+            assertThat(answer.selectedOptions()).hasSize(1);
+            assertThat(answer.selectedOptions().getFirst().id()).isEqualTo(200L);
+            assertThat(answer.selectedOptions().getFirst().text()).isEqualTo("원래 옵션");
+        }
+
         @DisplayName("archived 질문의 답변도 응답 조회에 포함됨")
         @Test
         void getMyResponse_IncludesArchivedQuestionAnswers() {

--- a/frontend/src/api/model/models/answerResponse.ts
+++ b/frontend/src/api/model/models/answerResponse.ts
@@ -35,12 +35,14 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
  */
 import type { AnswerResponseQuestionType } from "./answerResponseQuestionType";
 import type { GridAnswerResponse } from "./gridAnswerResponse";
+import type { SelectedOptionResponse } from "./selectedOptionResponse";
 
 export interface AnswerResponse {
   questionId?: number;
   questionType?: AnswerResponseQuestionType;
   textValue?: string;
-  selectedOptionIds?: number[];
+  /** 선택된 옵션 (id + text). archived 옵션도 텍스트 포함. */
+  selectedOptions?: SelectedOptionResponse[];
   numericValue?: number;
   gridAnswers?: GridAnswerResponse[];
 }

--- a/frontend/src/api/model/models/index.ts
+++ b/frontend/src/api/model/models/index.ts
@@ -270,6 +270,8 @@ export * from "./resendVerificationRequest";
 export * from "./rowResponse";
 export * from "./saveQuestionOptionRequest";
 export * from "./saveQuestionRowRequest";
+export * from "./selectedOptionResponse";
+export * from "./selectedRowResponse";
 export * from "./semesterMemberListResponse";
 export * from "./semesterMemberListResponseRole";
 export * from "./semesterSummaryResponse";

--- a/frontend/src/api/model/models/selectedOptionResponse.ts
+++ b/frontend/src/api/model/models/selectedOptionResponse.ts
@@ -33,11 +33,11 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
  * OpenAPI spec version: ec724ff
  */
-import type { SelectedOptionResponse } from "./selectedOptionResponse";
-import type { SelectedRowResponse } from "./selectedRowResponse";
 
-export interface GridAnswerResponse {
-  row?: SelectedRowResponse;
-  /** 선택된 옵션 (id + text). archived 옵션도 텍스트 포함. */
-  selectedOptions?: SelectedOptionResponse[];
+/**
+ * 응답에 선택된 옵션 (id + 표시용 text). archived 옵션도 응답 보존을 위해 텍스트가 채워짐.
+ */
+export interface SelectedOptionResponse {
+  id: number;
+  text: string;
 }

--- a/frontend/src/api/model/models/selectedRowResponse.ts
+++ b/frontend/src/api/model/models/selectedRowResponse.ts
@@ -33,11 +33,11 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
  * OpenAPI spec version: ec724ff
  */
-import type { SelectedOptionResponse } from "./selectedOptionResponse";
-import type { SelectedRowResponse } from "./selectedRowResponse";
 
-export interface GridAnswerResponse {
-  row?: SelectedRowResponse;
-  /** 선택된 옵션 (id + text). archived 옵션도 텍스트 포함. */
-  selectedOptions?: SelectedOptionResponse[];
+/**
+ * 응답에 선택된 그리드 행 (id + 표시용 label). archived 행도 응답 보존을 위해 라벨이 채워짐.
+ */
+export interface SelectedRowResponse {
+  id: number;
+  label: string;
 }

--- a/frontend/src/components/feature/event/SurveyAnswerPanel.tsx
+++ b/frontend/src/components/feature/event/SurveyAnswerPanel.tsx
@@ -24,15 +24,12 @@ function renderAnswer(
 
     case "MULTIPLE_CHOICE":
     case "DROPDOWN": {
-      const selectedId = answer.selectedOptionIds?.[0];
-      const option = question.options?.find((o) => o.id === selectedId);
-      return option?.text ?? "미응답";
+      const text = answer.selectedOptions?.[0]?.text;
+      return text ?? "미응답";
     }
 
     case "CHECKBOX": {
-      const labels = (answer.selectedOptionIds ?? [])
-        .map((id) => question.options?.find((o) => o.id === id)?.text)
-        .filter((t): t is string => t !== undefined);
+      const labels = (answer.selectedOptions ?? []).map((o) => o.text);
       return labels.length > 0 ? labels.join(", ") : "미응답";
     }
 
@@ -40,6 +37,21 @@ function renderAnswer(
       return answer.numericValue !== undefined
         ? `${answer.numericValue} / ${question.scaleMax ?? 5}`
         : "미응답";
+
+    case "MULTIPLE_CHOICE_GRID":
+    case "CHECKBOX_GRID": {
+      const grid = answer.gridAnswers ?? [];
+      if (grid.length === 0) return "미응답";
+      return grid
+        .map((g) => {
+          const rowLabel = g.row?.label ?? "";
+          const optionTexts = (g.selectedOptions ?? [])
+            .map((o) => o.text)
+            .join(", ");
+          return `${rowLabel}: ${optionTexts}`;
+        })
+        .join(" / ");
+    }
 
     default:
       return "표시할 수 없는 형식";

--- a/frontend/src/utils/surveyStats.ts
+++ b/frontend/src/utils/surveyStats.ts
@@ -46,9 +46,9 @@ export function aggregateChoiceAnswers(
   }
 
   for (const answer of answers) {
-    if (answer.selectedOptionIds) {
-      for (const optId of answer.selectedOptionIds) {
-        countMap.set(optId, (countMap.get(optId) ?? 0) + 1);
+    if (answer.selectedOptions) {
+      for (const opt of answer.selectedOptions) {
+        countMap.set(opt.id, (countMap.get(opt.id) ?? 0) + 1);
       }
     }
   }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -700,6 +700,10 @@ components:
       $ref: './schemas/surveys.yaml#/AnswerResponse'
     GridAnswerResponse:
       $ref: './schemas/surveys.yaml#/GridAnswerResponse'
+    SelectedOptionResponse:
+      $ref: './schemas/surveys.yaml#/SelectedOptionResponse'
+    SelectedRowResponse:
+      $ref: './schemas/surveys.yaml#/SelectedRowResponse'
     GridAnswerRequest:
       $ref: './schemas/surveys.yaml#/GridAnswerRequest'
     AdminSurveyResponseListItem:

--- a/openapi/schemas/surveys.yaml
+++ b/openapi/schemas/surveys.yaml
@@ -332,6 +332,30 @@ SubmitAnswerRequest:
         $ref: '#/GridAnswerRequest'
   required:
   - questionId
+SelectedOptionResponse:
+  type: object
+  description: 응답에 선택된 옵션 (id + 표시용 text). archived 옵션도 응답 보존을 위해 텍스트가 채워짐.
+  properties:
+    id:
+      type: integer
+      format: int64
+    text:
+      type: string
+  required:
+  - id
+  - text
+SelectedRowResponse:
+  type: object
+  description: 응답에 선택된 그리드 행 (id + 표시용 label). archived 행도 응답 보존을 위해 라벨이 채워짐.
+  properties:
+    id:
+      type: integer
+      format: int64
+    label:
+      type: string
+  required:
+  - id
+  - label
 AnswerResponse:
   type: object
   properties:
@@ -354,11 +378,11 @@ AnswerResponse:
       - FILE_UPLOAD
     textValue:
       type: string
-    selectedOptionIds:
+    selectedOptions:
       type: array
+      description: 선택된 옵션 (id + text). archived 옵션도 텍스트 포함.
       items:
-        type: integer
-        format: int64
+        $ref: '#/SelectedOptionResponse'
     numericValue:
       type: integer
       format: int32
@@ -369,14 +393,13 @@ AnswerResponse:
 GridAnswerResponse:
   type: object
   properties:
-    rowId:
-      type: integer
-      format: int64
-    selectedOptionIds:
+    row:
+      $ref: '#/SelectedRowResponse'
+    selectedOptions:
       type: array
+      description: 선택된 옵션 (id + text). archived 옵션도 텍스트 포함.
       items:
-        type: integer
-        format: int64
+        $ref: '#/SelectedOptionResponse'
 GridAnswerRequest:
   type: object
   properties:


### PR DESCRIPTION
## Summary
- 운영진이 설문 옵션 텍스트를 수정하면 (응답이 있어 archive 처리), 과거 응답이 운영진 응답 뷰에서 "미응답"으로 표시되던 문제를 수정
- 응답 DTO 자체에 옵션 텍스트·행 라벨을 포함시켜 프론트 lookup 의존성을 제거
- archive 모델의 가치(과거 응답 보존)가 응답 표시까지 일관되게 적용됨

## 배경
PR #546 에서 archive 모델을 도입하여 옵션이 archived 되어도 DB·통계는 보존되도록 했으나, 응답 상세 표시는 여전히 "미응답"으로 출력되었습니다. 원인은 응답 DTO 가 `selectedOptionIds: number[]` 만 내려주고, 프론트가 `question.options.find(o => o.id === id)?.text` 로 텍스트를 lookup 하는데, archived 옵션은 `question.options` 에서 제외되어 있어 lookup 이 실패한 것이었습니다.

해결책으로 응답 DTO 자체에 옵션 텍스트와 행 라벨을 직접 포함시켰습니다. archive 든 hard-delete 든 응답 표시는 영향받지 않습니다.

## 주요 변경

### OpenAPI 스펙 (`openapi/schemas/surveys.yaml`)
- 신규: `SelectedOptionResponse(id, text)`, `SelectedRowResponse(id, label)`
- `AnswerResponse.selectedOptionIds` (id 배열) → `selectedOptions` (객체 배열)
- `GridAnswerResponse.rowId/selectedOptionIds` → `row` (객체) / `selectedOptions` (객체 배열)
- `SubmitAnswerRequest` (폼 제출 입력) 은 그대로 유지

### Backend
- `SurveyResponseDetailResponse`: 신규 record 두 개 추가, `from()` 에서 `getSelectedOption().getText()` / `getSelectedRow().getLabel()` 호출
- `SurveyResponseService.convertExternalAnswer`: 외부인 JSON 응답에 대해 `survey.getQuestions()` 전체(archived 포함)에서 옵션·행 맵을 빌드해 텍스트 resolve. hard-delete 된 항목은 `"(삭제된 선택지)"` / `"(삭제된 행)"` fallback
- 컨트롤러 3개 (`SurveyResponseController`, `SurveyAnonymousResponseController`, `AdminSurveyResponseController`): API DTO 매핑 갱신

### Frontend
- `SurveyAnswerPanel.tsx`: ID lookup 로직 제거. 응답에 포함된 텍스트 그대로 출력. GRID 응답 표시 케이스 추가
- `surveyStats.ts`: `selectedOptions` 기반 집계로 마이그레이션
- 폼 페이지(`EventApplyPage`, `EventExternalApplyPage`)는 로컬 form state 만 사용 → 변경 없음

### Tests
- `SurveyResponseServiceTest.getMyResponse_IncludesArchivedOptionText`: archive 된 옵션의 텍스트가 응답에 포함되어 "미응답" 으로 표시되지 않는지 검증
- 기존 통합 테스트 `matchesOpenApiSpec()` 가 새 스키마와 응답 일치 여부를 자동 검증

## Test plan
- [x] 백엔드 전체 테스트 통과 (`./gradlew test`)
- [x] 프론트 타입 체크/린트/포맷 통과 (`pnpm tsc --noEmit && pnpm lint && pnpm format`)
- [ ] 수동: 응답 1건 있는 설문에서 옵션 텍스트 수정 → 운영진 응답 뷰에서 과거 응답이 옛 옵션 텍스트로 표시되는지 확인
- [ ] 수동: 외부인 응답에 대해서도 동일 시나리오 확인
- [ ] 수동: 새 옵션으로 새 응답 제출 후 새 텍스트 정상 표시 확인

## Note
- PR #546 (archive 모델 도입) 의 후속 작업입니다. 이 PR 의 base 는 `frontend-yyjun-admin-page` 로, #546 머지 시 자동으로 main 으로 재타겟됩니다.