### PR TITLE
feat(play): 작성자 승인작 공개/비공개 토글

### DIFF
--- a/play-igrus/backend/db.go
+++ b/play-igrus/backend/db.go
@@ -36,6 +36,7 @@ var schema = []string{
 	  total_clicks        BIGINT        NOT NULL DEFAULT 0,
 	  score               DOUBLE        NOT NULL DEFAULT 0,
 	  version             INT           NOT NULL DEFAULT 0,
+	  hidden              TINYINT(1)    NOT NULL DEFAULT 0,
 	  INDEX idx_projects_status_score (status, score DESC),
 	  INDEX idx_projects_student (student_id)
 	) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`,
@@ -89,7 +90,8 @@ type row struct {
 	CreatedAt         time.Time
 	TotalClicks       int64
 	Score             float64
-	Version           int // 라이브 버전 번호 (0 = 아직 승인된 버전 없음)
+	Version           int  // 라이브 버전 번호 (0 = 아직 승인된 버전 없음)
+	Hidden            bool // 작성자가 공개를 내린 상태 — 심사 상태(status)와 별개 축
 }
 
 func openDB(dsn string) (*sql.DB, error) {
@@ -119,13 +121,18 @@ func openDB(dsn string) (*sql.DB, error) {
 
 // migrate 는 구버전 스키마에서 넘어오는 idempotent 이관 — 매 부팅마다 실행해도 안전하다.
 func migrate(db *sql.DB) error {
-	// ① 기존 projects 테이블에 version 컬럼 추가 (MySQL 은 ADD COLUMN IF NOT EXISTS 미지원)
+	// ① 기존 projects 테이블에 없는 컬럼 추가 (MySQL 은 ADD COLUMN IF NOT EXISTS 미지원)
 	var n int
-	db.QueryRow(`SELECT COUNT(*) FROM information_schema.columns
-		WHERE table_schema = DATABASE() AND table_name = 'projects' AND column_name = 'version'`).Scan(&n)
-	if n == 0 {
-		if _, err := db.Exec(`ALTER TABLE projects ADD COLUMN version INT NOT NULL DEFAULT 0`); err != nil {
-			return err
+	for col, ddl := range map[string]string{
+		"version": `ALTER TABLE projects ADD COLUMN version INT NOT NULL DEFAULT 0`,
+		"hidden":  `ALTER TABLE projects ADD COLUMN hidden TINYINT(1) NOT NULL DEFAULT 0`,
+	} {
+		db.QueryRow(`SELECT COUNT(*) FROM information_schema.columns
+			WHERE table_schema = DATABASE() AND table_name = 'projects' AND column_name = ?`, col).Scan(&n)
+		if n == 0 {
+			if _, err := db.Exec(ddl); err != nil {
+				return err
+			}
 		}
 	}
 	// ② 버전 이력이 없는 기존 프로젝트는 현재 내용을 v1 로 백필
@@ -167,7 +174,7 @@ func migrate(db *sql.DB) error {
 
 const selectCols = `id, student_id, author_name, department, title, description, body_md,
 	thumbnail_key, banner_key, redirect_url, category, status, reject_reason,
-	reviewer_student_id, reviewer_name, reviewed_at, created_at, total_clicks, score, version`
+	reviewer_student_id, reviewer_name, reviewed_at, created_at, total_clicks, score, version, hidden`
 
 func scanRows(rows *sql.Rows) ([]row, error) {
 	defer rows.Close()
@@ -179,7 +186,7 @@ func scanRows(rows *sql.Rows) ([]row, error) {
 		err := rows.Scan(&p.ID, &p.StudentID, &p.AuthorName, &p.Department, &p.Title,
 			&p.Description, &p.BodyMD, &p.ThumbnailKey, &p.BannerKey, &p.RedirectURL,
 			&p.Category, &p.Status, &p.RejectReason, &p.ReviewerStudentID, &p.ReviewerName,
-			&reviewed, &p.CreatedAt, &p.TotalClicks, &p.Score, &p.Version)
+			&reviewed, &p.CreatedAt, &p.TotalClicks, &p.Score, &p.Version, &p.Hidden)
 		if err != nil {
 			return nil, err
 		}
@@ -229,7 +236,7 @@ func insertProject(db *sql.DB, p row) (int64, error) {
 // listApprovedProjects — sort 는 핸들러에서 검증된 값만 온다.
 // popular: score DESC(동점 최신순) / recent: 최신순.
 func listApprovedProjects(db *sql.DB, category, sort string) ([]row, error) {
-	q := `SELECT ` + selectCols + ` FROM projects WHERE status = 'approved'`
+	q := `SELECT ` + selectCols + ` FROM projects WHERE status = 'approved' AND hidden = 0`
 	args := []any{}
 	if category != "" {
 		q += ` AND category = ?`
@@ -450,7 +457,7 @@ func listVersionsByStatus(db *sql.DB, status string) ([]versionItem, error) {
 		err := rows.Scan(&p.ID, &p.StudentID, &p.AuthorName, &p.Department, &p.Title,
 			&p.Description, &p.BodyMD, &p.ThumbnailKey, &p.BannerKey, &p.RedirectURL,
 			&p.Category, &p.Status, &p.RejectReason, &p.ReviewerStudentID, &p.ReviewerName,
-			&pReviewed, &p.CreatedAt, &p.TotalClicks, &p.Score, &p.Version,
+			&pReviewed, &p.CreatedAt, &p.TotalClicks, &p.Score, &p.Version, &p.Hidden,
 			&v.ProjectID, &v.Version, &v.Title, &v.Description, &v.BodyMD,
 			&v.ThumbnailKey, &v.BannerKey, &v.RedirectURL, &v.Category, &v.Status,
 			&v.RejectReason, &v.ReviewerName, &vReviewed, &v.CreatedAt)
@@ -496,10 +503,17 @@ func listLatestVersionsByStudent(db *sql.DB, studentID string) (map[int64]versio
 	return latest, nil
 }
 
+// setProjectHidden 은 공개/비공개 토글 — 소유·상태 검증은 핸들러가 한다.
+func setProjectHidden(db *sql.DB, id int64, hidden bool) error {
+	_, err := db.Exec(`UPDATE projects SET hidden = ? WHERE id = ?`, hidden, id)
+	return err
+}
+
 // addClick 은 승인된 작품의 클릭을 총합 + 일별(KST 날짜) 버킷에 기록한다.
 func addClick(db *sql.DB, id int64, date string) error {
 	res, err := db.Exec(
-		`UPDATE projects SET total_clicks = total_clicks + 1 WHERE id = ? AND status = 'approved'`, id)
+		`UPDATE projects SET total_clicks = total_clicks + 1
+		 WHERE id = ? AND status = 'approved' AND hidden = 0`, id)
 	if err != nil {
 		return err
 	}

--- a/play-igrus/backend/main.go
+++ b/play-igrus/backend/main.go
@@ -67,6 +67,7 @@ func main() {
 	// 로그인 필요
 	mux.HandleFunc("POST /api/projects", s.auth.requireLogin(s.createProject))
 	mux.HandleFunc("PUT /api/projects/{id}", s.auth.requireLogin(s.updateProject))
+	mux.HandleFunc("PUT /api/projects/{id}/visibility", s.auth.requireLogin(s.setVisibility))
 	mux.HandleFunc("GET /api/projects/mine", s.auth.requireLogin(s.listMine))
 
 	// 운영진 전용

--- a/play-igrus/backend/main_test.go
+++ b/play-igrus/backend/main_test.go
@@ -292,6 +292,24 @@ func TestReviewAndRankingWithMySQL(t *testing.T) {
 	if err != nil || lv.Version != 3 || lv.Status != "rejected" || lv.RejectReason != "별로" {
 		t.Fatalf("v3 반려 기록이 틀림: %+v %v", lv, err)
 	}
+
+	// 작성자 비공개 → 공개 목록 제외 + 클릭 차단, 재공개 → score·클릭수 그대로 복귀
+	if err := setProjectHidden(db, id, true); err != nil {
+		t.Fatal(err)
+	}
+	if items, _ := listApprovedProjects(db, "", "popular"); len(items) != 0 {
+		t.Fatalf("비공개 작품이 공개 목록에 남음: %+v", items)
+	}
+	if err := addClick(db, id, kstTodayString()); err != errNotFound {
+		t.Errorf("비공개 작품 클릭이 막히지 않음: %v", err)
+	}
+	if err := setProjectHidden(db, id, false); err != nil {
+		t.Fatal(err)
+	}
+	items, _ = listApprovedProjects(db, "", "popular")
+	if len(items) != 1 || items[0].TotalClicks != 2 {
+		t.Fatalf("재공개 복귀가 틀림 (클릭수 유지돼야 함): %+v", items)
+	}
 }
 
 // 공개 프로필 프록시 — 닉네임이 있으면 목록/작성자 응답의 이름이 닉네임으로 바뀌고

--- a/play-igrus/backend/profiles.go
+++ b/play-igrus/backend/profiles.go
@@ -116,7 +116,7 @@ func (s *server) getAuthor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p, err := getProject(s.db, id)
-	if err == errNotFound || (err == nil && p.Status != "approved") {
+	if err == errNotFound || (err == nil && (p.Status != "approved" || p.Hidden)) {
 		writeErr(w, http.StatusNotFound, "작품을 찾을 수 없습니다")
 		return
 	}
@@ -138,10 +138,10 @@ func (s *server) getAuthor(w http.ResponseWriter, r *http.Request) {
 			out.Links = prof.Links
 		}
 	}
-	// 이 작성자의 다른 승인작 — 승인작만 공개 (심사중/반려 비공개)
+	// 이 작성자의 다른 승인작 — 승인작만 공개 (심사중/반려/작성자 비공개 제외)
 	if mine, err := listByStudent(s.db, p.StudentID); err == nil {
 		for _, it := range mine {
-			if it.Status == "approved" {
+			if it.Status == "approved" && !it.Hidden {
 				out.Projects = append(out.Projects, listView(it))
 			}
 		}

--- a/play-igrus/backend/projects.go
+++ b/play-igrus/backend/projects.go
@@ -71,6 +71,7 @@ type projectView struct {
 	BannerURL    string       `json:"bannerUrl,omitempty"`
 	RedirectURL  string       `json:"redirectUrl,omitempty"`
 	Status       string       `json:"status,omitempty"`
+	Hidden       bool         `json:"hidden,omitempty"` // 작성자가 공개를 내린 상태 (내 작품 응답에만)
 	RejectReason string       `json:"rejectReason,omitempty"`
 	ReviewerName string       `json:"reviewerName,omitempty"`
 	CreatedAt    time.Time    `json:"createdAt"`
@@ -114,6 +115,7 @@ func detailView(p row) projectView {
 func mineView(p row) projectView {
 	v := detailView(p)
 	v.Status = p.Status
+	v.Hidden = p.Hidden
 	v.RejectReason = p.RejectReason
 	v.ReviewedAt = p.ReviewedAt
 	v.Version = p.Version
@@ -176,7 +178,7 @@ func (s *server) getDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p, err := getProject(s.db, id)
-	if err == errNotFound || (err == nil && p.Status != "approved") {
+	if err == errNotFound || (err == nil && (p.Status != "approved" || p.Hidden)) {
 		writeErr(w, http.StatusNotFound, "작품을 찾을 수 없습니다")
 		return
 	}
@@ -374,6 +376,45 @@ func writeImageErr(w http.ResponseWriter, err error) {
 	default:
 		writeErr(w, http.StatusInternalServerError, "이미지 저장에 실패했습니다")
 	}
+}
+
+// PUT /api/projects/{id}/visibility — 본인 승인작 공개/비공개 토글.
+// 심사 상태(status)와 별개 축 — 재공개 시 재심사 없이 즉시 노출, 클릭수·score 유지.
+func (s *server) setVisibility(w http.ResponseWriter, r *http.Request, p Profile) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "잘못된 id 입니다")
+		return
+	}
+	var body struct {
+		Hidden bool `json:"hidden"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErr(w, http.StatusBadRequest, "요청 본문이 올바르지 않습니다")
+		return
+	}
+	proj, err := getProject(s.db, id)
+	if err == errNotFound {
+		writeErr(w, http.StatusNotFound, "작품을 찾을 수 없습니다")
+		return
+	}
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "작품을 불러올 수 없습니다")
+		return
+	}
+	if proj.StudentID != p.StudentID {
+		writeErr(w, http.StatusForbidden, "본인 작품만 변경할 수 있습니다")
+		return
+	}
+	if proj.Status != "approved" {
+		writeErr(w, http.StatusBadRequest, "승인된 작품만 공개 설정을 바꿀 수 있습니다")
+		return
+	}
+	if err := setProjectHidden(s.db, id, body.Hidden); err != nil {
+		writeErr(w, http.StatusInternalServerError, "처리에 실패했습니다")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"hidden": body.Hidden})
 }
 
 // GET /api/projects/mine — 내 제출 현황. 라이브 버전 번호 + 심사 대기/반려된 최신 버전.

--- a/play-igrus/frontend/src/api/client.ts
+++ b/play-igrus/frontend/src/api/client.ts
@@ -127,6 +127,8 @@ export interface Project {
   bannerUrl?: string;
   redirectUrl?: string;
   status?: "pending" | "approved" | "rejected";
+  /** 작성자가 공개를 내린 상태 (내 작품 응답에만) */
+  hidden?: boolean;
   rejectReason?: string;
   reviewerName?: string;
   createdAt: string;
@@ -200,6 +202,14 @@ export const updateProject = (id: number, form: FormData) =>
   playFetch<{ id: number; status: string }>(`/api/projects/${id}`, {
     method: "PUT",
     body: form,
+  });
+
+/** 본인 승인작 공개/비공개 토글 — 재공개는 재심사 없이 즉시 반영 */
+export const setProjectVisibility = (id: number, hidden: boolean) =>
+  playFetch<{ hidden: boolean }>(`/api/projects/${id}/visibility`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ hidden }),
   });
 
 export const fetchAdminProjects = (status: string) =>

--- a/play-igrus/frontend/src/pages/MyPage.tsx
+++ b/play-igrus/frontend/src/pages/MyPage.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { css } from "styled-system/css";
 import { flex } from "styled-system/patterns";
-import { fetchMine, imageSrc, type Project } from "../api/client";
+import { fetchMine, imageSrc, setProjectVisibility, type Project } from "../api/client";
 import RequireLogin from "../components/RequireLogin";
 import { categoryColor } from "../components/category";
 
@@ -22,6 +22,7 @@ const STATUS_LABEL = {
 
 function MyList() {
   const [items, setItems] = useState<Project[] | null>(null);
+  const [confirming, setConfirming] = useState<Project | null>(null);
 
   useEffect(() => {
     fetchMine()
@@ -101,6 +102,22 @@ function MyList() {
                     >
                       {s.text}
                     </span>
+                    {p.status === "approved" && p.hidden && (
+                      <span
+                        className={css({
+                          flexShrink: 0,
+                          fontSize: "xs",
+                          fontWeight: "700",
+                          px: "2",
+                          py: "0.5",
+                          rounded: "full",
+                          bg: "gray.200",
+                          color: "gray.600",
+                        })}
+                      >
+                        비공개
+                      </span>
+                    )}
                   </div>
                   <p className={css({ fontSize: "sm", color: "gray.500", truncate: true })}>
                     {p.description}
@@ -122,29 +139,158 @@ function MyList() {
                     </p>
                   )}
                 </div>
-                <Link
-                  to={`/edit/${p.id}`}
-                  className={css({
-                    alignSelf: "center",
-                    flexShrink: 0,
-                    fontSize: "sm",
-                    fontWeight: "600",
-                    color: "indigo.600",
-                    px: "2.5",
-                    py: "1.5",
-                    rounded: "lg",
-                    border: "1px solid",
-                    borderColor: "indigo.200",
-                  })}
-                >
-                  수정
-                </Link>
+                <div className={flex({ direction: "column", gap: "1.5", alignSelf: "center", flexShrink: 0 })}>
+                  <Link
+                    to={`/edit/${p.id}`}
+                    className={css({
+                      textAlign: "center",
+                      fontSize: "sm",
+                      fontWeight: "600",
+                      color: "indigo.600",
+                      px: "2.5",
+                      py: "1.5",
+                      rounded: "lg",
+                      border: "1px solid",
+                      borderColor: "indigo.200",
+                    })}
+                  >
+                    수정
+                  </Link>
+                  {/* 공개 토글은 승인작에만 — 심사중/반려작은 애초에 비공개 */}
+                  {p.status === "approved" && (
+                    <button
+                      type="button"
+                      onClick={() => setConfirming(p)}
+                      className={css({
+                        fontSize: "sm",
+                        fontWeight: "600",
+                        color: "gray.600",
+                        px: "2.5",
+                        py: "1.5",
+                        rounded: "lg",
+                        border: "1px solid",
+                        borderColor: "gray.300",
+                        cursor: "pointer",
+                      })}
+                    >
+                      {p.hidden ? "공개하기" : "숨기기"}
+                    </button>
+                  )}
+                </div>
               </li>
             );
           })}
         </ul>
       )}
+
+      <VisibilityDialog
+        project={confirming}
+        onClose={() => setConfirming(null)}
+        onDone={(updated) => {
+          setItems((prev) => prev?.map((it) => (it.id === updated.id ? updated : it)) ?? prev);
+          setConfirming(null);
+        }}
+      />
     </div>
+  );
+}
+
+/** 공개/비공개 확인 다이얼로그 (native <dialog> — ProjectDialog 와 같은 패턴) */
+function VisibilityDialog({
+  project,
+  onClose,
+  onDone,
+}: {
+  project: Project | null;
+  onClose: () => void;
+  onDone: (updated: Project) => void;
+}) {
+  const ref = useRef<HTMLDialogElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    if (project && !dialog.open) dialog.showModal();
+    if (!project && dialog.open) dialog.close();
+    setError("");
+  }, [project]);
+
+  if (!project) return null;
+  const toHidden = !project.hidden;
+
+  const submit = () => {
+    setBusy(true);
+    setProjectVisibility(project.id, toHidden)
+      .then(() => onDone({ ...project, hidden: toHidden }))
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : "처리에 실패했습니다"))
+      .finally(() => setBusy(false));
+  };
+
+  return (
+    <dialog
+      ref={ref}
+      onClose={onClose}
+      onClick={(e) => {
+        if (e.target === ref.current) onClose();
+      }}
+      className={css({
+        m: "auto",
+        p: "6",
+        border: "none",
+        rounded: "2xl",
+        w: "min(360px, 92vw)",
+        _backdrop: { bg: "black/60" },
+      })}
+    >
+      <p className={css({ fontWeight: "700", mb: "2" })}>
+        {toHidden ? "작품을 숨길까요?" : "작품을 다시 공개할까요?"}
+      </p>
+      <p className={css({ fontSize: "sm", color: "gray.500", mb: "4" })}>
+        {toHidden
+          ? `‘${project.title}’이(가) 메인 목록에서 보이지 않게 돼요. 언제든 다시 공개할 수 있어요.`
+          : `‘${project.title}’이(가) 심사 없이 바로 다시 공개돼요.`}
+      </p>
+      {error && <p className={css({ fontSize: "sm", color: "red.500", mb: "3" })}>{error}</p>}
+      <div className={flex({ gap: "2", justify: "flex-end" })}>
+        <button
+          type="button"
+          onClick={onClose}
+          className={css({
+            fontSize: "sm",
+            fontWeight: "600",
+            px: "3",
+            py: "1.5",
+            rounded: "lg",
+            border: "1px solid",
+            borderColor: "gray.300",
+            color: "gray.600",
+            cursor: "pointer",
+          })}
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={busy}
+          className={css({
+            fontSize: "sm",
+            fontWeight: "600",
+            px: "3",
+            py: "1.5",
+            rounded: "lg",
+            bg: toHidden ? "gray.700" : "indigo.600",
+            color: "white",
+            cursor: "pointer",
+            _disabled: { opacity: 0.5, cursor: "default" },
+          })}
+        >
+          {busy ? "처리 중…" : toHidden ? "숨기기" : "공개하기"}
+        </button>
+      </div>
+    </dialog>
   );
 }
 

--- a/specs/play-igrus/spec.md
+++ b/specs/play-igrus/spec.md
@@ -64,8 +64,18 @@ IGRUS 가입자(동아리 비회원 포함 — 인하대생 누구나)가 본인
     (클릭수·score 유지), 반려 시 이력에만 기록. 배너 제거는 미지원(교체만).
   - **미승인작**(심사중/반려): 프로젝트 행도 최신 내용으로 동기화되고 다시 심사 대기.
 - `/my` 는 라이브 버전(vN 뱃지)과 심사중/반려된 수정 버전을 함께 보여준다.
-- 구 스키마 이관은 부팅 시 idempotent migrate: `projects.version` 컬럼 추가, 기존 행
-  v1 백필, 구 `project_revisions` → 다음 버전 이관 후 테이블 제거.
+- 구 스키마 이관은 부팅 시 idempotent migrate: `projects.version`·`hidden` 컬럼 추가,
+  기존 행 v1 백필, 구 `project_revisions` → 다음 버전 이관 후 테이블 제거.
+
+### 공개/비공개 (작성자 토글)
+
+- 작성자가 본인 **승인작**을 공개 목록에서 내리거나 다시 올릴 수 있다
+  (`PUT /api/projects/{id}/visibility`, body `{"hidden": true|false}`).
+- `projects.hidden` — 심사 상태(status)와 **별개 축**. 숨겨도 승인 상태·클릭수·score 는
+  유지되고, 재공개는 재심사 없이 즉시 반영된다.
+- 숨김 중에는 메인 목록·상세·작성자 다이얼로그의 승인작 목록에서 제외되고 클릭 집계도
+  차단된다 (score 오염 방지). 랭킹 배치는 그대로 돈다.
+- `/my` 에서는 계속 보이며 "비공개" 뱃지 + 숨기기/공개하기 버튼(확인 다이얼로그) 표시.
 
 ## 랭킹 (인기순)
 
@@ -86,7 +96,8 @@ IGRUS 가입자(동아리 비회원 포함 — 인하대생 누구나)가 본인
 | `POST /api/projects/{id}/click` | 공개 | 클릭 집계 (204) |
 | `POST /api/projects` | 로그인 | multipart 제출 → pending |
 | `PUT /api/projects/{id}` | 로그인(본인) | 수정 — 승인작은 수정본 대기, 그 외 즉시 반영 후 pending |
-| `GET /api/projects/mine` | 로그인 | 내 제출 현황 (반려 사유·수정본 상태 포함) |
+| `PUT /api/projects/{id}/visibility` | 로그인(본인) | 승인작 공개/비공개 토글 (`{"hidden": bool}`) |
+| `GET /api/projects/mine` | 로그인 | 내 제출 현황 (반려 사유·수정본 상태·`hidden` 포함) |
 | `GET /api/admin/projects?status=` | 운영진 | 검수 목록 — 버전 이력 단위 (기본 pending) |
 | `POST /api/admin/projects/{id}/approve` | 운영진 | 승인 — 신규는 공개, 수정 요청은 라이브 반영 |
 | `POST /api/admin/projects/{id}/reject` | 운영진 | 반려 (`{reason}` 선택) — 수정 요청은 라이브 유지 |
@@ -108,7 +119,8 @@ IGRUS 가입자(동아리 비회원 포함 — 인하대생 누구나)가 본인
 - `/edit/{id}`: 제출 폼 재사용 — 대기 중 수정본이 있으면 그 내용을 프리필.
 - `/profile`: 공개 프로필(내 정보) 편집 — 닉네임/자기소개/링크 +·🗑 (igrus `users`
   테이블에 저장, `PATCH /api/v1/mypage/profile` 직접 호출).
-- `/my`: 내 제출 상태 (심사중/승인됨/반려됨+사유, 수정 심사중/수정 반려 표시, 수정 버튼).
+- `/my`: 내 제출 상태 (심사중/승인됨/반려됨+사유, 수정 심사중/수정 반려 표시, 수정 버튼,
+  승인작 숨기기/공개하기 버튼 + 비공개 뱃지).
 - 헤더: 출시하기(+운영진 검수)와 프로필 아바타(스켈레톤) — 아바타 탭 →
   내 정보 / 내 작품 / 로그아웃 메뉴 (내 작품·로그아웃 버튼은 메뉴로 이동).
 - `/admin`: 운영진 검수 (대기/승인/반려 탭, 승인·반려 버튼).


### PR DESCRIPTION
## 개요
작성자가 본인 승인작을 공개 목록에서 내리거나(숨기기) 다시 올릴(공개하기) 수 있게 한다.

## 변경사항
- `projects.hidden` 컬럼 — 심사 상태(status)와 별개 축, 부팅 시 idempotent migrate
- `PUT /api/projects/{id}/visibility` (`{"hidden": bool}`) — 로그인 + 본인 승인작만
- 숨김 시 메인 목록·상세·제작자 다이얼로그 승인작 목록에서 제외 + 클릭 집계 차단 (score 오염 방지)
- score·클릭수는 유지 — 재공개는 재심사 없이 즉시 원래 자리로 복귀
- `/my` 승인작 카드에 숨기기/공개하기 버튼 + 확인 다이얼로그 + 비공개 뱃지
- MySQL 통합 테스트에 숨김→목록 제외→재공개 복귀 시나리오 추가
- `specs/play-igrus/spec.md` 업데이트

## 테스트
- `go build && go vet && go test ./...` 통과 (MySQL 통합 테스트는 TEST_DSN 환경에서)
- 프론트 `tsc -b && vite build`, `oxlint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)