### PR TITLE
feat(play): 모바일 다이얼로그를 바텀시트 CTA로 전환

### DIFF
--- a/play-igrus/frontend/src/components/AuthorDialog.tsx
+++ b/play-igrus/frontend/src/components/AuthorDialog.tsx
@@ -3,6 +3,7 @@ import { css } from "styled-system/css";
 import { flex } from "styled-system/patterns";
 import { fetchAuthor, imageSrc, type AuthorProfile, type Project } from "../api/client";
 import { categoryColor } from "./category";
+import AvatarPlaceholder from "./Avatar";
 
 interface Props {
   /** 열려 있는 동안의 대상 프로젝트 id — undefined 면 닫힘 */
@@ -25,6 +26,11 @@ export default function AuthorDialog({ projectId, onClose, onProject }: Props) {
     if (!dialog) return;
     if (projectId !== undefined && !dialog.open) dialog.showModal();
     if (projectId === undefined && dialog.open) dialog.close();
+    if (projectId === undefined) return;
+    document.body.style.overflow = "hidden"; // 시트 열린 동안 배경 스크롤 잠금
+    return () => {
+      document.body.style.overflow = "";
+    };
   }, [projectId]);
 
   useEffect(() => {
@@ -47,15 +53,19 @@ export default function AuthorDialog({ projectId, onClose, onProject }: Props) {
         if (e.target === ref.current) onClose(); // 바깥 탭으로 닫기
       }}
       className={css({
-        m: "auto",
         p: 0,
         border: "none",
-        rounded: { base: "none", sm: "3xl" },
+        // 모바일: 하단에 붙는 바텀시트 / 데스크톱: 중앙 다이얼로그
+        mx: "auto",
+        mt: "auto",
+        mb: { base: 0, sm: "auto" },
+        rounded: { base: "20px 20px 0 0", sm: "3xl" },
         w: { base: "100vw", sm: "min(480px, 92vw)" },
-        h: { base: "100dvh", sm: "auto" },
+        h: "auto",
         maxW: { base: "100vw", sm: "min(480px, 92vw)" },
-        maxH: { base: "100dvh", sm: "88dvh" },
+        maxH: { base: "85dvh", sm: "88dvh" },
         overflow: "hidden",
+        animation: { base: "sheet-up 0.28s cubic-bezier(0.32, 0.72, 0, 1)", sm: "none" },
         _backdrop: { bg: "black/60" },
       })}
     >
@@ -106,21 +116,7 @@ export default function AuthorDialog({ projectId, onClose, onProject }: Props) {
                   className={css({ w: "16", h: "16", rounded: "2xl", objectFit: "cover" })}
                 />
               ) : (
-                <div
-                  className={flex({
-                    w: "16",
-                    h: "16",
-                    align: "center",
-                    justify: "center",
-                    rounded: "2xl",
-                    bg: "indigo.600",
-                    color: "white",
-                    fontSize: "2xl",
-                    fontWeight: "800",
-                  })}
-                >
-                  {author.displayName.slice(0, 1)}
-                </div>
+                <AvatarPlaceholder size="16" rounded="2xl" />
               )}
 
               <h2 className={css({ mt: "3", fontSize: "2xl", fontWeight: "800", letterSpacing: "tight" })}>

--- a/play-igrus/frontend/src/components/Avatar.tsx
+++ b/play-igrus/frontend/src/components/Avatar.tsx
@@ -1,0 +1,37 @@
+import { flex } from "styled-system/patterns";
+
+/** 프로필 사진 없을 때 공통으로 쓰는 회색 사람 실루엣 (아바타 자리표시자) */
+export function PersonIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" width="60%" height="60%" aria-hidden>
+      <path d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0 2c-4.42 0-8 2.24-8 5v3h16v-3c0-2.76-3.58-5-8-5Z" />
+    </svg>
+  );
+}
+
+interface Props {
+  /** 한 변 크기 (panda 사이즈 토큰) */
+  size: string;
+  /** 모서리 — 원형은 "full", 사각형은 "xl" 등 (기본 원형) */
+  rounded?: string;
+}
+
+/** 회색 배경 + 사람 실루엣. 사진 미등록 프로필에 어디서나 동일하게 쓴다. */
+export default function AvatarPlaceholder({ size, rounded = "full" }: Props) {
+  return (
+    <div
+      className={flex({
+        w: size,
+        h: size,
+        flexShrink: 0,
+        align: "center",
+        justify: "center",
+        rounded,
+        bg: "gray.200",
+        color: "gray.500",
+      })}
+    >
+      <PersonIcon />
+    </div>
+  );
+}

--- a/play-igrus/frontend/src/components/Layout.tsx
+++ b/play-igrus/frontend/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import { css } from "styled-system/css";
 import { flex } from "styled-system/patterns";
 import { logout } from "../api/client";
 import { isStaff, useAuthStore } from "../stores/authStore";
+import { PersonIcon } from "./Avatar";
 
 export default function Layout() {
   const { accessToken, user } = useAuthStore();
@@ -84,10 +85,8 @@ export default function Layout() {
                       _hover: { bg: "gray.300" },
                     })}
                   >
-                    {/* 프로필 스켈레톤 (사람 실루엣) */}
-                    <svg viewBox="0 0 24 24" fill="currentColor" width="22" height="22" aria-hidden>
-                      <path d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0 2c-4.42 0-8 2.24-8 5v3h16v-3c0-2.76-3.58-5-8-5Z" />
-                    </svg>
+                    {/* 프로필 자리표시자 (회색 사람 실루엣) */}
+                    <PersonIcon />
                   </button>
 
                   {menuOpen && (

--- a/play-igrus/frontend/src/components/ProjectDialog.tsx
+++ b/play-igrus/frontend/src/components/ProjectDialog.tsx
@@ -21,6 +21,11 @@ export default function ProjectDialog({ project, onClose, onAuthor }: Props) {
     if (!dialog) return;
     if (project && !dialog.open) dialog.showModal();
     if (!project && dialog.open) dialog.close();
+    if (!project) return;
+    document.body.style.overflow = "hidden"; // 시트 열린 동안 배경 스크롤 잠금
+    return () => {
+      document.body.style.overflow = "";
+    };
   }, [project]);
 
   if (!project) return null;
@@ -42,15 +47,19 @@ export default function ProjectDialog({ project, onClose, onAuthor }: Props) {
         if (e.target === ref.current) onClose(); // 바깥(backdrop) 탭으로 닫기
       }}
       className={css({
-        m: "auto",
         p: 0,
         border: "none",
-        rounded: { base: "none", sm: "2xl" },
+        // 모바일: 하단에 붙는 바텀시트 / 데스크톱: 중앙 다이얼로그
+        mx: "auto",
+        mt: "auto",
+        mb: { base: 0, sm: "auto" },
+        rounded: { base: "20px 20px 0 0", sm: "2xl" },
         w: { base: "100vw", sm: "min(640px, 92vw)" },
-        h: { base: "100dvh", sm: "auto" },
+        h: "auto",
         maxW: { base: "100vw", sm: "min(640px, 92vw)" },
-        maxH: { base: "100dvh", sm: "85dvh" },
+        maxH: { base: "85dvh", sm: "85dvh" },
         overflow: "hidden",
+        animation: { base: "sheet-up 0.28s cubic-bezier(0.32, 0.72, 0, 1)", sm: "none" },
         _backdrop: { bg: "black/60" },
       })}
     >

--- a/play-igrus/frontend/src/index.css
+++ b/play-igrus/frontend/src/index.css
@@ -13,3 +13,13 @@
     sans-serif;
   -webkit-font-smoothing: antialiased;
 }
+
+/* 바텀시트(모바일 CTA) 슬라이드업 */
+@keyframes sheet-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}

--- a/play-igrus/frontend/src/pages/HomePage.tsx
+++ b/play-igrus/frontend/src/pages/HomePage.tsx
@@ -177,7 +177,11 @@ export default function HomePage() {
       <ProjectDialog
         project={selected}
         onClose={() => setSelected(null)}
-        onAuthor={() => selected && setAuthorFor(selected.id)}
+        onAuthor={() => {
+          if (!selected) return;
+          setAuthorFor(selected.id); // 새 바텀시트 올리고
+          setSelected(null); // 기존 작품 시트는 지운다
+        }}
       />
       <AuthorDialog
         projectId={authorFor}

--- a/play-igrus/frontend/src/pages/ProfilePage.tsx
+++ b/play-igrus/frontend/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { css } from "styled-system/css";
 import { flex } from "styled-system/patterns";
 import {
@@ -13,7 +13,10 @@ import {
 } from "../api/client";
 import RequireLogin from "../components/RequireLogin";
 import { field, input, label } from "../components/formStyles";
-import ImageDropzone from "../components/ImageDropzone";
+import AvatarPlaceholder from "../components/Avatar";
+
+const ACCEPTED_AVATAR = ["image/png", "image/jpeg", "image/webp"];
+const MAX_AVATAR_BYTES = 4 << 20; // 서버와 동일 4MB
 
 export default function ProfilePage() {
   return (
@@ -48,6 +51,7 @@ function ProfileEditor() {
   const [avatarUrl, setAvatarUrl] = useState("");
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ text: string; ok: boolean }>();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     fetchMyProfile()
@@ -70,6 +74,14 @@ function ProfileEditor() {
   const pickAvatar = async (file?: File) => {
     if (!file) return;
     setMessage(undefined);
+    if (!ACCEPTED_AVATAR.includes(file.type)) {
+      setMessage({ text: "PNG/JPEG/WebP 이미지만 올릴 수 있어요", ok: false });
+      return;
+    }
+    if (file.size > MAX_AVATAR_BYTES) {
+      setMessage({ text: "4MB 이하 이미지만 올릴 수 있어요", ok: false });
+      return;
+    }
     try {
       const { avatarUrl: url } = await uploadMyAvatar(file);
       setAvatarUrl(url);
@@ -149,31 +161,70 @@ function ProfileEditor() {
               <p className={readOnlyValue}>{name || "—"}</p>
             </div>
           </div>
-          <div>
-            <ImageDropzone
-              id="avatar"
-              title="프로필 사진"
-              hint="PNG/JPG/WebP · 4MB 이하"
-              square
-              existingUrl={imageSrc(avatarUrl)}
-              onChange={pickAvatar}
-            />
-            {avatarUrl && (
-              <button
-                type="button"
-                onClick={removeAvatar}
-                className={css({
-                  mt: "2",
-                  fontSize: "xs",
-                  fontWeight: "600",
-                  color: "gray.500",
-                  cursor: "pointer",
-                  _hover: { color: "red.500", textDecoration: "underline" },
-                })}
-              >
-                사진 지우기
-              </button>
-            )}
+          <div className={field}>
+            <span className={label}>프로필 사진</span>
+            <div className={flex({ direction: "column", align: "center", gap: "3" })}>
+              {avatarUrl ? (
+                <img
+                  src={imageSrc(avatarUrl)}
+                  alt="프로필 사진"
+                  className={css({
+                    w: "40",
+                    h: "40",
+                    rounded: "xl",
+                    objectFit: "cover",
+                    border: "1px solid",
+                    borderColor: "gray.200",
+                  })}
+                />
+              ) : (
+                <AvatarPlaceholder size="40" rounded="xl" />
+              )}
+              <div className={flex({ gap: "3", align: "center" })}>
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className={css({
+                    px: "4",
+                    py: "2",
+                    rounded: "lg",
+                    fontSize: "sm",
+                    fontWeight: "700",
+                    bg: "gray.100",
+                    color: "gray.700",
+                    cursor: "pointer",
+                    _hover: { bg: "gray.200" },
+                  })}
+                >
+                  수정하기
+                </button>
+                {avatarUrl && (
+                  <button
+                    type="button"
+                    onClick={removeAvatar}
+                    className={css({
+                      fontSize: "xs",
+                      fontWeight: "600",
+                      color: "gray.500",
+                      cursor: "pointer",
+                      _hover: { color: "red.500", textDecoration: "underline" },
+                    })}
+                  >
+                    사진 지우기
+                  </button>
+                )}
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={ACCEPTED_AVATAR.join(",")}
+                className={css({ srOnly: true })}
+                onChange={(e) => {
+                  void pickAvatar(e.target.files?.[0]);
+                  e.target.value = ""; // 같은 파일 다시 선택 가능하게 초기화
+                }}
+              />
+            </div>
           </div>
 
           <div className={field}>


### PR DESCRIPTION
## 요약
play.igrus.co.kr 모바일에서 카드/개발자 탭 시 뜨던 풀스크린 다이얼로그를 하단 **바텀시트 CTA**로 바꿉니다.

## 변경
- 작품·작성자 다이얼로그 → 모바일에서 하단 바텀시트 (슬라이드업 애니메이션, 상단 라운드, `maxH 85dvh`). 데스크톱 중앙 다이얼로그는 그대로.
- 시트가 열린 동안 배경 스크롤 잠금(`body overflow: hidden`), 시트 내부 컨텐츠만 스크롤 (길어도 시트 안에서 스크롤 가능).
- 작품 시트에서 작성자 탭 → 기존 시트를 닫고 작성자 시트를 새로 올림.
- 아바타 자리표시자(`PersonIcon`/`AvatarPlaceholder`)를 공통 컴포넌트로 분리해 Layout·프로필에서 재사용.

## 확인
- `tsc --noEmit` 통과
- `npm run dev` 모바일 뷰포트(≈492px)에서 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)