### PR TITLE
feat(play): 제작자 다이얼로그에 승인작 목록 표시

### DIFF
--- a/frontend/docs/testing/auth-test-guide.md
+++ b/frontend/docs/testing/auth-test-guide.md
@@ -21,18 +21,31 @@
 
 1. **가입 유형 선택 화면**: 첫 화면에서 "회원으로 가입" / "비회원으로 가입" 중 선택
    - 회원: 폼 하단(회원가입 버튼 위)에 회비 납부 안내 박스 표시 (회비 게이트 화면 제거)
-   - 비회원: 회비 안내 없이 가입. "기타" 섹션(가입 목적/관심 분야/가입 경로/가입 동기) 미노출
+   - 비회원: 회비 안내 없이 가입. 가입 목적/관심 분야/가입 경로/닉네임/자기소개 입력 영역 미노출
      - API 필수값은 프론트에서 기본값으로 전송: 관심 분야 `OTHER`, 가입 경로 `OTHER`, 가입 목적 `[]`
 2. **단일 화면 폼**: 기존 4단계(기본 정보 → 연락처 → 계정 보안 → 기타) 스텝을 제거하고 한 화면에서 모두 입력. "다음/이전" 버튼 및 스텝 인디케이터 없음
 3. **이메일 인증 수동 발송**: 이메일 입력 후 "이메일 인증하기" 버튼을 눌러야 인증 코드가 발송됨 (기존 중복 체크 통과 시 자동 발송 제거)
 4. **재발송 쿨다운 10초**: 인증 코드 재발송 대기 시간 60초 → 10초
 5. 중복(학번/이메일/전화번호) 검증은 blur 시 실시간 체크 + 제출 시 서버 에러 코드로 필드 에러 표시
 
+## 회원가입 필드 순서 변경 (2026-07-20)
+
+섹션 부제목(기본 정보/연락처/계정 보안/기타)을 모두 제거하고, 아래 순서의 단일 흐름으로 재배치했습니다:
+
+학번 → 이름 → **비밀번호/비밀번호 확인** → 성별 → 학년 → 재학상태 → 이메일(인증) → 전화번호 → 학과 → _(회원 전용)_ 가입 목적 → 관심 분야 → 가입 경로 → 닉네임(선택) → 자기소개(선택) → **개인정보 처리방침·이용약관 동의** → _(회원 전용)_ 회비 안내 → 제출
+
+- 비밀번호 입력을 폼 하단에서 이름 바로 다음으로 이동
+- 개인정보·이용약관 동의를 폼 중간에서 제출 버튼 바로 앞으로 이동
+- "가입 동기 (선택)" 텍스트 입력 필드 제거 (백엔드 optional 필드이므로 값 없이 전송)
+- "프로필 링크 (선택)" 입력 제거 (가입 시 입력받지 않으며, play-igrus 프로필에서 채움)
+
 **수동 테스트 체크리스트 (신규 플로우)**:
 
 - [ ] 가입 유형 선택 화면에서 두 버튼 모두 클릭 가능
-- [ ] 회원 선택 시: 기타 섹션 표시 + 회원가입 버튼 위 회비 안내 박스(계좌 복사 동작) 표시
-- [ ] 비회원 선택 시: 기타 섹션·회비 안내 미표시, 가입 성공 (Network: `POST .../signup` Body에 `interests: ["OTHER"]`, `joinRoute: "OTHER"`, `wishes: []`)
+- [ ] 회원 선택 시: 가입 목적/관심 분야/가입 경로/닉네임/자기소개 입력 영역 표시 + 회원가입 버튼 위 회비 안내 박스(계좌 복사 동작) 표시
+- [ ] 비회원 선택 시: 해당 입력 영역·회비 안내 미표시, 가입 성공 (Network: `POST .../signup` Body에 `interests: ["OTHER"]`, `joinRoute: "OTHER"`, `wishes: []`)
+- [ ] "가입 동기", "프로필 링크" 입력 필드가 더 이상 존재하지 않음
+- [ ] 개인정보 처리방침/이용약관 동의 체크박스가 제출 버튼 바로 위에 위치
 - [ ] 이메일 입력/도메인 변경 시 인증 메일이 자동 발송되지 않음
 - [ ] "이메일 인증하기" 클릭 시에만 발송, 재발송 버튼 10초 쿨다운
 - [ ] 이메일 미인증 상태로 회원가입 클릭 시 "이메일 인증을 완료해주세요." 표시
@@ -62,7 +75,6 @@ export class SignupPage {
   readonly departmentInput: Locator;
   readonly gradeInput: Locator;
   readonly genderSelect: Locator;
-  readonly motivationTextarea: Locator;
   readonly passwordInput: Locator;
   readonly passwordConfirmInput: Locator;
   readonly privacyConsentCheckbox: Locator;
@@ -89,8 +101,6 @@ export class SignupPage {
     this.departmentInput = page.getByPlaceholder("학과 (예: 컴퓨터공학과)");
     this.gradeInput = page.getByPlaceholder("학년 (1~4)");
     this.genderSelect = page.locator('select[name="gender"]');
-    this.motivationTextarea =
-      page.getByPlaceholder("동아리 가입 동기를 작성해주세요");
     this.passwordInput = page.locator('input[name="password"]').first();
     this.passwordConfirmInput = page.locator('input[name="passwordConfirm"]');
     this.privacyConsentCheckbox = page.locator('input[name="privacyConsent"]');
@@ -129,7 +139,6 @@ export class SignupPage {
     department: string;
     grade: string;
     gender: "MALE" | "FEMALE";
-    motivation: string;
     password: string;
     passwordConfirm: string;
   }) {
@@ -140,7 +149,6 @@ export class SignupPage {
     await this.departmentInput.fill(data.department);
     await this.gradeInput.fill(data.grade);
     await this.genderSelect.selectOption(data.gender);
-    await this.motivationTextarea.fill(data.motivation);
     await this.passwordInput.fill(data.password);
     await this.passwordConfirmInput.fill(data.passwordConfirm);
     await this.privacyConsentCheckbox.check();
@@ -268,7 +276,6 @@ export function generateUniqueUser() {
     department: "컴퓨터공학과",
     grade: "3",
     gender: "MALE" as const,
-    motivation: "프로그래밍에 관심이 많아서 지원합니다",
     password: "Test1234!@",
     passwordConfirm: "Test1234!@",
   };
@@ -692,14 +699,13 @@ test.describe("로그인", () => {
 2. 폼 입력:
    - 학번: `12345678`
    - 이름: `홍길동`
+   - 비밀번호: `Test1234!@`
+   - 비밀번호 확인: `Test1234!@`
+   - 성별: `남성` 선택
+   - 학년: `3`
    - 이메일: `test@inha.edu`
    - 전화번호: `010-1234-5678`
    - 학과: `컴퓨터공학과`
-   - 학년: `3`
-   - 성별: `남성` 선택
-   - 가입 동기: `프로그래밍에 관심이 많아서 지원합니다`
-   - 비밀번호: `Test1234!@`
-   - 비밀번호 확인: `Test1234!@`
    - 개인정보 동의: 체크
 3. "회원가입" 버튼 클릭
 4. **예상 결과**:

--- a/frontend/src/pages/auth/SignupPage.tsx
+++ b/frontend/src/pages/auth/SignupPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import {
@@ -9,7 +9,6 @@ import {
   Mail,
   Phone,
   Building2,
-  FileText,
   Eye,
   EyeOff,
   ChevronDown,
@@ -24,9 +23,6 @@ import {
   Copy,
   CircleCheck,
   LogIn,
-  Plus,
-  Trash2,
-  Link as LinkIcon,
 } from "lucide-react";
 import {
   useSignup,
@@ -114,25 +110,11 @@ const signupSchema = z
     customInterest: z.string().optional(),
     joinRoute: z.string().min(1, "가입 경로를 선택해주세요."),
     customJoinRoute: z.string().optional(),
-    motivation: z.string().optional(),
     nickname: z.string().max(50, "닉네임은 50자 이내여야 합니다.").optional(),
     introduction: z
       .string()
       .max(1000, "자기소개는 1000자 이내여야 합니다.")
       .optional(),
-    links: z
-      .array(
-        z.object({
-          label: z
-            .string()
-            .min(1, "라벨을 입력해주세요.")
-            .max(30, "라벨은 30자 이내여야 합니다."),
-          url: z
-            .string()
-            .regex(/^https?:\/\/.+/, "http/https 링크만 입력할 수 있습니다."),
-        }),
-      )
-      .max(10, "링크는 최대 10개까지 등록할 수 있습니다."),
     privacyConsent: z.literal(true, {
       message: "개인정보 처리방침에 동의해주세요.",
     }),
@@ -196,7 +178,6 @@ export default function SignupPage() {
 
   const {
     register,
-    control,
     handleSubmit,
     trigger,
     watch,
@@ -225,17 +206,13 @@ export default function SignupPage() {
       customInterest: "",
       joinRoute: "",
       customJoinRoute: "",
-      motivation: "",
       nickname: "",
       introduction: "",
-      links: [],
       privacyConsent: undefined as unknown as true,
       termsConsent: undefined as unknown as true,
     },
     mode: "onTouched",
   });
-
-  const linkFields = useFieldArray({ control, name: "links" });
 
   const watchedPassword = watch("password");
   const selectedWishes = watch("wishes") ?? [];
@@ -419,7 +396,6 @@ export default function SignupPage() {
         email: fullEmail,
         phoneNumber: formatPhoneNumber(data.phoneNumber),
         department: data.department,
-        motivation: data.motivation || undefined,
         gender: data.gender!,
         grade: data.grade!,
         enrollmentStatus: (enrollmentStatusToEnum[data.enrollmentStatus] ??
@@ -438,7 +414,6 @@ export default function SignupPage() {
           data.joinRoute === "기타" ? data.customJoinRoute : undefined,
         nickname: data.nickname || undefined,
         introduction: data.introduction || undefined,
-        links: data.links.length > 0 ? data.links : undefined,
         privacyConsent: data.privacyConsent,
         verificationToken,
       };
@@ -626,12 +601,7 @@ export default function SignupPage() {
             )}
 
             <form onSubmit={(e) => e.preventDefault()}>
-              {/* 기본 정보 */}
-              <div className="space-y-s4">
-                <h2 className="typo-h4 text-foreground flex items-center gap-s2 border-b border-border pb-s3">
-                  <User size={18} className="text-primary" />
-                  기본 정보
-                </h2>
+              <div className="space-y-s5">
                 {!useTempStudentId && (
                   <FormField
                     label="학번"
@@ -738,6 +708,83 @@ export default function SignupPage() {
                   </div>
                 </FormField>
 
+                <div className="rounded-r2 bg-muted/50 border border-border p-s4">
+                  <p className="typo-c1 text-muted-foreground">
+                    비밀번호는{" "}
+                    <strong className="text-foreground">
+                      영문, 숫자를 포함하여 8자 이상
+                    </strong>
+                    으로 설정해주세요.
+                  </p>
+                </div>
+
+                <FormField label="비밀번호" error={errors.password?.message}>
+                  <div className="relative">
+                    <Lock
+                      size={18}
+                      className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+                    />
+                    <Input
+                      {...register("password")}
+                      type={showPassword ? "text" : "password"}
+                      placeholder="비밀번호 입력"
+                      className="pl-10 pr-10"
+                    />
+                    <button
+                      type="button"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                    >
+                      {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </button>
+                  </div>
+                </FormField>
+
+                <FormField
+                  label="비밀번호 확인"
+                  error={errors.passwordConfirm?.message}
+                  success={
+                    passwordConfirmTouched &&
+                    !errors.passwordConfirm &&
+                    watch("passwordConfirm")
+                      ? "비밀번호가 일치합니다."
+                      : undefined
+                  }
+                >
+                  <div className="relative">
+                    <Lock
+                      size={18}
+                      className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+                    />
+                    <Input
+                      {...register("passwordConfirm", {
+                        onBlur: () => {
+                          setPasswordConfirmTouched(true);
+                          trigger("passwordConfirm");
+                        },
+                      })}
+                      type={showPasswordConfirm ? "text" : "password"}
+                      placeholder="비밀번호 재입력"
+                      className="pl-10 pr-10"
+                    />
+                    <button
+                      type="button"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() =>
+                        setShowPasswordConfirm(!showPasswordConfirm)
+                      }
+                      className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                    >
+                      {showPasswordConfirm ? (
+                        <EyeOff size={18} />
+                      ) : (
+                        <Eye size={18} />
+                      )}
+                    </button>
+                  </div>
+                </FormField>
+
                 <FormField label="성별" error={errors.gender?.message}>
                   <div className="grid grid-cols-2 gap-s3">
                     {(["MALE", "FEMALE"] as const).map((g) => (
@@ -809,59 +856,6 @@ export default function SignupPage() {
                   </div>
                 </FormField>
 
-                <div className="space-y-s3 rounded-r2 border border-border p-s4">
-                  <FormField error={errors.privacyConsent?.message}>
-                    <div className="flex items-center justify-between">
-                      <label className="flex items-center gap-s3 cursor-pointer group">
-                        <input
-                          type="checkbox"
-                          {...register("privacyConsent")}
-                          className="cursor-pointer accent-primary"
-                        />
-                        <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
-                          개인정보 처리방침에 동의합니다 (필수)
-                        </span>
-                      </label>
-                      <Link
-                        to="/privacy"
-                        target="_blank"
-                        className="text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        <ExternalLink size={16} />
-                      </Link>
-                    </div>
-                  </FormField>
-
-                  <FormField error={errors.termsConsent?.message}>
-                    <div className="flex items-center justify-between">
-                      <label className="flex items-center gap-s3 cursor-pointer group">
-                        <input
-                          type="checkbox"
-                          {...register("termsConsent")}
-                          className="cursor-pointer accent-primary"
-                        />
-                        <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
-                          이용약관에 동의합니다 (필수)
-                        </span>
-                      </label>
-                      <Link
-                        to="/terms"
-                        target="_blank"
-                        className="text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        <ExternalLink size={16} />
-                      </Link>
-                    </div>
-                  </FormField>
-                </div>
-              </div>
-
-              {/* 연락처 & 학과 */}
-              <div className="space-y-s4 mt-s7">
-                <h2 className="typo-h4 text-foreground flex items-center gap-s2 border-b border-border pb-s3">
-                  <Mail size={18} className="text-primary" />
-                  연락처
-                </h2>
                 <FormField
                   label="이메일"
                   error={
@@ -1204,314 +1198,199 @@ export default function SignupPage() {
                     />
                   </div>
                 </FormField>
-              </div>
 
-              {/* 계정 보안 */}
-              <div className="space-y-s4 mt-s7">
-                <h2 className="typo-h4 text-foreground flex items-center gap-s2 border-b border-border pb-s3">
-                  <Lock size={18} className="text-primary" />
-                  계정 보안
-                </h2>
-                <div className="rounded-r2 bg-muted/50 border border-border p-s4">
-                  <p className="typo-c1 text-muted-foreground">
-                    비밀번호는{" "}
-                    <strong className="text-foreground">
-                      영문, 숫자를 포함하여 8자 이상
-                    </strong>
-                    으로 설정해주세요.
-                  </p>
-                </div>
-
-                <FormField label="비밀번호" error={errors.password?.message}>
-                  <div className="relative">
-                    <Lock
-                      size={18}
-                      className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
-                    />
-                    <Input
-                      {...register("password")}
-                      type={showPassword ? "text" : "password"}
-                      placeholder="비밀번호 입력"
-                      className="pl-10 pr-10"
-                    />
-                    <button
-                      type="button"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                    >
-                      {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-                    </button>
-                  </div>
-                </FormField>
-
-                <FormField
-                  label="비밀번호 확인"
-                  error={errors.passwordConfirm?.message}
-                  success={
-                    passwordConfirmTouched &&
-                    !errors.passwordConfirm &&
-                    watch("passwordConfirm")
-                      ? "비밀번호가 일치합니다."
-                      : undefined
-                  }
+                <div
+                  className={cn(
+                    "space-y-s5",
+                    memberType !== "member" && "hidden",
+                  )}
                 >
-                  <div className="relative">
-                    <Lock
-                      size={18}
-                      className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
-                    />
-                    <Input
-                      {...register("passwordConfirm", {
-                        onBlur: () => {
-                          setPasswordConfirmTouched(true);
-                          trigger("passwordConfirm");
-                        },
-                      })}
-                      type={showPasswordConfirm ? "text" : "password"}
-                      placeholder="비밀번호 재입력"
-                      className="pl-10 pr-10"
-                    />
-                    <button
-                      type="button"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() =>
-                        setShowPasswordConfirm(!showPasswordConfirm)
-                      }
-                      className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                    >
-                      {showPasswordConfirm ? (
-                        <EyeOff size={18} />
-                      ) : (
-                        <Eye size={18} />
-                      )}
-                    </button>
-                  </div>
-                </FormField>
-              </div>
+                  <FormField
+                    label={WISH_TITLE}
+                    error={submitted ? errors.wishes?.message : undefined}
+                  >
+                    <div className="flex flex-wrap gap-s2">
+                      {wishOptions.map((wish) => (
+                        <button
+                          key={wish}
+                          type="button"
+                          onClick={() => handleWishToggle(wish)}
+                          className={cn(
+                            "px-s3 py-s2 rounded-full border text-sm transition-all cursor-pointer",
+                            selectedWishes.includes(wish)
+                              ? "bg-primary text-primary-foreground border-primary"
+                              : "border-border bg-muted text-foreground hover:border-primary/50",
+                          )}
+                        >
+                          {wish}
+                        </button>
+                      ))}
+                    </div>
+                  </FormField>
 
-              {/* 기타 (회원 전용) */}
-              <div
-                className={cn(
-                  "space-y-s4 mt-s7",
-                  memberType !== "member" && "hidden",
-                )}
-              >
-                <h2 className="typo-h4 text-foreground flex items-center gap-s2 border-b border-border pb-s3">
-                  <FileText size={18} className="text-primary" />
-                  기타
-                </h2>
-                <FormField
-                  label={WISH_TITLE}
-                  error={submitted ? errors.wishes?.message : undefined}
-                >
-                  <div className="flex flex-wrap gap-s2">
-                    {wishOptions.map((wish) => (
+                  <FormField
+                    label={INTEREST_TITLE}
+                    error={submitted ? errors.interests?.message : undefined}
+                  >
+                    <div className="flex flex-wrap gap-s2">
+                      {interestOptions.map((interest) => (
+                        <button
+                          key={interest}
+                          type="button"
+                          onClick={() => handleInterestToggle(interest)}
+                          className={cn(
+                            "px-s3 py-s2 rounded-full border text-sm transition-all cursor-pointer",
+                            selectedInterests.includes(interest)
+                              ? "bg-primary text-primary-foreground border-primary"
+                              : "border-border bg-muted text-foreground hover:border-primary/50",
+                          )}
+                        >
+                          {interest}
+                        </button>
+                      ))}
                       <button
-                        key={wish}
                         type="button"
-                        onClick={() => handleWishToggle(wish)}
+                        onClick={() => handleInterestToggle("기타")}
                         className={cn(
                           "px-s3 py-s2 rounded-full border text-sm transition-all cursor-pointer",
-                          selectedWishes.includes(wish)
+                          selectedInterests.includes("기타")
                             ? "bg-primary text-primary-foreground border-primary"
                             : "border-border bg-muted text-foreground hover:border-primary/50",
                         )}
                       >
-                        {wish}
+                        기타
                       </button>
-                    ))}
-                  </div>
-                </FormField>
+                    </div>
+                    {selectedInterests.includes("기타") && (
+                      <Input
+                        {...register("customInterest")}
+                        placeholder="관심 분야를 입력해주세요"
+                        className="mt-s2"
+                        onKeyDown={(e) =>
+                          e.key === "Enter" && e.preventDefault()
+                        }
+                      />
+                    )}
+                  </FormField>
 
-                <FormField
-                  label={INTEREST_TITLE}
-                  error={submitted ? errors.interests?.message : undefined}
-                >
-                  <div className="flex flex-wrap gap-s2">
-                    {interestOptions.map((interest) => (
+                  <FormField
+                    label={JOIN_ROUTE_TITLE}
+                    error={submitted ? errors.joinRoute?.message : undefined}
+                  >
+                    <div className="flex flex-wrap gap-s2">
+                      {joinRouteOptions.map((route) => (
+                        <button
+                          key={route}
+                          type="button"
+                          onClick={() => handleJoinRouteSelect(route)}
+                          className={cn(
+                            "px-s3 py-s2 rounded-full border text-sm transition-all cursor-pointer",
+                            selectedJoinRoute === route
+                              ? "bg-primary text-primary-foreground border-primary"
+                              : "border-border bg-muted text-foreground hover:border-primary/50",
+                          )}
+                        >
+                          {route}
+                        </button>
+                      ))}
                       <button
-                        key={interest}
                         type="button"
-                        onClick={() => handleInterestToggle(interest)}
+                        onClick={() => handleJoinRouteSelect("기타")}
                         className={cn(
                           "px-s3 py-s2 rounded-full border text-sm transition-all cursor-pointer",
-                          selectedInterests.includes(interest)
+                          selectedJoinRoute === "기타"
                             ? "bg-primary text-primary-foreground border-primary"
                             : "border-border bg-muted text-foreground hover:border-primary/50",
                         )}
                       >
-                        {interest}
+                        기타
                       </button>
-                    ))}
-                    <button
-                      type="button"
-                      onClick={() => handleInterestToggle("기타")}
-                      className={cn(
-                        "px-s3 py-s2 rounded-full border text-sm transition-all cursor-pointer",
-                        selectedInterests.includes("기타")
-                          ? "bg-primary text-primary-foreground border-primary"
-                          : "border-border bg-muted text-foreground hover:border-primary/50",
-                      )}
-                    >
-                      기타
-                    </button>
-                  </div>
-                  {selectedInterests.includes("기타") && (
+                    </div>
+                    {selectedJoinRoute === "기타" && (
+                      <Input
+                        {...register("customJoinRoute")}
+                        placeholder="가입 경로를 입력해주세요"
+                        className="mt-s2"
+                        onKeyDown={(e) =>
+                          e.key === "Enter" && e.preventDefault()
+                        }
+                      />
+                    )}
+                  </FormField>
+
+                  <FormField
+                    label="닉네임 (선택)"
+                    error={errors.nickname?.message}
+                  >
                     <Input
-                      {...register("customInterest")}
-                      placeholder="관심 분야를 입력해주세요"
-                      className="mt-s2"
+                      {...register("nickname")}
+                      placeholder="공개 프로필에 표시될 이름 (미설정 시 이름으로 표시)"
                       onKeyDown={(e) => e.key === "Enter" && e.preventDefault()}
                     />
-                  )}
-                </FormField>
+                  </FormField>
 
-                <FormField
-                  label={JOIN_ROUTE_TITLE}
-                  error={submitted ? errors.joinRoute?.message : undefined}
-                >
-                  <div className="flex flex-wrap gap-s2">
-                    {joinRouteOptions.map((route) => (
-                      <button
-                        key={route}
-                        type="button"
-                        onClick={() => handleJoinRouteSelect(route)}
-                        className={cn(
-                          "px-s3 py-s2 rounded-full border text-sm transition-all cursor-pointer",
-                          selectedJoinRoute === route
-                            ? "bg-primary text-primary-foreground border-primary"
-                            : "border-border bg-muted text-foreground hover:border-primary/50",
-                        )}
-                      >
-                        {route}
-                      </button>
-                    ))}
-                    <button
-                      type="button"
-                      onClick={() => handleJoinRouteSelect("기타")}
-                      className={cn(
-                        "px-s3 py-s2 rounded-full border text-sm transition-all cursor-pointer",
-                        selectedJoinRoute === "기타"
-                          ? "bg-primary text-primary-foreground border-primary"
-                          : "border-border bg-muted text-foreground hover:border-primary/50",
-                      )}
-                    >
-                      기타
-                    </button>
-                  </div>
-                  {selectedJoinRoute === "기타" && (
-                    <Input
-                      {...register("customJoinRoute")}
-                      placeholder="가입 경로를 입력해주세요"
-                      className="mt-s2"
-                      onKeyDown={(e) => e.key === "Enter" && e.preventDefault()}
-                    />
-                  )}
-                </FormField>
-
-                <FormField label="가입 동기 (선택)">
-                  <div className="relative">
-                    <FileText
-                      size={18}
-                      className="absolute left-s3 top-s3 text-muted-foreground"
-                    />
+                  <FormField
+                    label="자기소개 (선택)"
+                    error={errors.introduction?.message}
+                  >
                     <textarea
-                      {...register("motivation")}
-                      placeholder="동아리 가입 동기를 작성해주세요"
-                      rows={4}
+                      {...register("introduction")}
+                      placeholder="공개 프로필에 표시될 자기소개를 작성해주세요"
+                      rows={3}
                       className={cn(
-                        "w-full rounded-r2 border border-input bg-transparent pl-10 pr-s3 py-s2 text-sm",
+                        "w-full rounded-r2 border border-input bg-transparent px-s3 py-s2 text-sm",
                         "placeholder:text-muted-foreground resize-none transition-all outline-none",
                         "focus:border-ring focus:ring-ring/50 focus:ring-[3px]",
                       )}
                     />
-                  </div>
-                </FormField>
+                  </FormField>
+                </div>
 
-                <FormField
-                  label="닉네임 (선택)"
-                  error={errors.nickname?.message}
-                >
-                  <Input
-                    {...register("nickname")}
-                    placeholder="공개 프로필에 표시될 이름 (미설정 시 이름으로 표시)"
-                    onKeyDown={(e) => e.key === "Enter" && e.preventDefault()}
-                  />
-                </FormField>
-
-                <FormField
-                  label="자기소개 (선택)"
-                  error={errors.introduction?.message}
-                >
-                  <textarea
-                    {...register("introduction")}
-                    placeholder="공개 프로필에 표시될 자기소개를 작성해주세요"
-                    rows={3}
-                    className={cn(
-                      "w-full rounded-r2 border border-input bg-transparent px-s3 py-s2 text-sm",
-                      "placeholder:text-muted-foreground resize-none transition-all outline-none",
-                      "focus:border-ring focus:ring-ring/50 focus:ring-[3px]",
-                    )}
-                  />
-                </FormField>
-
-                <FormField label="프로필 링크 (선택)">
-                  <div className="space-y-s2">
-                    {linkFields.fields.map((field, index) => (
-                      <div key={field.id} className="space-y-s1">
-                        <div className="flex items-center gap-s2">
-                          <Input
-                            {...register(`links.${index}.label`)}
-                            placeholder="github"
-                            className="w-28 shrink-0"
-                            onKeyDown={(e) =>
-                              e.key === "Enter" && e.preventDefault()
-                            }
-                          />
-                          <Input
-                            {...register(`links.${index}.url`)}
-                            placeholder="https://github.com/username"
-                            onKeyDown={(e) =>
-                              e.key === "Enter" && e.preventDefault()
-                            }
-                          />
-                          <button
-                            type="button"
-                            onClick={() => linkFields.remove(index)}
-                            className="shrink-0 p-s2 text-muted-foreground hover:text-destructive transition-colors cursor-pointer"
-                            aria-label="링크 삭제"
-                          >
-                            <Trash2 size={16} />
-                          </button>
-                        </div>
-                        {(errors.links?.[index]?.label ??
-                          errors.links?.[index]?.url) && (
-                          <p className="text-xs text-destructive">
-                            {errors.links[index]?.label?.message ??
-                              errors.links[index]?.url?.message}
-                          </p>
-                        )}
-                      </div>
-                    ))}
-                    {linkFields.fields.length < 10 && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          linkFields.append({ label: "", url: "" })
-                        }
-                        className={cn(
-                          "flex items-center gap-s1 text-sm text-muted-foreground",
-                          "hover:text-primary transition-colors cursor-pointer",
-                        )}
+                <div className="space-y-s3 rounded-r2 border border-border p-s4">
+                  <FormField error={errors.privacyConsent?.message}>
+                    <div className="flex items-center justify-between">
+                      <label className="flex items-center gap-s3 cursor-pointer group">
+                        <input
+                          type="checkbox"
+                          {...register("privacyConsent")}
+                          className="cursor-pointer accent-primary"
+                        />
+                        <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
+                          개인정보 처리방침에 동의합니다 (필수)
+                        </span>
+                      </label>
+                      <Link
+                        to="/privacy"
+                        target="_blank"
+                        className="text-muted-foreground hover:text-foreground transition-colors"
                       >
-                        <Plus size={16} />
-                        <LinkIcon size={14} />
-                        링크 추가
-                      </button>
-                    )}
-                  </div>
-                </FormField>
+                        <ExternalLink size={16} />
+                      </Link>
+                    </div>
+                  </FormField>
+
+                  <FormField error={errors.termsConsent?.message}>
+                    <div className="flex items-center justify-between">
+                      <label className="flex items-center gap-s3 cursor-pointer group">
+                        <input
+                          type="checkbox"
+                          {...register("termsConsent")}
+                          className="cursor-pointer accent-primary"
+                        />
+                        <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
+                          이용약관에 동의합니다 (필수)
+                        </span>
+                      </label>
+                      <Link
+                        to="/terms"
+                        target="_blank"
+                        className="text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        <ExternalLink size={16} />
+                      </Link>
+                    </div>
+                  </FormField>
+                </div>
               </div>
 
               {/* 회비 납부 안내 (회원 전용) */}

--- a/play-igrus/backend/profiles.go
+++ b/play-igrus/backend/profiles.go
@@ -125,7 +125,10 @@ func (s *server) getAuthor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := publicProfile{DisplayName: p.AuthorName, Links: []profileLink{}}
+	out := struct {
+		publicProfile
+		Projects []projectView `json:"projects"`
+	}{publicProfile{DisplayName: p.AuthorName, Links: []profileLink{}}, []projectView{}}
 	if prof, ok := s.auth.publicProfile(r.Context(), p.StudentID); ok {
 		if prof.DisplayName != "" {
 			out.DisplayName = prof.DisplayName
@@ -133,6 +136,14 @@ func (s *server) getAuthor(w http.ResponseWriter, r *http.Request) {
 		out.Introduction = prof.Introduction
 		if prof.Links != nil {
 			out.Links = prof.Links
+		}
+	}
+	// 이 작성자의 다른 승인작 — 승인작만 공개 (심사중/반려 비공개)
+	if mine, err := listByStudent(s.db, p.StudentID); err == nil {
+		for _, it := range mine {
+			if it.Status == "approved" {
+				out.Projects = append(out.Projects, listView(it))
+			}
 		}
 	}
 	writeJSON(w, http.StatusOK, out)

--- a/play-igrus/frontend/src/api/client.ts
+++ b/play-igrus/frontend/src/api/client.ts
@@ -162,6 +162,8 @@ export interface AuthorProfile {
   displayName: string;
   introduction?: string;
   links: ProfileLink[];
+  /** 이 작성자의 승인작 목록 */
+  projects?: Project[];
 }
 
 export const fetchAuthor = (projectId: number) =>

--- a/play-igrus/frontend/src/components/AuthorDialog.tsx
+++ b/play-igrus/frontend/src/components/AuthorDialog.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useRef, useState } from "react";
 import { css } from "styled-system/css";
-import { flex } from "styled-system/patterns";
-import { fetchAuthor, type AuthorProfile } from "../api/client";
+import { flex, grid } from "styled-system/patterns";
+import { fetchAuthor, imageSrc, type AuthorProfile, type Project } from "../api/client";
+import { categoryColor } from "./category";
 
 interface Props {
   /** 열려 있는 동안의 대상 프로젝트 id — undefined 면 닫힘 */
   projectId?: number;
   onClose: () => void;
+  /** 작품 목록에서 작품 탭 — 이 다이얼로그를 닫고 해당 작품을 연다 */
+  onProject?: (p: Project) => void;
 }
 
-/** 작성자 프로필 다이얼로그 — 닉네임(또는 이름), 자기소개, 링크 */
-export default function AuthorDialog({ projectId, onClose }: Props) {
+/** 작성자 프로필 다이얼로그 — 닉네임(또는 이름), 자기소개, 링크, 제작한 작품 */
+export default function AuthorDialog({ projectId, onClose, onProject }: Props) {
   const ref = useRef<HTMLDialogElement>(null);
   const [author, setAuthor] = useState<AuthorProfile | null>(null);
 
@@ -120,6 +123,58 @@ export default function AuthorDialog({ projectId, onClose }: Props) {
                   </li>
                 ))}
               </ul>
+            )}
+
+            {author.projects && author.projects.length > 0 && (
+              <>
+                <h3 className={css({ mt: "5", fontSize: "sm", fontWeight: "800", color: "gray.500" })}>
+                  제작한 작품
+                </h3>
+                <div className={grid({ columns: 3, gap: "2", mt: "2" })}>
+                  {author.projects.map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => onProject?.(p)}
+                      className={css({ textAlign: "left", cursor: "pointer" })}
+                    >
+                      <div
+                        className={css({ aspectRatio: "1", rounded: "lg", overflow: "hidden", bg: "gray.100" })}
+                        style={
+                          p.thumbnailUrl
+                            ? undefined
+                            : { background: `linear-gradient(135deg, ${categoryColor(p.category)}, #1e1b4b)` }
+                        }
+                      >
+                        {p.thumbnailUrl ? (
+                          <img
+                            src={imageSrc(p.thumbnailUrl)}
+                            alt={p.title}
+                            loading="lazy"
+                            className={css({ w: "full", h: "full", objectFit: "cover" })}
+                          />
+                        ) : (
+                          <div
+                            className={flex({
+                              w: "full",
+                              h: "full",
+                              align: "center",
+                              justify: "center",
+                              color: "white",
+                              fontWeight: "800",
+                            })}
+                          >
+                            {p.title.slice(0, 1)}
+                          </div>
+                        )}
+                      </div>
+                      <p className={css({ mt: "1", fontSize: "xs", fontWeight: "700", truncate: true })}>
+                        {p.title}
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              </>
             )}
           </>
         )}

--- a/play-igrus/frontend/src/components/Layout.tsx
+++ b/play-igrus/frontend/src/components/Layout.tsx
@@ -48,7 +48,9 @@ export default function Layout() {
               alt=""
               className={css({ h: "8", w: "8", rounded: "md", objectFit: "cover" })}
             />
-            Play <span className={css({ color: "indigo.600" })}>Inha</span>
+            <span>
+              Play <span className={css({ color: "indigo.600" })}>Inha</span>
+            </span>
           </Link>
 
           <nav className={flex({ align: "center", gap: "3", fontSize: "sm" })}>

--- a/play-igrus/frontend/src/pages/HomePage.tsx
+++ b/play-igrus/frontend/src/pages/HomePage.tsx
@@ -179,7 +179,14 @@ export default function HomePage() {
         onClose={() => setSelected(null)}
         onAuthor={() => selected && setAuthorFor(selected.id)}
       />
-      <AuthorDialog projectId={authorFor} onClose={() => setAuthorFor(undefined)} />
+      <AuthorDialog
+        projectId={authorFor}
+        onClose={() => setAuthorFor(undefined)}
+        onProject={(p) => {
+          setAuthorFor(undefined);
+          open(p);
+        }}
+      />
     </>
   );
 }

--- a/specs/play-igrus/spec.md
+++ b/specs/play-igrus/spec.md
@@ -47,8 +47,8 @@ IGRUS 가입자(동아리 비회원 포함 — 인하대생 누구나)가 본인
   이름 — 폴백은 **igrus 서버가 한다** (`GET /api/v1/users/{학번}/public-profile` 의
   `displayName`; 닉네임이 있으면 실명은 응답에 없음). 학번·입학년도는 비공개.
   play 서버는 5분 TTL 캐시로 조회하고, 실패 시 제출 당시 이름 스냅샷으로 폴백.
-- 작성자 탭(카드/상세) → 프로필 다이얼로그: 표시 이름·자기소개·링크
-  (`GET /api/projects/{id}/author` — 학번 비노출 프록시).
+- 작성자 탭(카드/상세) → 프로필 다이얼로그: 표시 이름·자기소개·링크·제작한 작품
+  (승인작만, 탭 → 해당 작품 다이얼로그) (`GET /api/projects/{id}/author` — 학번 비노출 프록시).
 - **클릭수는 어떤 API 응답에도 싣지 않는다** (본인·운영진 포함 서버단 제공 금지) —
   랭킹 정렬 입력으로만 쓰인다.
 
@@ -82,7 +82,7 @@ IGRUS 가입자(동아리 비회원 포함 — 인하대생 누구나)가 본인
 |---|---|---|
 | `GET /api/projects?category=&sort=` | 공개 | 승인작 목록 (sort: popular 기본 / recent) |
 | `GET /api/projects/{id}` | 공개 | 상세 (배너·본문·리다이렉트 URL 포함) |
-| `GET /api/projects/{id}/author` | 공개 | 작성자 공개 프로필 (표시 이름·자기소개·링크, 학번 비노출) |
+| `GET /api/projects/{id}/author` | 공개 | 작성자 공개 프로필 (표시 이름·자기소개·링크·승인작 목록, 학번 비노출) |
 | `POST /api/projects/{id}/click` | 공개 | 클릭 집계 (204) |
 | `POST /api/projects` | 로그인 | multipart 제출 → pending |
 | `PUT /api/projects/{id}` | 로그인(본인) | 수정 — 승인작은 수정본 대기, 그 외 즉시 반영 후 pending |


### PR DESCRIPTION
## 변경사항
- `GET /api/projects/{id}/author` 응답에 승인작 목록(`projects`) 추가 — 심사중/반려작 비공개, 학번 비노출 유지
- 제작자 다이얼로그에 "제작한 작품" 그리드 — 탭하면 해당 작품 다이얼로그로 이동
- 헤더 로고 Play/Inha 사이에 flex gap이 끼어 벌어지던 간격 수정
- specs/play-igrus/spec.md 반영

## 확인
- Go build/test 통과, tsc/oxlint 통과
- 구버전 API(projects 필드 없음) 응답에서도 다이얼로그 정상 동작 확인