### PR TITLE
feat(auth): 회원가입 폼에서 자기소개 입력 UI 제거

### DIFF
--- a/frontend/src/pages/auth/SignupPage.tsx
+++ b/frontend/src/pages/auth/SignupPage.tsx
@@ -1328,22 +1328,6 @@ export default function SignupPage() {
                       onKeyDown={(e) => e.key === "Enter" && e.preventDefault()}
                     />
                   </FormField>
-
-                  <FormField
-                    label="자기소개 (선택)"
-                    error={errors.introduction?.message}
-                  >
-                    <textarea
-                      {...register("introduction")}
-                      placeholder="공개 프로필에 표시될 자기소개를 작성해주세요"
-                      rows={3}
-                      className={cn(
-                        "w-full rounded-r2 border border-input bg-transparent px-s3 py-s2 text-sm",
-                        "placeholder:text-muted-foreground resize-none transition-all outline-none",
-                        "focus:border-ring focus:ring-ring/50 focus:ring-[3px]",
-                      )}
-                    />
-                  </FormField>
                 </div>
 
                 <div className="space-y-s3 rounded-r2 border border-border p-s4">


### PR DESCRIPTION
## 변경 사항

회원가입 폼에서 자기소개(선택) `textarea` 입력 UI를 제거했습니다.

- `introduction` 필드는 스키마에서 이미 `.optional()` 이고 기본값이 `""` 이므로, 제출 시 `undefined` 로 전송됩니다.
- 백엔드 요청 스펙 변경 없음 (선택 필드 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)