### PR TITLE
fix(frontend): 행사 수정 후 설문 문항 캐시 무효화 누락 수정

### DIFF
--- a/frontend/src/hooks/useSurveyEdit.ts
+++ b/frontend/src/hooks/useSurveyEdit.ts
@@ -60,6 +60,8 @@ export function useSurveyEdit(existingSurveyId?: number) {
     allowExternal?: boolean,
   ): Promise<number | undefined> => {
     try {
+      let resolvedSurveyId: number | undefined;
+
       if (existingSurveyId) {
         // 항상 서버에서 최신 데이터를 가져와 stale 캐시로 인한 오류 방지
         const freshResponse = await getQuestionList(existingSurveyId);
@@ -141,7 +143,8 @@ export function useSurveyEdit(existingSurveyId?: number) {
           }
         }
 
-        return draftQuestions.length > 0 ? existingSurveyId : undefined;
+        resolvedSurveyId =
+          draftQuestions.length > 0 ? existingSurveyId : undefined;
       } else if (draftQuestions.length > 0) {
         // 기존 설문 없음 & 새 문항 있음 → 신규 생성
         const surveyRes = await createSurveyAsync({
@@ -154,37 +157,44 @@ export function useSurveyEdit(existingSurveyId?: number) {
           surveyRes.status === 201
             ? (surveyRes.data.id ?? undefined)
             : undefined;
-        if (!newSurveyId) return undefined;
-
-        for (const q of draftQuestions) {
-          const qRes = await createQuestionAsync({
-            surveyId: newSurveyId,
-            data: {
-              questionType: q.questionType,
-              title: q.title || "질문",
-              required: q.required,
-              displayOrder: q.displayOrder,
-            },
-          });
-          const newQuestionId =
-            qRes.status === 201 ? (qRes.data?.id ?? undefined) : undefined;
-          if (newQuestionId && q.options?.length) {
-            for (const [i, text] of q.options.entries()) {
-              if (text.trim()) {
-                await createOptionAsync({
-                  surveyId: newSurveyId,
-                  questionId: newQuestionId,
-                  data: { text: text.trim(), displayOrder: i + 1 },
-                });
+        if (newSurveyId) {
+          for (const q of draftQuestions) {
+            const qRes = await createQuestionAsync({
+              surveyId: newSurveyId,
+              data: {
+                questionType: q.questionType,
+                title: q.title || "질문",
+                required: q.required,
+                displayOrder: q.displayOrder,
+              },
+            });
+            const newQuestionId =
+              qRes.status === 201 ? (qRes.data?.id ?? undefined) : undefined;
+            if (newQuestionId && q.options?.length) {
+              for (const [i, text] of q.options.entries()) {
+                if (text.trim()) {
+                  await createOptionAsync({
+                    surveyId: newSurveyId,
+                    questionId: newQuestionId,
+                    data: { text: text.trim(), displayOrder: i + 1 },
+                  });
+                }
               }
             }
           }
+          resolvedSurveyId = newSurveyId;
         }
-
-        return newSurveyId;
       }
 
-      return undefined;
+      // 성공 종료 시 question list 캐시 무효화 → 재진입 시 NEW 데이터 보장
+      const invalidationTarget = resolvedSurveyId ?? existingSurveyId;
+      if (invalidationTarget) {
+        await queryClient.invalidateQueries({
+          queryKey: getGetQuestionListQueryKey(invalidationTarget),
+        });
+      }
+
+      return resolvedSurveyId;
     } catch (err) {
       // 부분 변경 후 실패 시 캐시 무효화
       if (existingSurveyId) {


### PR DESCRIPTION
## Summary
- 행사 수정 페이지에서 설문 문항을 수정 후 재진입했을 때 OLD 캐시가 표시되는 버그 수정
- `submitSurvey` 정상 종료 시 question list 캐시(`/api/v1/surveys/{id}/questions`) invalidate 호출 추가
- 기존에는 catch 경로에서만 invalidate되어, 정상 흐름에서 5분 staleTime 동안 OLD 데이터가 노출됨

## Changes
- `frontend/src/hooks/useSurveyEdit.ts`
  - `submitSurvey`의 try 블록 단일 종료점화 (`resolvedSurveyId` 변수)
  - 신규 생성 분기의 early return 제거
  - 종료 직전 `await queryClient.invalidateQueries(...)` 호출 추가

## Test plan
- [ ] 운영진 계정으로 설문 연결된 행사의 수정 페이지 진입
- [ ] 설문 문항 수정 후 "수정 완료" 클릭
- [ ] Network 탭에서 PUT 직후 `/api/v1/surveys/{id}/questions` GET이 발사되는지 확인
- [ ] 목록으로 이동 후 같은 행사의 수정 페이지 재진입 시 NEW 문항이 표시되는지 확인
- [ ] 하드 리프레시와 동일한 데이터인지 교차 확인
- [ ] 설문 없는 행사 수정 시 정상 동작 회귀 테스트