### PR TITLE
feat(infra): Fargate+ALB → 단일 EC2+Caddy 전환 (월 ~$150 → ~$49)

### DIFF
--- a/.github/workflows/backend-prod-cd.yaml
+++ b/.github/workflows/backend-prod-cd.yaml
@@ -1,3 +1,6 @@
+# ⚠️ EC2+Caddy 전환(phase 2 cutover) 이후 유효한 파이프라인.
+# cutover 전에 릴리즈하면 EC2 만 갱신되고 api.igrus.co.kr(ALB→Fargate)은 구버전이 유지됨.
+# 절차: docs/infra/ec2-migration-runbook.md
 name: Backend Production CD Pipeline
 on:
   push:
@@ -21,12 +24,10 @@ jobs:
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       ECR_REPOSITORY_SPRING: ${{ vars.ECR_REPOSITORY_SPRING }}
-      CONTAINER_NAME_SPRING: ${{ vars.CONTAINER_NAME_SPRING }}
-      ECS_SERVICE_SPRING: ${{ vars.ECS_SERVICE_SPRING }}
-      ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
-      ECS_TASK_DEFINITION_NAME_SPRING: ${{ vars.ECS_TASK_DEFINITION_NAME_SPRING }}
       SPRING_ACTIVE_PROFILE: ${{ vars.SPRING_ACTIVE_PROFILE }}
       AWS_BACKEND_GITHUB_ACTIONS_ROLE_ARN: ${{ vars.AWS_BACKEND_GITHUB_ACTIONS_ROLE_ARN }}
+      EC2_INSTANCE_NAME: IGRUS-Web-App-EC2
+      IMAGE_TAG: ${{ inputs.version || github.ref_name }}
     defaults:
       run:
         working-directory: backend
@@ -70,36 +71,56 @@ jobs:
         id: build-image-spring
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ inputs.version || github.ref_name }}
         run: |
-          # Build a docker container and
-          # push it to ECR so that it can
-          # be deployed to ECS.
+          # Build a docker container and push it to ECR
+          # so that it can be deployed to the app EC2.
           docker build --build-arg SPRING_ACTIVE_PROFILE=$SPRING_ACTIVE_PROFILE --build-arg GIT_COMMIT_HASH=${{ github.sha }} -t $ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG
-          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY_SPRING:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-      - name: Get Latest ECS Task Definition ARN
-        id: get-latest-task-df
+      # EC2 위의 igrus-deploy 스크립트(SSM RunCommand)가 .env 태그 갱신 → compose pull/up
+      - name: Deploy to EC2 via SSM
         run: |
-          LATEST_TASK_DEF=$(aws ecs describe-task-definition \
-            --task-definition $ECS_TASK_DEFINITION_NAME_SPRING \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text)
-          echo "ECS_TASK_DEFINITION_ARN=$LATEST_TASK_DEF" >> $GITHUB_ENV
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=$EC2_INSTANCE_NAME" "Name=instance-state-name,Values=running" \
+            --query "Reservations[].Instances[].InstanceId" --output text)
+          if [ -z "$INSTANCE_ID" ]; then
+            echo "::error::running instance named $EC2_INSTANCE_NAME not found"
+            exit 1
+          fi
+          echo "Deploying $IMAGE_TAG to $INSTANCE_ID"
 
-      - name: Fill in the new image ID in the Amazon ECS task definition [Spring]
-        id: task-def-spring
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition-arn: ${{ env.ECS_TASK_DEFINITION_ARN }}
-          container-name: ${{ env.CONTAINER_NAME_SPRING }}
-          image: ${{ steps.build-image-spring.outputs.image }}
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --comment "igrus-web deploy $IMAGE_TAG" \
+            --parameters "commands=/usr/local/bin/igrus-deploy $IMAGE_TAG" \
+            --query "Command.CommandId" --output text)
 
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-        with:
-          task-definition: ${{ steps.task-def-spring.outputs.task-definition }}
-          service: ${{ env.ECS_SERVICE_SPRING }}
-          cluster: ${{ env.ECS_CLUSTER }}
-          wait-for-service-stability: true
+          set +e
+          aws ssm wait command-executed --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID"
+          WAIT_RC=$?
+          set -e
+
+          aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+            --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" --output json
+          STATUS=$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+            --query "Status" --output text)
+          if [ "$STATUS" != "Success" ] || [ $WAIT_RC -ne 0 ]; then
+            echo "::error::deploy command finished with status $STATUS"
+            exit 1
+          fi
+
+      # 컨테이너 재기동(~60초) 후 실서비스 health 확인
+      - name: Verify health
+        run: |
+          for i in $(seq 1 30); do
+            CODE=$(curl -s -o /dev/null -w "%{http_code}" https://api.igrus.co.kr/actuator/health || true)
+            if [ "$CODE" = "200" ]; then
+              echo "healthy (attempt $i)"
+              exit 0
+            fi
+            echo "waiting... ($i/30, http=$CODE)"
+            sleep 10
+          done
+          echo "::error::health check failed after 300s"
+          exit 1

--- a/.github/workflows/backend-prod-cd.yaml
+++ b/.github/workflows/backend-prod-cd.yaml
@@ -114,7 +114,8 @@ jobs:
       - name: Verify health
         run: |
           for i in $(seq 1 30); do
-            CODE=$(curl -s -o /dev/null -w "%{http_code}" https://api.igrus.co.kr/actuator/health || true)
+            # actuator 는 prod 에 노출되지 않음 → ALB 헬스체크와 동일하게 / (200) 사용
+            CODE=$(curl -s -o /dev/null -w "%{http_code}" https://api.igrus.co.kr/ || true)
             if [ "$CODE" = "200" ]; then
               echo "healthy (attempt $i)"
               exit 0

--- a/.github/workflows/backend-staging-cd.yaml
+++ b/.github/workflows/backend-staging-cd.yaml
@@ -1,12 +1,8 @@
+# ⚠️ EC2+Caddy 전환(phase 2.5)으로 staging ECS/RDS 가 제거되어 자동 배포를 중지함.
+# staging 을 다시 쓰려면 EC2 방식(SSM igrus-deploy)으로 재설계 필요 — docs/infra/ec2-migration-runbook.md
 name: Backend Staging CD Pipeline
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'backend/**'
-      - '.github/workflows/backend-staging-cd.yaml'
-      - '!backend/docs/**'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docs/infra/ec2-caddy-migration-rationale.md
+++ b/docs/infra/ec2-caddy-migration-rationale.md
@@ -262,7 +262,8 @@ IGRUS 웹(앱+DB) + 다른 동아리 프로젝트 + 내부 도구(스테이징, 
 
 ## 10. 관련 문서
 
+- **`docs/infra/ec2-migration-runbook.md` — 이 결정의 실행 절차 (MIGRATION_PHASE 1→2→3)**
 - `docs/infra/v1-decommission-runbook.md` — v1 자원 삭제 절차
 - `docs/infra/reconcile-runbook.md` — v2 드리프트 reconcile
 - `docs/infra/rds-shrink-runbook.md` — RDS 스토리지 축소
-- `infra/cdk/lib/igrus-web-v2-stack.ts` — 현재 v2 IaC (전환 시 EC2 construct 추가 대상)
+- `infra/cdk/lib/igrus-web-v2-stack.ts` — IaC (EC2+Caddy construct 구현 완료, phase 플래그로 전환)

--- a/docs/infra/ec2-migration-runbook.md
+++ b/docs/infra/ec2-migration-runbook.md
@@ -1,0 +1,153 @@
+# EC2 + Caddy 전환 런북 (Fargate+ALB → 단일 t3.small)
+
+근거·비용·목표 아키텍처: `docs/infra/ec2-caddy-migration-rationale.md` (옵션 A).
+구현: `infra/cdk/lib/igrus-web-v2-stack.ts` 의 **`MIGRATION_PHASE` 상수(1→2→3)** 를 올려가며 3회 배포한다.
+
+> 계정 `218736972976` / `ap-northeast-2`. `cdk deploy` 는 자동모드 가드가 막으므로 **사용자가 직접 실행**.
+> 각 단계는 독립적으로 롤백 가능: 플래그를 이전 값으로 되돌려 재배포하면 원복된다(phase 3 제외 — 아래 참조).
+
+```bash
+cd infra/cdk
+export AWS_PROFILE=igrus AWS_DEFAULT_REGION=ap-northeast-2
+npm install && npm run build
+```
+
+---
+
+## Phase 1 — 병행 프로비저닝 (무중단)
+
+`MIGRATION_PHASE = 1` (현재 코드 상태). 기존 Fargate+ALB 는 그대로 두고 추가만 한다:
+
+- **EC2 t3.small** `IGRUS-Web-App-EC2` (AL2023, 30GB gp3 암호화, IMDSv2 hop-limit 2)
+- **user-data**: swap 5GB(`vm.swappiness=10`) + Docker/compose + ECR credential helper +
+  `/opt/igrus/{docker-compose.yml,Caddyfile,.env}` + `/usr/local/bin/igrus-deploy` + `docker compose up -d`
+- **Caddy**(컨테이너): `api.igrus.co.kr`, `ec2.igrus.co.kr` 자동 Let's Encrypt + `app:8080` 리버스 프록시
+- **app**(컨테이너): 동일 ECR 이미지, `SPRING_ACTIVE_PROFILE=prod`, v2 RDS datasource, `-Xmx1g`
+- **EIP 1개** + 검증용 A레코드 `ec2.igrus.co.kr`
+- IAM 롤 `IGRUS-Web-App-EC2-ROLE`: SSM + ECR pull + S3 + prod 시크릿 read (기존 taskRole 동등)
+- RDS SG 에 EC2 SG 3306 인바운드 추가
+
+```bash
+npx cdk deploy
+```
+
+### 검증
+```bash
+# 부팅 + user-data(도커 설치·이미지 pull·앱 기동) 3~5분 대기 후
+curl -s -o /dev/null -w "%{http_code}\n" https://ec2.igrus.co.kr/actuator/health   # 200
+
+# 실동작: 로그인 (EC2 경로가 prod RDS/시크릿/S3 를 정상 사용하는지)
+curl -s -o /dev/null -w "%{http_code}\n" -X POST https://ec2.igrus.co.kr/api/v1/auth/password/login \
+  -H 'Content-Type: application/json' -d '{"studentId":"<학번>","password":"<비번>"}'
+
+# 문제 시 인스턴스 진입 (bastion 불필요 — SSM)
+aws ssm start-session --target <AppEc2InstanceId 출력값>
+#   sudo cat /var/log/cloud-init-output.log      # user-data 로그
+#   sudo docker ps / sudo docker logs igrus-app-1
+```
+
+> ⚠️ 이 시점에 EC2 앱도 **prod RDS 에 실제로 붙는다** (Fargate 와 동일 DB 병행 — 스케줄러 중복 실행이
+> 걱정되면 검증 후 cutover 까지의 간격을 짧게 유지할 것).
+> ⚠️ Caddy 는 `api.igrus.co.kr` 인증서 발급을 DNS cutover 전까지 실패-재시도(백오프)한다. 정상이다.
+
+### GitHub Actions 롤 권한 추가 (phase 2 전 필수, 1회)
+`AWS_BACKEND_GITHUB_ACTIONS_ROLE_ARN` 롤에 인라인 정책 추가 (SSM 배포용):
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow", "Action": "ec2:DescribeInstances", "Resource": "*" },
+    { "Effect": "Allow", "Action": "ssm:SendCommand",
+      "Resource": [
+        "arn:aws:ec2:ap-northeast-2:218736972976:instance/*",
+        "arn:aws:ssm:ap-northeast-2::document/AWS-RunShellScript"
+      ],
+      "Condition": { "StringEquals": { "ssm:resourceTag/Name": "IGRUS-Web-App-EC2" } } },
+    { "Effect": "Allow", "Action": "ssm:GetCommandInvocation", "Resource": "*" }
+  ]
+}
+```
+> `ssm:resourceTag` 조건은 instance ARN 에만 유효하다. document ARN 쪽 조건 불일치로 거부되면
+> 조건을 instance statement 로 분리할 것.
+
+---
+
+## Phase 2 — cutover (수 분 내 완료, 트래픽 ≈0)
+
+`MIGRATION_PHASE = 2` 로 수정 후:
+
+```bash
+npx cdk deploy
+```
+변경: `api.igrus.co.kr` A레코드 **ALB alias → EIP (TTL 60s)**, prod Fargate `desiredCount 1 → 0`.
+
+```bash
+# DNS 전파 확인 (EIP 가 나와야)
+dig +short api.igrus.co.kr
+
+# Caddy 인증서 즉시 재발급 (백오프 대기 없이)
+aws ssm send-command --document-name AWS-RunShellScript \
+  --targets "Key=tag:Name,Values=IGRUS-Web-App-EC2" \
+  --parameters 'commands=cd /opt/igrus && docker compose restart caddy'
+
+# 검증
+curl -s -o /dev/null -w "%{http_code}\n" https://api.igrus.co.kr/actuator/health   # 200
+```
+
+이후 **prod CD 파이프라인 변경(PR)을 머지**한다 (`.github/workflows/backend-prod-cd.yaml`
+— ECS 배포 → ECR push + SSM `igrus-deploy`). cutover 전에 머지하면 릴리즈가 EC2 에만 반영되므로 순서 주의.
+
+### 롤백 (수 분)
+`MIGRATION_PHASE = 1` 로 되돌려 `npx cdk deploy` → api 레코드가 ALB alias 로, Fargate desired 1 로 원복.
+
+---
+
+## Phase 3 — cleanup (며칠 안정 운영 확인 후)
+
+`MIGRATION_PHASE = 3` 으로 수정 후:
+
+```bash
+npx cdk deploy
+```
+제거: ALB(+리스너/TG/clone 인증서/clone·staging-clone·staging-api 레코드), ECS 클러스터/서비스/태스크데프,
+ECS·ALB·bastion SG 와 RDS SG 의 해당 인바운드, task/execution/SSM IAM 롤, **bastion EC2** (앱 EC2 의 SSM 이 대체),
+**staging RDS** (RemovalPolicy=SNAPSHOT → 최종 스냅샷 자동 보존).
+변경: prod RDS `db.t3.micro → db.t4g.micro` (ARM, −10%, 짧은 재부팅 1회 발생).
+
+주의:
+- 이 단계는 플래그 원복만으로 완전 롤백되지 않는다(재생성은 되지만 staging RDS 는 스냅샷 복원 절차 필요).
+- CloudWatch 로그 그룹(`/ecs/...`)은 RETAIN 이라 보존된다.
+- **staging CD**(`backend-staging-cd.yaml`)는 phase 3 이후 배포 대상(ECS)이 없어 실패한다 —
+  staging 을 다시 쓸 때 EC2 방식으로 재설계하거나 워크플로우를 비활성화할 것.
+- GitHub `production` environment 의 ECS 관련 vars(`ECS_CLUSTER`, `ECS_SERVICE_SPRING`,
+  `ECS_TASK_DEFINITION_NAME_SPRING`, `CONTAINER_NAME_SPRING`)는 더 이상 사용되지 않는다(정리 가능).
+
+### 검증 & 비용 확인
+```bash
+aws elbv2 describe-load-balancers --query "LoadBalancers[].LoadBalancerName"   # ALB-v2 없어야
+aws ecs list-clusters --query clusterArns                                      # v2 클러스터 없어야
+aws rds describe-db-instances \
+  --query "DBInstances[].{id:DBInstanceIdentifier,class:DBInstanceClass}"      # prod 만, t4g.micro
+curl -s -o /dev/null -w "%{http_code}\n" https://api.igrus.co.kr/actuator/health
+```
+목표: 월 ~$175 → **~$47** (EC2 $19.3 + EBS $2.7 + EIP $3.7 + RDS t4g.micro $20 + ECR/Secrets ~$1.7).
+다음 달 Cost Explorer 에서 ECS/ALB/VPC-IPv4 라인이 사라졌는지 확인.
+
+---
+
+## 운영 메모 (전환 후)
+
+- **배포**: 태그 push(v*) → CI 가 ECR push 후 SSM 으로 `igrus-deploy <tag>` 실행 (컨테이너 재기동 ~60초 다운타임,
+  트래픽 ≈0 이라 수용. 무중단이 필요해지면 blue-green 을 후속 도입).
+- **인스턴스 교체**: user-data 수정 시 인스턴스가 교체된다(`userDataCausesReplacement`). EIP/DNS 는 유지되고
+  Caddy 인증서는 재발급된다(Let's Encrypt 중복 발급 한도 주 5회 유의).
+- **장애 복구**: EC2 는 시스템 장애 시 simplified auto-recovery 로 자동 복구. 심각 시 스택 재배포로 재현.
+- **RDS 접속**: `aws ssm start-session --target <앱 EC2>` 후 mysql 클라이언트 또는 포트포워딩 (bastion 대체).
+- **모니터링(후속 과제)**: CloudWatch 에 `mem_used_percent`/swap 알람 추가 검토 (rationale §7).
+- **보안(미해결)**: `MEMO.md` 의 평문 IAM 키 rotate + 삭제 (rationale §7 경고, git 미추적이어도 로컬 유출 리스크).
+
+## 관련 문서
+- `docs/infra/ec2-caddy-migration-rationale.md` — 의사결정 근거·비용·트레이드오프
+- `docs/infra/v1-decommission-runbook.md` — v1 자원 삭제 (선행 작업)
+- `docs/infra/rds-shrink-runbook.md` — RDS 20GB 축소 (선행 작업)
+- `infra/cdk/README.md` — CDK 사용법

--- a/docs/infra/ec2-migration-runbook.md
+++ b/docs/infra/ec2-migration-runbook.md
@@ -1,10 +1,10 @@
 # EC2 + Caddy 전환 런북 (Fargate+ALB → 단일 t3.small)
 
 근거·비용·목표 아키텍처: `docs/infra/ec2-caddy-migration-rationale.md` (옵션 A).
-구현: `infra/cdk/lib/igrus-web-v2-stack.ts` 의 **`MIGRATION_PHASE` 상수(1→2→3)** 를 올려가며 3회 배포한다.
+구현: `infra/cdk/lib/igrus-web-v2-stack.ts` 의 **`MIGRATION_PHASE` 상수(1→2→2.5→3)** 를 올려가며 배포한다.
 
 > 계정 `218736972976` / `ap-northeast-2`. `cdk deploy` 는 자동모드 가드가 막으므로 **사용자가 직접 실행**.
-> 각 단계는 독립적으로 롤백 가능: 플래그를 이전 값으로 되돌려 재배포하면 원복된다(phase 3 제외 — 아래 참조).
+> 각 단계는 독립적으로 롤백 가능: 플래그를 이전 값으로 되돌려 재배포하면 원복된다(phase 2.5 부터는 재생성 소요 — 아래 참조).
 
 ```bash
 cd infra/cdk
@@ -102,25 +102,32 @@ curl -s -o /dev/null -w "%{http_code}\n" https://api.igrus.co.kr/   # 200
 
 ---
 
-## Phase 3 — cleanup (며칠 안정 운영 확인 후)
+## Phase 2.5 — cleanup: 미사용 레거시 제거 (무중단)
 
-`MIGRATION_PHASE = 3` 으로 수정 후:
+`MIGRATION_PHASE = 2.5` 로 수정 후:
 
 ```bash
 npx cdk deploy
 ```
-제거: ALB(+리스너/TG/clone 인증서/clone·staging-clone·staging-api 레코드), ECS 클러스터/서비스/태스크데프,
-ECS·ALB·bastion SG 와 RDS SG 의 해당 인바운드, task/execution/SSM IAM 롤, **bastion EC2** (앱 EC2 의 SSM 이 대체),
-**staging RDS** (RemovalPolicy=SNAPSHOT → 최종 스냅샷 자동 보존).
-변경: prod RDS `db.t3.micro → db.t4g.micro` (ARM, −10%, 짧은 재부팅 1회 발생).
+제거: ALB(+리스너/TG/clone 인증서/clone·staging-clone·staging-api 레코드, **퍼블릭 IPv4 4개**),
+ECS 클러스터/서비스/태스크데프, ECS·ALB·bastion SG 와 RDS SG 의 해당 인바운드, task/execution/SSM IAM 롤,
+**bastion EC2** (앱 EC2 의 SSM 이 대체), **staging RDS** (RemovalPolicy=SNAPSHOT → 최종 스냅샷 자동 보존).
+라이브 경로(EC2→prod RDS)는 무변경 → 무중단. 비용 ~$105 → **~$50/월**.
 
 주의:
-- 이 단계는 플래그 원복만으로 완전 롤백되지 않는다(재생성은 되지만 staging RDS 는 스냅샷 복원 절차 필요).
+- 이 단계부터 플래그 원복만으로 즉시 롤백되지 않는다(ALB/ECS 재생성 ~20분, staging RDS 는 스냅샷에서 재생성).
 - CloudWatch 로그 그룹(`/ecs/...`)은 RETAIN 이라 보존된다.
-- **staging CD**(`backend-staging-cd.yaml`)는 phase 3 이후 배포 대상(ECS)이 없어 실패한다 —
-  staging 을 다시 쓸 때 EC2 방식으로 재설계하거나 워크플로우를 비활성화할 것.
+- **staging CD**(`backend-staging-cd.yaml`)는 배포 대상(ECS)이 없어져 자동 트리거를 제거했다(workflow_dispatch 만 잔존) —
+  staging 을 다시 쓸 때 EC2 방식으로 재설계할 것.
 - GitHub `production` environment 의 ECS 관련 vars(`ECS_CLUSTER`, `ECS_SERVICE_SPRING`,
   `ECS_TASK_DEFINITION_NAME_SPRING`, `CONTAINER_NAME_SPRING`)는 더 이상 사용되지 않는다(정리 가능).
+
+---
+
+## Phase 3 — prod RDS ARM 전환 (짧은 다운타임)
+
+`MIGRATION_PHASE = 3` 으로 수정 후 `npx cdk deploy`.
+변경: prod RDS `db.t3.micro → db.t4g.micro` (ARM, −10%, **재부팅 수 분 발생** — 저트래픽 시간대 권장).
 
 ### 검증 & 비용 확인
 ```bash

--- a/docs/infra/ec2-migration-runbook.md
+++ b/docs/infra/ec2-migration-runbook.md
@@ -34,7 +34,7 @@ npx cdk deploy
 ### 검증
 ```bash
 # 부팅 + user-data(도커 설치·이미지 pull·앱 기동) 3~5분 대기 후
-curl -s -o /dev/null -w "%{http_code}\n" https://ec2.igrus.co.kr/actuator/health   # 200
+curl -s -o /dev/null -w "%{http_code}\n" https://ec2.igrus.co.kr/   # 200 (actuator 는 prod 미노출 → / 사용)
 
 # 실동작: 로그인 (EC2 경로가 prod RDS/시크릿/S3 를 정상 사용하는지)
 curl -s -o /dev/null -w "%{http_code}\n" -X POST https://ec2.igrus.co.kr/api/v1/auth/password/login \
@@ -91,7 +91,7 @@ aws ssm send-command --document-name AWS-RunShellScript \
   --parameters 'commands=cd /opt/igrus && docker compose restart caddy'
 
 # 검증
-curl -s -o /dev/null -w "%{http_code}\n" https://api.igrus.co.kr/actuator/health   # 200
+curl -s -o /dev/null -w "%{http_code}\n" https://api.igrus.co.kr/   # 200
 ```
 
 이후 **prod CD 파이프라인 변경(PR)을 머지**한다 (`.github/workflows/backend-prod-cd.yaml`
@@ -128,7 +128,7 @@ aws elbv2 describe-load-balancers --query "LoadBalancers[].LoadBalancerName"   #
 aws ecs list-clusters --query clusterArns                                      # v2 클러스터 없어야
 aws rds describe-db-instances \
   --query "DBInstances[].{id:DBInstanceIdentifier,class:DBInstanceClass}"      # prod 만, t4g.micro
-curl -s -o /dev/null -w "%{http_code}\n" https://api.igrus.co.kr/actuator/health
+curl -s -o /dev/null -w "%{http_code}\n" https://api.igrus.co.kr/
 ```
 목표: 월 ~$175 → **~$47** (EC2 $19.3 + EBS $2.7 + EIP $3.7 + RDS t4g.micro $20 + ECR/Secrets ~$1.7).
 다음 달 Cost Explorer 에서 ECS/ALB/VPC-IPv4 라인이 사라졌는지 확인.

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -1,9 +1,25 @@
 # IGRUS-Web 인프라 (AWS CDK)
 
-운영(Production) 인프라를 **토씨 하나 같게** 복제하는 IaC.
-수동 생성 자원의 **이름에만 `-v2`** 를 붙이고, 접속 도메인만 `clone.igrus.co.kr` 로 새로 연결한다.
+운영(Production) 인프라를 **토씨 하나 같게** 복제한 v2(Fargate+ALB) IaC 에,
+**EC2+Caddy 전환(v3)** 이 `MIGRATION_PHASE` 플래그로 구현되어 있다.
 
 > 계정 `218736972976` / 리전 `ap-northeast-2` / 기준 스냅샷 2026-06-29
+
+## EC2 + Caddy 전환 (진행 중)
+
+상시 저부하 워크로드의 Fargate/ALB/IPv4 고정비 제거 (월 ~$175 → ~$47).
+`lib/igrus-web-v2-stack.ts` 상단 `MIGRATION_PHASE`(1→2→3)를 올려가며 배포한다:
+
+| Phase | 내용 |
+| --- | --- |
+| 1 | EC2 t3.small(`IGRUS-Web-App-EC2`) + Caddy + EIP + `ec2.igrus.co.kr` 병행 프로비저닝. 기존 인프라 유지 |
+| 2 | cutover — `api.igrus.co.kr` → EIP, prod Fargate desiredCount 0 (플래그 원복 = 즉시 롤백) |
+| 3 | cleanup — ALB/ECS/bastion/staging RDS 제거, prod RDS t4g.micro 전환 |
+
+근거: `docs/infra/ec2-caddy-migration-rationale.md` / 절차: `docs/infra/ec2-migration-runbook.md`
+
+배포는 태그 릴리즈 시 GitHub Actions 가 ECR push 후 SSM 으로 인스턴스의
+`/usr/local/bin/igrus-deploy <tag>` 를 실행한다 (`.github/workflows/backend-prod-cd.yaml`).
 
 ## 무엇을 만드나 (운영 → v2)
 

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -8,13 +8,14 @@
 ## EC2 + Caddy 전환 (진행 중)
 
 상시 저부하 워크로드의 Fargate/ALB/IPv4 고정비 제거 (월 ~$175 → ~$47).
-`lib/igrus-web-v2-stack.ts` 상단 `MIGRATION_PHASE`(1→2→3)를 올려가며 배포한다:
+`lib/igrus-web-v2-stack.ts` 상단 `MIGRATION_PHASE`(1→2→2.5→3)를 올려가며 배포한다:
 
 | Phase | 내용 |
 | --- | --- |
 | 1 | EC2 t3.small(`IGRUS-Web-App-EC2`) + Caddy + EIP + `ec2.igrus.co.kr` 병행 프로비저닝. 기존 인프라 유지 |
 | 2 | cutover — `api.igrus.co.kr` → EIP, prod Fargate desiredCount 0 (플래그 원복 = 즉시 롤백) |
-| 3 | cleanup — ALB/ECS/bastion/staging RDS 제거, prod RDS t4g.micro 전환 |
+| 2.5 | cleanup — ALB(+IPv4)/ECS/bastion/staging RDS 제거 (무중단) |
+| 3 | prod RDS t4g.micro 전환 (짧은 재부팅) |
 
 근거: `docs/infra/ec2-caddy-migration-rationale.md` / 절차: `docs/infra/ec2-migration-runbook.md`
 

--- a/infra/cdk/cdk.context.json
+++ b/infra/cdk/cdk.context.json
@@ -40,5 +40,6 @@
   "hosted-zone:account=218736972976:domainName=igrus.co.kr:region=ap-northeast-2": {
     "Id": "/hostedzone/Z0288891201KKBESMOAHJ",
     "Name": "igrus.co.kr."
-  }
+  },
+  "ssm:account=218736972976:parameterName=/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64:region=ap-northeast-2": "ami-0212948777c137c94"
 }

--- a/infra/cdk/lib/igrus-web-v2-stack.ts
+++ b/infra/cdk/lib/igrus-web-v2-stack.ts
@@ -14,48 +14,69 @@ import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const SSL_POLICY = 'ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09' as elbv2.SslPolicy;
 
-/** 한 앱 환경(prod/staging) 구성 설정 */
+/**
+ * EC2+Caddy 전환 단계 (근거: docs/infra/ec2-caddy-migration-rationale.md,
+ * 절차: docs/infra/ec2-migration-runbook.md)
+ *
+ * 1 — 병행 프로비저닝: 기존 Fargate+ALB 유지 + EC2(t3.small)+Caddy 추가.
+ *     ec2.igrus.co.kr 로 EC2 경로 검증. api.igrus.co.kr 은 아직 ALB.
+ * 2 — cutover: api.igrus.co.kr A레코드 → EC2 EIP, prod Fargate desiredCount 0.
+ *     ALB/Fargate 는 롤백 경로로 유지 (플래그를 1로 되돌리면 원복).
+ * 3 — cleanup: ALB/ECS/bastion/staging RDS 제거(스냅샷 보존), prod RDS t4g.micro 전환.
+ */
+const MIGRATION_PHASE: 1 | 2 | 3 = 1;
+const CUTOVER = MIGRATION_PHASE >= 2; // api 도메인이 EC2 를 향하고 Fargate 는 중지
+const LEGACY = MIGRATION_PHASE <= 2; // Fargate/ALB/bastion/staging 자원 유지 여부
+
+const ECR_IMAGE_REPO = '218736972976.dkr.ecr.ap-northeast-2.amazonaws.com/igrus/web/spring';
+/** EC2 최초 부팅 시 기동할 이미지 태그 (이후 배포는 CD 가 igrus-deploy 로 갱신) */
+const INITIAL_IMAGE_TAG = 'v1.1.8';
+
+/** 한 앱 환경(prod/staging)의 ECS 구성 설정 */
 interface AppEnvConfig {
   idPrefix: string;
-  /** 기존 Secrets Manager 시크릿 이름 (그대로 재사용) */
-  existingSecretName: string;
+  /** 기존 Secrets Manager 시크릿 (그대로 재사용) */
+  appSecret: secretsmanager.ISecret;
   springProfile: string;
-  // ECS
   serviceName: string;
   family: string;
   containerName: string;
   image: string;
   logGroupName: string;
   attachDefaultSgToService: boolean; // prod=true, staging=false (운영 현황 그대로)
-  desiredCount: number; // prod=1(상시 가동), staging=0(비용 절감 위해 중지)
-  // RDS (기존 DB 스냅샷에서 복원 → 데이터 그대로 복제)
+  desiredCount: number;
+  rdsDbName: string; // SPRING_DATASOURCE_URL 구성용
+  db: rds.IDatabaseInstance;
+}
+
+/** RDS 인스턴스 구성 설정 (기존 DB 스냅샷에서 복원 → 데이터 그대로 복제) */
+interface DbConfig {
+  idPrefix: string;
   rdsId: string;
   rdsVersion: rds.MysqlEngineVersion;
   rdsSnapshotIdentifier: string;
-  rdsDbName: string; // SPRING_DATASOURCE_URL 구성용 (스냅샷 내 DB명)
   rdsPubliclyAccessible: boolean;
   rdsBackupDays: number;
+  instanceType: ec2.InstanceType;
 }
 
 interface SharedCtx {
   vpc: ec2.IVpc;
   cluster: ecs.ICluster;
   ecsSg: ec2.ISecurityGroup;
-  rdsSg: ec2.ISecurityGroup;
   defaultSg: ec2.ISecurityGroup;
   taskRole: iam.IRole;
   executionRole: iam.IRole;
 }
 
 /**
- * IGRUS-Web 운영 + 스테이징 인프라를 "토씨 하나 같게" 복제하는 스택.
+ * IGRUS-Web 인프라 스택.
  *
- * - 수동 생성 자원 이름에만 `-v2` 접미사
- * - 접속 도메인만 신규: clone.igrus.co.kr (운영) / staging-clone.igrus.co.kr (스테이징)
- * - 시크릿은 기존 Secrets Manager(igrus/web/server/prod, .../staging)를 그대로 재사용
- * - 앱 코드 불변. DB만 v2로 격리: v2 RDS 자동생성 자격증명을 ECS 가 앱 datasource 에 주입
+ * - v2: 운영 인프라를 "토씨 하나 같게" 복제한 Fargate+ALB 구조 (MIGRATION_PHASE<=2 유지)
+ * - v3(EC2+Caddy): 단일 t3.small 에 Docker(동일 ECR 이미지)+Caddy(자동 TLS) —
+ *   상시 저부하 워크로드에 맞춰 Fargate/ALB/IPv4 고정비 제거 (월 ~$175 → ~$47)
  *
- * 기준 스냅샷 2026-06-29 / account 218736972976 / ap-northeast-2 / default VPC.
+ * account 218736972976 / ap-northeast-2 / default VPC.
  */
 export class IgrusWebV2Stack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: cdk.StackProps) {
@@ -71,31 +92,7 @@ export class IgrusWebV2Stack extends cdk.Stack {
     );
     const zone = route53.HostedZone.fromLookup(this, 'Zone', { domainName: 'igrus.co.kr' });
 
-    // ── 보안그룹 (이름/규칙 운영과 동일, 이름만 -v2) ──
-    const albSg = new ec2.SecurityGroup(this, 'AlbSg', {
-      vpc,
-      securityGroupName: 'IGRUS-WEB-ALB-SG-v2',
-      description: 'IGRUS-WEB-ALB-SG',
-      allowAllOutbound: true,
-    });
-    [80, 443, 8080].forEach((p) => albSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(p)));
-
-    const ecsSg = new ec2.SecurityGroup(this, 'EcsSg', {
-      vpc,
-      securityGroupName: 'igrus-web-server-ecs-service-sg-v2',
-      description: 'igrus-web-server-ecs-service-sg',
-      allowAllOutbound: true,
-    });
-    ecsSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(8080));
-
-    const bastionSg = new ec2.SecurityGroup(this, 'BastionSg', {
-      vpc,
-      securityGroupName: 'launch-wizard-1-v2',
-      description: 'launch-wizard-1',
-      allowAllOutbound: true,
-    });
-    bastionSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(22));
-
+    // ── RDS 보안그룹 (이름/규칙 운영과 동일, 이름만 -v2) ──
     const rdsSg = new ec2.SecurityGroup(this, 'RdsSg', {
       vpc,
       securityGroupName: 'IGRUS-Web-MySQL-RDS-SG-v2',
@@ -103,84 +100,462 @@ export class IgrusWebV2Stack extends cdk.Stack {
       allowAllOutbound: true,
     });
     rdsSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(3306));
-    rdsSg.addIngressRule(ecsSg, ec2.Port.tcp(3306));
-    rdsSg.addIngressRule(bastionSg, ec2.Port.tcp(3306));
 
-    // ── IAM 역할 (운영 prod 역할을 prod/staging 공용 사용, 이름만 -v2) ──
-    const taskRole = new iam.Role(this, 'TaskRole', {
-      roleName: 'igrus-web-server-prod-ecs-task-role-v2',
-      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
-      managedPolicies: [
-        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonS3FullAccess'),
-        iam.ManagedPolicy.fromAwsManagedPolicyName('AWSSecretsManagerClientReadOnlyAccess'),
-      ],
-    });
-    const executionRole = new iam.Role(this, 'ExecutionRole', {
-      roleName: 'igrus-web-server-prod-ecs-task-execution-role-v2',
-      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
-      managedPolicies: [
-        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonECSTaskExecutionRolePolicy'),
-        iam.ManagedPolicy.fromAwsManagedPolicyName('AWSSecretsManagerClientReadOnlyAccess'),
-      ],
-    });
-
-    // ── ECS 클러스터 (FARGATE / FARGATE_SPOT) ──
-    const cluster = new ecs.Cluster(this, 'Cluster', {
-      clusterName: 'IGRUS-WEB-ECS-Cluster-v2',
-      vpc,
-      enableFargateCapacityProviders: true,
-    });
-
-    const ctx: SharedCtx = { vpc, cluster, ecsSg, rdsSg, defaultSg, taskRole, executionRole };
-
-    // ── 운영(prod) 앱 환경 ──
-    const prod = this.addAppEnvironment(
+    // ── prod 시크릿 + prod RDS (아키텍처와 무관하게 상시 유지) ──
+    const prodSecret = secretsmanager.Secret.fromSecretNameV2(
+      this,
+      'ProdAppSecret',
+      'igrus/web/server/prod',
+    );
+    const prodDb = this.addDatabase(
       {
         idPrefix: 'Prod',
-        existingSecretName: 'igrus/web/server/prod',
-        springProfile: 'prod',
-        serviceName: 'igrus-web-server-ecs-service-v2',
-        family: 'igrus-web-server-task-def-v2',
-        containerName: 'IGRUS-WEB-SPRING-SERVER',
-        image: '218736972976.dkr.ecr.ap-northeast-2.amazonaws.com/igrus/web/spring:v1.1.8',
-        logGroupName: '/ecs/igrus-web-server-task-def-v2',
-        attachDefaultSgToService: true,
-        desiredCount: 1,
         rdsId: 'igrus-web-mysql-rds-v2',
         rdsVersion: rds.MysqlEngineVersion.of('8.0.44', '8.0'),
         rdsSnapshotIdentifier: 'igrus-web-mysql-rds-v2seed-20260629',
-        rdsDbName: 'igrus_web',
         rdsPubliclyAccessible: false,
         rdsBackupDays: 3,
+        // cleanup 단계에서 x86(t3) → ARM(t4g) 전환: 동급 스펙 −10%, 짧은 재부팅 1회
+        instanceType:
+          MIGRATION_PHASE >= 3
+            ? ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MICRO)
+            : ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
       },
-      ctx,
+      vpc,
+      [rdsSg, defaultSg],
     );
 
-    // ── 스테이징(staging) 앱 환경 ──
-    const staging = this.addAppEnvironment(
-      {
-        idPrefix: 'Staging',
-        existingSecretName: 'igrus/web/server/staging',
-        springProfile: 'staging',
-        serviceName: 'igrus-web-server-staging-task-def-service-v2',
-        family: 'igrus-web-server-staging-task-def-v2',
-        containerName: 'IGRUS-WEB-SPRING-STAGING-SERVER',
-        image:
-          '218736972976.dkr.ecr.ap-northeast-2.amazonaws.com/igrus/web/staging/spring:6b34009e2deac8c65c6d31f4d62c34a07343a8f7',
-        logGroupName: '/ecs/igrus-web-server-staging-task-def-v2',
-        attachDefaultSgToService: false,
-        desiredCount: 0, // staging 중지(비용 절감). 필요 시 1로 올려 재배포
-        rdsId: 'igrus-web-staging-mysql-rds-v2',
-        rdsVersion: rds.MysqlEngineVersion.of('8.4.7', '8.4'),
-        rdsSnapshotIdentifier: 'igrus-web-staging-mysql-rds-v2seed-20260629',
-        rdsDbName: 'igrus_web_staging',
-        rdsPubliclyAccessible: false, // 보안상 private (실 PII 복원이라 운영 public 설정에서 이것만 변경)
-        rdsBackupDays: 1,
-      },
-      ctx,
+    // ══════════════════════════════════════════════════════════════════
+    // EC2 + Caddy 앱 호스트 (v3 아키텍처 본체)
+    // ══════════════════════════════════════════════════════════════════
+    const appSg = new ec2.SecurityGroup(this, 'AppEc2Sg', {
+      vpc,
+      securityGroupName: 'IGRUS-Web-App-EC2-SG',
+      description: 'IGRUS Web App EC2 (Caddy 80/443)',
+      allowAllOutbound: true,
+    });
+    [80, 443].forEach((p) => appSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(p)));
+    rdsSg.addIngressRule(appSg, ec2.Port.tcp(3306));
+
+    // 앱 컨테이너가 인스턴스 프로파일로 Secrets Manager / S3 접근 (기존 taskRole 과 동등 권한)
+    // + SSM(원격 관리·배포·RDS 터널 = bastion 대체) + ECR pull
+    const appRole = new iam.Role(this, 'AppEc2Role', {
+      roleName: 'IGRUS-Web-App-EC2-ROLE',
+      assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
+        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonEC2ContainerRegistryReadOnly'),
+        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonS3FullAccess'),
+      ],
+    });
+    prodSecret.grantRead(appRole);
+
+    const userData = ec2.UserData.forLinux();
+    userData.addCommands(
+      `set -euxo pipefail
+
+# ── swap 5GB — RAM 2GB 하드 OOM 방지 안전망 (rationale §4, 상시 의존 아님) ──
+fallocate -l 5G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile none swap sw 0 0' >> /etc/fstab
+sysctl -w vm.swappiness=10
+echo 'vm.swappiness=10' >> /etc/sysctl.conf
+
+# ── Docker + compose v2 + ECR credential helper (인스턴스 롤로 무기한 pull) ──
+dnf install -y docker amazon-ecr-credential-helper
+systemctl enable --now docker
+mkdir -p /usr/local/lib/docker/cli-plugins
+curl -fsSL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 \\
+  -o /usr/local/lib/docker/cli-plugins/docker-compose
+chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+mkdir -p /opt/igrus/.docker
+cat > /opt/igrus/.docker/config.json <<'DOCKERCFG'
+{ "credsStore": "ecr-login" }
+DOCKERCFG
+
+# ── Caddy: 자동 Let's Encrypt TLS + 리버스 프록시 (ALB+ACM 대체) ──
+# api.igrus.co.kr 인증서는 DNS cutover 전까지 발급 실패(백오프 재시도)가 정상.
+# cutover 직후 'docker compose restart caddy' 로 즉시 재발급 (런북 참조).
+cat > /opt/igrus/Caddyfile <<'CADDYFILE'
+api.igrus.co.kr, ec2.igrus.co.kr {
+	encode gzip
+	reverse_proxy app:8080
+}
+CADDYFILE
+
+cat > /opt/igrus/.env <<'ENVFILE'
+IMAGE_TAG=${INITIAL_IMAGE_TAG}
+ENVFILE
+
+cat > /opt/igrus/docker-compose.yml <<'COMPOSE'
+services:
+  caddy:
+    image: caddy:2.10
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /opt/igrus/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+  app:
+    image: ${ECR_IMAGE_REPO}:\${IMAGE_TAG}
+    restart: unless-stopped
+    environment:
+      SPRING_ACTIVE_PROFILE: prod
+      SPRING_DATASOURCE_URL: jdbc:mysql://${prodDb.dbInstanceEndpointAddress}:3306/igrus_web
+      JAVA_TOOL_OPTIONS: -Xmx1g
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+volumes:
+  caddy_data:
+  caddy_config:
+COMPOSE
+
+# ── 배포 스크립트 (GitHub Actions 가 SSM RunCommand 로 호출) ──
+cat > /usr/local/bin/igrus-deploy <<'DEPLOY'
+#!/bin/bash
+set -euo pipefail
+TAG="\${1:?usage: igrus-deploy <image-tag>}"
+export DOCKER_CONFIG=/opt/igrus/.docker
+cd /opt/igrus
+sed -i "s|^IMAGE_TAG=.*|IMAGE_TAG=\${TAG}|" .env
+docker compose pull app
+docker compose up -d app
+docker image prune -f
+DEPLOY
+chmod +x /usr/local/bin/igrus-deploy
+
+export DOCKER_CONFIG=/opt/igrus/.docker
+cd /opt/igrus
+docker compose up -d`,
     );
 
-    // ── S3 file-storage 버킷 ×2 (AES256 + public 전체 차단) ──
+    const appInstance = new ec2.Instance(this, 'AppEc2', {
+      instanceName: 'IGRUS-Web-App-EC2',
+      vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.SMALL),
+      machineImage: ec2.MachineImage.latestAmazonLinux2023({ cachedInContext: true }),
+      securityGroup: appSg,
+      role: appRole,
+      userData,
+      // user-data 는 부팅 1회 실행 → 수정 시 인스턴스 교체로 재현 (EIP/DNS 는 유지됨)
+      userDataCausesReplacement: true,
+      blockDevices: [
+        {
+          deviceName: '/dev/xvda',
+          // 30GB: OS ~3 + swap 5 + 이미지/로그 누적 헤드룸 (디스크 full 장애 방지)
+          volume: ec2.BlockDeviceVolume.ebs(30, {
+            volumeType: ec2.EbsDeviceVolumeType.GP3,
+            encrypted: true,
+          }),
+        },
+      ],
+    });
+
+    // 컨테이너(브리지 네트워크 = 홉 +1)가 IMDSv2 로 인스턴스 롤 자격증명을 읽도록 hop limit 2
+    const imdsLt = new ec2.CfnLaunchTemplate(this, 'AppEc2ImdsLt', {
+      launchTemplateData: {
+        metadataOptions: { httpTokens: 'required', httpPutResponseHopLimit: 2 },
+      },
+    });
+    const cfnAppInstance = appInstance.node.defaultChild as ec2.CfnInstance;
+    cfnAppInstance.launchTemplate = {
+      launchTemplateId: imdsLt.ref,
+      version: imdsLt.attrLatestVersionNumber,
+    };
+
+    // 퍼블릭 IPv4 5~6개 → EIP 1개 (인스턴스 교체 시에도 IP 불변)
+    const appEip = new ec2.CfnEIP(this, 'AppEip', {
+      domain: 'vpc',
+      tags: [{ key: 'Name', value: 'IGRUS-Web-App-EIP' }],
+    });
+    new ec2.CfnEIPAssociation(this, 'AppEipAssoc', {
+      allocationId: appEip.attrAllocationId,
+      instanceId: appInstance.instanceId,
+    });
+
+    // 검증용 도메인: cutover 전에 EC2 경로(Caddy TLS + 앱 + RDS)를 실도메인으로 점검
+    new route53.ARecord(this, 'AppEc2Alias', {
+      zone,
+      recordName: 'ec2',
+      target: route53.RecordTarget.fromIpAddresses(appEip.ref),
+      ttl: cdk.Duration.seconds(60),
+    });
+
+    if (CUTOVER) {
+      // cutover: 실운영 도메인을 ALB alias → EC2 EIP 로 전환 (TTL 짧게 = 빠른 롤백)
+      new route53.ARecord(this, 'ApiAlias', {
+        zone,
+        recordName: 'api',
+        target: route53.RecordTarget.fromIpAddresses(appEip.ref),
+        ttl: cdk.Duration.seconds(60),
+      });
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // 레거시 (v2 Fargate + ALB) — cleanup(phase 3) 전까지 롤백 경로로 유지
+    // ══════════════════════════════════════════════════════════════════
+    if (LEGACY) {
+      // ── 보안그룹 (이름/규칙 운영과 동일, 이름만 -v2) ──
+      const albSg = new ec2.SecurityGroup(this, 'AlbSg', {
+        vpc,
+        securityGroupName: 'IGRUS-WEB-ALB-SG-v2',
+        description: 'IGRUS-WEB-ALB-SG',
+        allowAllOutbound: true,
+      });
+      [80, 443, 8080].forEach((p) => albSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(p)));
+
+      const ecsSg = new ec2.SecurityGroup(this, 'EcsSg', {
+        vpc,
+        securityGroupName: 'igrus-web-server-ecs-service-sg-v2',
+        description: 'igrus-web-server-ecs-service-sg',
+        allowAllOutbound: true,
+      });
+      ecsSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(8080));
+
+      const bastionSg = new ec2.SecurityGroup(this, 'BastionSg', {
+        vpc,
+        securityGroupName: 'launch-wizard-1-v2',
+        description: 'launch-wizard-1',
+        allowAllOutbound: true,
+      });
+      bastionSg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(22));
+
+      rdsSg.addIngressRule(ecsSg, ec2.Port.tcp(3306));
+      rdsSg.addIngressRule(bastionSg, ec2.Port.tcp(3306));
+
+      // ── IAM 역할 (운영 prod 역할을 prod/staging 공용 사용, 이름만 -v2) ──
+      const taskRole = new iam.Role(this, 'TaskRole', {
+        roleName: 'igrus-web-server-prod-ecs-task-role-v2',
+        assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
+        managedPolicies: [
+          iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonS3FullAccess'),
+          iam.ManagedPolicy.fromAwsManagedPolicyName('AWSSecretsManagerClientReadOnlyAccess'),
+        ],
+      });
+      const executionRole = new iam.Role(this, 'ExecutionRole', {
+        roleName: 'igrus-web-server-prod-ecs-task-execution-role-v2',
+        assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
+        managedPolicies: [
+          iam.ManagedPolicy.fromAwsManagedPolicyName(
+            'service-role/AmazonECSTaskExecutionRolePolicy',
+          ),
+          iam.ManagedPolicy.fromAwsManagedPolicyName('AWSSecretsManagerClientReadOnlyAccess'),
+        ],
+      });
+
+      // ── ECS 클러스터 (FARGATE / FARGATE_SPOT) ──
+      const cluster = new ecs.Cluster(this, 'Cluster', {
+        clusterName: 'IGRUS-WEB-ECS-Cluster-v2',
+        vpc,
+        enableFargateCapacityProviders: true,
+      });
+
+      const ctx: SharedCtx = { vpc, cluster, ecsSg, defaultSg, taskRole, executionRole };
+
+      // ── 운영(prod) 앱 환경 ──
+      const prodService = this.addEcsService(
+        {
+          idPrefix: 'Prod',
+          appSecret: prodSecret,
+          springProfile: 'prod',
+          serviceName: 'igrus-web-server-ecs-service-v2',
+          family: 'igrus-web-server-task-def-v2',
+          containerName: 'IGRUS-WEB-SPRING-SERVER',
+          image: `${ECR_IMAGE_REPO}:${INITIAL_IMAGE_TAG}`,
+          logGroupName: '/ecs/igrus-web-server-task-def-v2',
+          attachDefaultSgToService: true,
+          desiredCount: CUTOVER ? 0 : 1, // cutover 후 중지 (롤백 시 1로 원복)
+          rdsDbName: 'igrus_web',
+          db: prodDb,
+        },
+        ctx,
+      );
+
+      // ── 스테이징(staging) 앱 환경 ──
+      const stagingSecret = secretsmanager.Secret.fromSecretNameV2(
+        this,
+        'StagingAppSecret',
+        'igrus/web/server/staging',
+      );
+      const stagingDb = this.addDatabase(
+        {
+          idPrefix: 'Staging',
+          rdsId: 'igrus-web-staging-mysql-rds-v2',
+          rdsVersion: rds.MysqlEngineVersion.of('8.4.7', '8.4'),
+          rdsSnapshotIdentifier: 'igrus-web-staging-mysql-rds-v2seed-20260629',
+          rdsPubliclyAccessible: false, // 실 PII 복원이라 private
+          rdsBackupDays: 1,
+          instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
+        },
+        vpc,
+        [rdsSg, defaultSg],
+      );
+      const stagingService = this.addEcsService(
+        {
+          idPrefix: 'Staging',
+          appSecret: stagingSecret,
+          springProfile: 'staging',
+          serviceName: 'igrus-web-server-staging-task-def-service-v2',
+          family: 'igrus-web-server-staging-task-def-v2',
+          containerName: 'IGRUS-WEB-SPRING-STAGING-SERVER',
+          image:
+            '218736972976.dkr.ecr.ap-northeast-2.amazonaws.com/igrus/web/staging/spring:6b34009e2deac8c65c6d31f4d62c34a07343a8f7',
+          logGroupName: '/ecs/igrus-web-server-staging-task-def-v2',
+          attachDefaultSgToService: false,
+          desiredCount: 0, // staging 중지(비용 절감). 필요 시 1로 올려 재배포
+          rdsDbName: 'igrus_web_staging',
+          db: stagingDb,
+        },
+        ctx,
+      );
+
+      // ── ALB-v2 + 인증서 + 3 리스너 (운영 ALB 와 동일 구조) ──
+      const alb = new elbv2.ApplicationLoadBalancer(this, 'Alb', {
+        loadBalancerName: 'IGRUS-Web-ALB-v2',
+        vpc,
+        internetFacing: true,
+        securityGroup: albSg,
+        vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+      });
+      alb.addSecurityGroup(defaultSg);
+
+      const cloneCert = new acm.Certificate(this, 'CloneCert', {
+        domainName: 'clone.igrus.co.kr',
+        validation: acm.CertificateValidation.fromDns(zone),
+      });
+      const stagingCloneCert = new acm.Certificate(this, 'StagingCloneCert', {
+        domainName: 'staging-clone.igrus.co.kr',
+        validation: acm.CertificateValidation.fromDns(zone),
+      });
+
+      // cutover 로 v2 ALB 가 실제 운영 도메인도 서비스 → 기존 운영 인증서 참조(SNI 추가)
+      const apiCert = acm.Certificate.fromCertificateArn(
+        this,
+        'ApiCert',
+        'arn:aws:acm:ap-northeast-2:218736972976:certificate/189f0561-f2d4-4cf8-821d-0a0012ce9aaa', // api.igrus.co.kr
+      );
+      const stagingApiCert = acm.Certificate.fromCertificateArn(
+        this,
+        'StagingApiCert',
+        'arn:aws:acm:ap-northeast-2:218736972976:certificate/6280a8cb-0941-48b3-b6e1-1d75f4666e10', // staging-api.igrus.co.kr
+      );
+
+      const prodTg = new elbv2.ApplicationTargetGroup(this, 'ProdTg', {
+        targetGroupName: 'IGRUS-Web-Spring-ECS-TG-v2',
+        vpc,
+        port: 8080,
+        protocol: elbv2.ApplicationProtocol.HTTP,
+        targetType: elbv2.TargetType.IP,
+        targets: [
+          prodService.loadBalancerTarget({
+            containerName: 'IGRUS-WEB-SPRING-SERVER',
+            containerPort: 8080,
+          }),
+        ],
+        healthCheck: { path: '/', protocol: elbv2.Protocol.HTTP, healthyHttpCodes: '200' },
+      });
+
+      const stagingTg = new elbv2.ApplicationTargetGroup(this, 'StagingTg', {
+        // AWS TG 이름 최대 32자 제한 → 'Staging' 을 'Stg' 로 축약 (원본: IGRUS-Web-Spring-Staging-ECS-TG)
+        targetGroupName: 'IGRUS-Web-Spring-Stg-ECS-TG-v2',
+        vpc,
+        port: 80,
+        protocol: elbv2.ApplicationProtocol.HTTP,
+        targetType: elbv2.TargetType.IP,
+        targets: [
+          stagingService.loadBalancerTarget({
+            containerName: 'IGRUS-WEB-SPRING-STAGING-SERVER',
+            containerPort: 8080,
+          }),
+        ],
+        healthCheck: { path: '/', protocol: elbv2.Protocol.HTTP, healthyHttpCodes: '200' },
+      });
+
+      alb.addListener('Prod443', {
+        port: 443,
+        protocol: elbv2.ApplicationProtocol.HTTPS,
+        certificates: [cloneCert, apiCert], // clone.* (default) + api.igrus.co.kr (SNI)
+        sslPolicy: SSL_POLICY,
+        defaultTargetGroups: [prodTg],
+      });
+      alb.addListener('Staging8080', {
+        port: 8080,
+        protocol: elbv2.ApplicationProtocol.HTTPS,
+        certificates: [stagingCloneCert, stagingApiCert], // staging-clone.* + staging-api.igrus.co.kr
+        sslPolicy: SSL_POLICY,
+        defaultTargetGroups: [stagingTg],
+      });
+      alb.addListener('Staging8000', {
+        port: 8000,
+        protocol: elbv2.ApplicationProtocol.HTTP,
+        defaultTargetGroups: [stagingTg],
+      });
+
+      // ── Route53 A레코드 (alias) ──
+      new route53.ARecord(this, 'CloneAlias', {
+        zone,
+        recordName: 'clone',
+        target: route53.RecordTarget.fromAlias(new route53targets.LoadBalancerTarget(alb)),
+      });
+      new route53.ARecord(this, 'StagingCloneAlias', {
+        zone,
+        recordName: 'staging-clone',
+        target: route53.RecordTarget.fromAlias(new route53targets.LoadBalancerTarget(alb)),
+      });
+      if (!CUTOVER) {
+        // cutover 전: 실제 운영 도메인은 v2 ALB 로 (기존 콘솔 레코드를 코드 관리로 전환)
+        new route53.ARecord(this, 'ApiAlias', {
+          zone,
+          recordName: 'api',
+          target: route53.RecordTarget.fromAlias(new route53targets.LoadBalancerTarget(alb)),
+        });
+      }
+      new route53.ARecord(this, 'StagingApiAlias', {
+        zone,
+        recordName: 'staging-api',
+        target: route53.RecordTarget.fromAlias(new route53targets.LoadBalancerTarget(alb)),
+      });
+
+      // ── SSM Bastion EC2 (운영 IGRUS-Web-RDS-SSM-EC2 복제) — cleanup 시 앱 EC2 가 대체 ──
+      const ssmRole = new iam.Role(this, 'SsmRole', {
+        roleName: 'EC2_SSM_ROLE-v2',
+        assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+        managedPolicies: [
+          iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
+        ],
+      });
+      new ec2.Instance(this, 'Bastion', {
+        instanceName: 'IGRUS-Web-RDS-SSM-EC2-v2',
+        vpc,
+        vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+        instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
+        machineImage: ec2.MachineImage.genericLinux({ 'ap-northeast-2': 'ami-0092e0c93f74c293a' }),
+        securityGroup: bastionSg,
+        role: ssmRole,
+        blockDevices: [
+          {
+            deviceName: '/dev/xvda',
+            volume: ec2.BlockDeviceVolume.ebs(8, { volumeType: ec2.EbsDeviceVolumeType.GP3 }),
+          },
+        ],
+      });
+
+      new cdk.CfnOutput(this, 'ProdCloneUrl', { value: 'https://clone.igrus.co.kr' });
+      new cdk.CfnOutput(this, 'StagingCloneUrl', { value: 'https://staging-clone.igrus.co.kr:8080' });
+    }
+
+    // ── S3 file-storage 버킷 ×2 (AES256 + public 전체 차단) — 아키텍처 무관 상시 유지 ──
     // 웹/정적 버킷(igrus-web-bucket)은 CloudFront(프론트) 전용이며 백엔드가 접근하지 않으므로
     // v2 를 만들지 않는다. 백엔드가 실제 사용하는 file-storage 버킷만 v2 로 복제한다.
     this.bucket('FileBucketProd', 'igrus-web-file-storage-bucket-v2', true, [
@@ -193,111 +568,6 @@ export class IgrusWebV2Stack extends cdk.Stack {
       'https://staging-api.igrus.co.kr',
     ]);
 
-    // ── ALB-v2 + 인증서 + 3 리스너 (운영 ALB 와 동일 구조) ──
-    const alb = new elbv2.ApplicationLoadBalancer(this, 'Alb', {
-      loadBalancerName: 'IGRUS-Web-ALB-v2',
-      vpc,
-      internetFacing: true,
-      securityGroup: albSg,
-      vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
-    });
-    alb.addSecurityGroup(defaultSg);
-
-    const cloneCert = new acm.Certificate(this, 'CloneCert', {
-      domainName: 'clone.igrus.co.kr',
-      validation: acm.CertificateValidation.fromDns(zone),
-    });
-    const stagingCloneCert = new acm.Certificate(this, 'StagingCloneCert', {
-      domainName: 'staging-clone.igrus.co.kr',
-      validation: acm.CertificateValidation.fromDns(zone),
-    });
-
-    // cutover 로 v2 ALB 가 실제 운영 도메인도 서비스 → 기존 운영 인증서 참조(SNI 추가)
-    const apiCert = acm.Certificate.fromCertificateArn(
-      this,
-      'ApiCert',
-      'arn:aws:acm:ap-northeast-2:218736972976:certificate/189f0561-f2d4-4cf8-821d-0a0012ce9aaa', // api.igrus.co.kr
-    );
-    const stagingApiCert = acm.Certificate.fromCertificateArn(
-      this,
-      'StagingApiCert',
-      'arn:aws:acm:ap-northeast-2:218736972976:certificate/6280a8cb-0941-48b3-b6e1-1d75f4666e10', // staging-api.igrus.co.kr
-    );
-
-    const prodTg = new elbv2.ApplicationTargetGroup(this, 'ProdTg', {
-      targetGroupName: 'IGRUS-Web-Spring-ECS-TG-v2',
-      vpc,
-      port: 8080,
-      protocol: elbv2.ApplicationProtocol.HTTP,
-      targetType: elbv2.TargetType.IP,
-      targets: [
-        prod.service.loadBalancerTarget({
-          containerName: 'IGRUS-WEB-SPRING-SERVER',
-          containerPort: 8080,
-        }),
-      ],
-      healthCheck: { path: '/', protocol: elbv2.Protocol.HTTP, healthyHttpCodes: '200' },
-    });
-
-    const stagingTg = new elbv2.ApplicationTargetGroup(this, 'StagingTg', {
-      // AWS TG 이름 최대 32자 제한 → 'Staging' 을 'Stg' 로 축약 (원본: IGRUS-Web-Spring-Staging-ECS-TG)
-      targetGroupName: 'IGRUS-Web-Spring-Stg-ECS-TG-v2',
-      vpc,
-      port: 80,
-      protocol: elbv2.ApplicationProtocol.HTTP,
-      targetType: elbv2.TargetType.IP,
-      targets: [
-        staging.service.loadBalancerTarget({
-          containerName: 'IGRUS-WEB-SPRING-STAGING-SERVER',
-          containerPort: 8080,
-        }),
-      ],
-      healthCheck: { path: '/', protocol: elbv2.Protocol.HTTP, healthyHttpCodes: '200' },
-    });
-
-    alb.addListener('Prod443', {
-      port: 443,
-      protocol: elbv2.ApplicationProtocol.HTTPS,
-      certificates: [cloneCert, apiCert], // clone.* (default) + api.igrus.co.kr (SNI)
-      sslPolicy: SSL_POLICY,
-      defaultTargetGroups: [prodTg],
-    });
-    alb.addListener('Staging8080', {
-      port: 8080,
-      protocol: elbv2.ApplicationProtocol.HTTPS,
-      certificates: [stagingCloneCert, stagingApiCert], // staging-clone.* + staging-api.igrus.co.kr
-      sslPolicy: SSL_POLICY,
-      defaultTargetGroups: [stagingTg],
-    });
-    alb.addListener('Staging8000', {
-      port: 8000,
-      protocol: elbv2.ApplicationProtocol.HTTP,
-      defaultTargetGroups: [stagingTg],
-    });
-
-    // ── Route53 A레코드 (alias) ──
-    new route53.ARecord(this, 'CloneAlias', {
-      zone,
-      recordName: 'clone',
-      target: route53.RecordTarget.fromAlias(new route53targets.LoadBalancerTarget(alb)),
-    });
-    new route53.ARecord(this, 'StagingCloneAlias', {
-      zone,
-      recordName: 'staging-clone',
-      target: route53.RecordTarget.fromAlias(new route53targets.LoadBalancerTarget(alb)),
-    });
-    // cutover: 실제 운영 도메인을 v2 ALB 로 (기존 콘솔 레코드를 코드 관리로 전환)
-    new route53.ARecord(this, 'ApiAlias', {
-      zone,
-      recordName: 'api',
-      target: route53.RecordTarget.fromAlias(new route53targets.LoadBalancerTarget(alb)),
-    });
-    new route53.ARecord(this, 'StagingApiAlias', {
-      zone,
-      recordName: 'staging-api',
-      target: route53.RecordTarget.fromAlias(new route53targets.LoadBalancerTarget(alb)),
-    });
-
     // project.igrus.co.kr → Vercel(igrus-project). ALB/백엔드와 무관한 프론트 프로젝트지만
     // igrus.co.kr 존 DNS 를 한 곳(IaC)에서 관리하기 위해 코드화. (기존 CLI 레코드는 deleteExisting 으로 흡수)
     new route53.CnameRecord(this, 'ProjectVercelCname', {
@@ -308,66 +578,44 @@ export class IgrusWebV2Stack extends cdk.Stack {
       deleteExisting: true,
     });
 
-    // ── SSM Bastion EC2 (운영 IGRUS-Web-RDS-SSM-EC2 복제) ──
-    const ssmRole = new iam.Role(this, 'SsmRole', {
-      roleName: 'EC2_SSM_ROLE-v2',
-      assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
-      managedPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore')],
+    new cdk.CfnOutput(this, 'AppEc2ValidationUrl', { value: 'https://ec2.igrus.co.kr' });
+    new cdk.CfnOutput(this, 'AppEc2Eip', { value: appEip.ref });
+    new cdk.CfnOutput(this, 'AppEc2InstanceId', { value: appInstance.instanceId });
+    new cdk.CfnOutput(this, 'AppEc2SsmSession', {
+      value: `aws ssm start-session --target ${appInstance.instanceId}`,
     });
-    new ec2.Instance(this, 'Bastion', {
-      instanceName: 'IGRUS-Web-RDS-SSM-EC2-v2',
-      vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
-      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
-      machineImage: ec2.MachineImage.genericLinux({ 'ap-northeast-2': 'ami-0092e0c93f74c293a' }),
-      securityGroup: bastionSg,
-      role: ssmRole,
-      blockDevices: [
-        {
-          deviceName: '/dev/xvda',
-          volume: ec2.BlockDeviceVolume.ebs(8, { volumeType: ec2.EbsDeviceVolumeType.GP3 }),
-        },
-      ],
-    });
-
-    new cdk.CfnOutput(this, 'ProdCloneUrl', { value: 'https://clone.igrus.co.kr' });
-    new cdk.CfnOutput(this, 'StagingCloneUrl', { value: 'https://staging-clone.igrus.co.kr:8080' });
   }
 
-  /** 한 앱 환경(RDS + log + taskdef + service)을 생성. 시크릿은 기존 것을 참조 */
-  private addAppEnvironment(
-    cfg: AppEnvConfig,
-    ctx: SharedCtx,
-  ): { service: ecs.FargateService; db: rds.IDatabaseInstance } {
-    // 기존 Secrets Manager 시크릿 참조 (앱이 spring.config.import 로 그대로 읽음)
-    const appSecret = secretsmanager.Secret.fromSecretNameV2(
-      this,
-      `${cfg.idPrefix}AppSecret`,
-      cfg.existingSecretName,
-    );
-
-    const logGroup = new logs.LogGroup(this, `${cfg.idPrefix}LogGroup`, {
-      logGroupName: cfg.logGroupName,
-      retention: logs.RetentionDays.INFINITE,
-    });
-
-    // v2 RDS: 기존 DB 스냅샷에서 복원 → 데이터 그대로 복제.
+  /** RDS 인스턴스 생성 (기존 DB 스냅샷에서 복원 → 데이터 그대로 복제) */
+  private addDatabase(
+    cfg: DbConfig,
+    vpc: ec2.IVpc,
+    securityGroups: ec2.ISecurityGroup[],
+  ): rds.IDatabaseInstance {
     // credentials 미지정 → 스냅샷의 마스터 자격증명(=기존 시크릿의 datasource 값)을 그대로 유지
-    const db = new rds.DatabaseInstanceFromSnapshot(this, `${cfg.idPrefix}Rds`, {
+    return new rds.DatabaseInstanceFromSnapshot(this, `${cfg.idPrefix}Rds`, {
       snapshotIdentifier: cfg.rdsSnapshotIdentifier,
       instanceIdentifier: cfg.rdsId,
       engine: rds.DatabaseInstanceEngine.mysql({ version: cfg.rdsVersion }),
-      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
+      instanceType: cfg.instanceType,
       // 명시 안 하면 CDK 기본값 100GiB 로 부풀려짐 → 원본(v1)과 동일하게 20GB 고정
       allocatedStorage: 20,
-      vpc: ctx.vpc,
+      vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
       publiclyAccessible: cfg.rdsPubliclyAccessible,
       storageType: rds.StorageType.GP2,
       multiAz: false,
-      securityGroups: [ctx.rdsSg, ctx.defaultSg],
+      securityGroups,
       backupRetention: cdk.Duration.days(cfg.rdsBackupDays),
       removalPolicy: cdk.RemovalPolicy.SNAPSHOT,
+    });
+  }
+
+  /** 한 앱 환경(log + taskdef + service)을 생성. 시크릿은 기존 것을 참조 */
+  private addEcsService(cfg: AppEnvConfig, ctx: SharedCtx): ecs.FargateService {
+    const logGroup = new logs.LogGroup(this, `${cfg.idPrefix}LogGroup`, {
+      logGroupName: cfg.logGroupName,
+      retention: logs.RetentionDays.INFINITE,
     });
 
     const taskDef = new ecs.FargateTaskDefinition(this, `${cfg.idPrefix}TaskDef`, {
@@ -377,7 +625,7 @@ export class IgrusWebV2Stack extends cdk.Stack {
       taskRole: ctx.taskRole,
       executionRole: ctx.executionRole,
     });
-    appSecret.grantRead(ctx.taskRole); // 앱이 런타임에 기존 시크릿 읽기
+    cfg.appSecret.grantRead(ctx.taskRole); // 앱이 런타임에 기존 시크릿 읽기
 
     taskDef.addContainer(`${cfg.idPrefix}Spring`, {
       containerName: cfg.containerName,
@@ -389,14 +637,14 @@ export class IgrusWebV2Stack extends cdk.Stack {
       // (스냅샷 복원 RDS 는 마스터 비번이 기존과 동일하므로 별도 주입 불필요)
       environment: {
         SPRING_ACTIVE_PROFILE: cfg.springProfile,
-        SPRING_DATASOURCE_URL: `jdbc:mysql://${db.dbInstanceEndpointAddress}:3306/${cfg.rdsDbName}`,
+        SPRING_DATASOURCE_URL: `jdbc:mysql://${cfg.db.dbInstanceEndpointAddress}:3306/${cfg.rdsDbName}`,
         // S3 버킷명은 기존 시크릿(app.storage.s3.bucket-name)에서 직접 v2 버킷으로 지정됨
       },
     });
 
     const serviceSgs = cfg.attachDefaultSgToService ? [ctx.ecsSg, ctx.defaultSg] : [ctx.ecsSg];
 
-    const service = new ecs.FargateService(this, `${cfg.idPrefix}Service`, {
+    return new ecs.FargateService(this, `${cfg.idPrefix}Service`, {
       serviceName: cfg.serviceName,
       cluster: ctx.cluster,
       taskDefinition: taskDef,
@@ -412,8 +660,6 @@ export class IgrusWebV2Stack extends cdk.Stack {
       maxHealthyPercent: 200,
       circuitBreaker: { rollback: true },
     });
-
-    return { service, db };
   }
 
   /** S3 버킷 헬퍼 (AES256 + public 전체 차단, 선택적 CORS) */

--- a/infra/cdk/lib/igrus-web-v2-stack.ts
+++ b/infra/cdk/lib/igrus-web-v2-stack.ts
@@ -24,7 +24,7 @@ const SSL_POLICY = 'ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09' as elbv2.SslPoli
  *     ALB/Fargate 는 롤백 경로로 유지 (플래그를 1로 되돌리면 원복).
  * 3 — cleanup: ALB/ECS/bastion/staging RDS 제거(스냅샷 보존), prod RDS t4g.micro 전환.
  */
-const MIGRATION_PHASE: 1 | 2 | 3 = 1;
+const MIGRATION_PHASE: 1 | 2 | 3 = 2;
 const CUTOVER = MIGRATION_PHASE >= 2; // api 도메인이 EC2 를 향하고 Fargate 는 중지
 const LEGACY = MIGRATION_PHASE <= 2; // Fargate/ALB/bastion/staging 자원 유지 여부
 

--- a/infra/cdk/lib/igrus-web-v2-stack.ts
+++ b/infra/cdk/lib/igrus-web-v2-stack.ts
@@ -22,9 +22,11 @@ const SSL_POLICY = 'ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09' as elbv2.SslPoli
  *     ec2.igrus.co.kr 로 EC2 경로 검증. api.igrus.co.kr 은 아직 ALB.
  * 2 — cutover: api.igrus.co.kr A레코드 → EC2 EIP, prod Fargate desiredCount 0.
  *     ALB/Fargate 는 롤백 경로로 유지 (플래그를 1로 되돌리면 원복).
- * 3 — cleanup: ALB/ECS/bastion/staging RDS 제거(스냅샷 보존), prod RDS t4g.micro 전환.
+ * 2.5 — cleanup: 미사용 레거시 제거 — ALB(+IPv4 4개)/ECS/bastion/staging RDS(스냅샷 보존).
+ *       라이브 경로(EC2→prod RDS) 무변경 = 무중단.
+ * 3 — prod RDS t3.micro → t4g.micro (ARM −10%, 짧은 재부팅 다운타임 수반).
  */
-const MIGRATION_PHASE: 1 | 2 | 3 = 2;
+const MIGRATION_PHASE: 1 | 2 | 2.5 | 3 = 2.5;
 const CUTOVER = MIGRATION_PHASE >= 2; // api 도메인이 EC2 를 향하고 Fargate 는 중지
 const LEGACY = MIGRATION_PHASE <= 2; // Fargate/ALB/bastion/staging 자원 유지 여부
 


### PR DESCRIPTION
# PR: Fargate+ALB → 단일 EC2+Caddy 전환 (비용 −67%)

> `infra-ec2-caddy` → `main`. (account 218736972976 / ap-northeast-2)
> 근거 문서: `docs/infra/ec2-caddy-migration-rationale.md` (옵션 A)

## 개요
상시 저부하(평균 CPU <1%) 단일 컨테이너 워크로드에 과대했던 **Fargate+ALB+퍼블릭 IPv4 고정비를 제거**하고,
동일 ECR 이미지를 **단일 EC2 t3.small 위 Docker + Caddy(자동 Let's Encrypt TLS)** 로 전환한 작업입니다.
`MIGRATION_PHASE` 플래그(1→2→2.5→3)로 단계 배포하며, **phase 2.5까지 배포·검증 완료** 상태입니다.

## 주요 변경 (커밋 3개)
| 영역 | 내용 |
| --- | --- |
| **CDK 스택** | EC2 t3.small(`IGRUS-Web-App-EC2`) + EIP + SG + IAM 롤 + user-data(swap 5GB·Docker/compose·ECR helper·Caddy·배포 스크립트) 코드화. IMDSv2 hop-limit 2, 30GB gp3 암호화 |
| **단계 플래그** | phase 1 병행 프로비저닝 → 2 cutover(api→EIP, Fargate 0) → 2.5 레거시 제거 → 3 RDS t4g(대기) |
| **prod CD** | ECS 배포 → **ECR push + SSM `igrus-deploy <tag>`** 로 교체, 헬스체크 `/` (actuator 미노출 확인) |
| **staging CD** | 배포 대상(ECS) 소멸 → 자동 트리거 제거(workflow_dispatch만 잔존) |
| **문서** | `docs/infra/ec2-migration-runbook.md` 신규 (phase별 절차·검증·롤백) |

## 현재 AWS 상태 (배포·검증 완료)
- ✅ 실서비스: `api.igrus.co.kr` → EIP `54.116.147.223` (EC2 `i-0ac01b59c6ab8feeb`) — 200, Let's Encrypt 정상
- 🗑️ 삭제됨: ALB-v2(+IPv4 4개) · v2 ECS · v2 staging RDS(최종 스냅샷 보존) · bastion-v2 · **v1 잔재 전부**(ECS/RDS×2/bastion, 런북 수동 실행)
- 💰 월 ~$150(v1 포함 실질) → **~$49** (phase 3 후 ~$47)

## IaC 범위 밖 / 후속 작업
1. GH Actions 롤(`IGRUS-Web-Backend-Github-Actions-Role`)에 SSM 배포 인라인 정책 부착 (런북 §Phase1)
2. 다음 릴리즈에서 새 CD 파이프라인 첫 주행 확인
3. phase 3: prod RDS `t4g.micro` 전환 (재부팅 수 분, 원할 때)
4. GitHub `production` env의 ECS 관련 vars 4개 정리 (미사용)

## 트레이드오프 (rationale §6·7)
- SPOF/멀티AZ 상실 → 원래도 단일 태스크(명목 HA), EC2 auto-recovery로 완화
- 배포 시 ~60초 재기동 다운타임 → 트래픽 ≈0 수용, 필요 시 blue-green 후속

## 검증
- tsc 통과 / phase 1·2·2.5 순차 배포 성공
- EC2 경로 실데이터 응답이 기존 Fargate와 동일함 확인 (pinned-posts/events)
- cutover 후 `api.igrus.co.kr` 200 + TLS 정상 + Fargate desired=0
- 레거시 삭제 후에도 서비스 무중단 (api 200)

## 체크리스트
- [x] 빌드/타입체크 통과
- [x] 시크릿 미포함
- [ ] (머지 전/직후) GH Actions 롤 SSM 정책 부착
- [ ] 다음 릴리즈로 CD 검증
