### PR TITLE
feat(play): 바텀시트 끌어내려 닫기 + 앱 목록 스크롤 먹통 수정

### DIFF
--- a/play-igrus/frontend/src/components/AuthorDialog.tsx
+++ b/play-igrus/frontend/src/components/AuthorDialog.tsx
@@ -3,7 +3,9 @@ import { css } from "styled-system/css";
 import { flex } from "styled-system/patterns";
 import { fetchAuthor, imageSrc, type AuthorProfile, type Project } from "../api/client";
 import { useScrollLock } from "../hooks/useScrollLock";
+import { useSheetDrag } from "../hooks/useSheetDrag";
 import CloseButton from "./CloseButton";
+import SheetHandle from "./SheetHandle";
 import { categoryColor } from "./category";
 import AvatarPlaceholder from "./Avatar";
 
@@ -31,6 +33,7 @@ export default function AuthorDialog({ projectId, onClose, onProject }: Props) {
   }, [projectId]);
 
   useScrollLock(projectId !== undefined); // 시트 열린 동안 배경 스크롤 잠금
+  useSheetDrag(ref, onClose, projectId !== undefined); // 모바일: 손가락으로 끌어내려 닫기
 
   useEffect(() => {
     if (projectId === undefined) return;
@@ -70,6 +73,7 @@ export default function AuthorDialog({ projectId, onClose, onProject }: Props) {
     >
       <div className={flex({ pos: "relative", direction: "column", h: "full", maxH: "inherit", bg: "white" })}>
         <CloseButton onClick={onClose} />
+        <SheetHandle />
 
         {author === null ? (
           <p className={css({ textAlign: "center", color: "gray.400", py: "20", fontSize: "sm" })}>
@@ -144,24 +148,24 @@ export default function AuthorDialog({ projectId, onClose, onProject }: Props) {
               )}
             </div>
 
-            {/* 출시작 */}
-            <div className={css({ flex: 1, minH: 0, overflowY: "auto", px: "6", pb: "6" })}>
-              <h3
-                className={css({
-                  fontSize: "xs",
-                  fontWeight: "800",
-                  color: "gray.400",
-                  letterSpacing: "wider",
-                  pt: "2",
-                  pb: "3",
-                  pos: "sticky",
-                  top: 0,
-                  bg: "white",
-                })}
-              >
-                출시한 작품
-              </h3>
+            {/* 출시작 — 헤더는 스크롤 밖 고정, 목록만 스크롤 */}
+            <h3
+              className={css({
+                flexShrink: 0,
+                fontSize: "xs",
+                fontWeight: "800",
+                color: "gray.400",
+                letterSpacing: "wider",
+                px: "6",
+                pt: "2",
+                pb: "3",
+                bg: "white",
+              })}
+            >
+              출시한 앱
+            </h3>
 
+            <div data-sheet-scroll className={css({ flex: 1, minH: 0, overflowY: "auto", px: "6", pb: "6" })}>
               {projects.length === 0 ? (
                 <p className={css({ fontSize: "sm", color: "gray.400", py: "6", textAlign: "center" })}>
                   아직 공개된 작품이 없습니다

--- a/play-igrus/frontend/src/components/ProjectDialog.tsx
+++ b/play-igrus/frontend/src/components/ProjectDialog.tsx
@@ -4,7 +4,9 @@ import { css } from "styled-system/css";
 import { flex } from "styled-system/patterns";
 import { clickProject, imageSrc, type Project } from "../api/client";
 import { useScrollLock } from "../hooks/useScrollLock";
+import { useSheetDrag } from "../hooks/useSheetDrag";
 import CloseButton from "./CloseButton";
+import SheetHandle from "./SheetHandle";
 import { categoryColor } from "./category";
 
 interface Props {
@@ -26,6 +28,7 @@ export default function ProjectDialog({ project, onClose, onAuthor }: Props) {
   }, [project]);
 
   useScrollLock(project != null); // 시트 열린 동안 배경 스크롤 잠금
+  useSheetDrag(ref, onClose, project != null); // 모바일: 손가락으로 끌어내려 닫기
 
   if (!project) return null;
 
@@ -65,6 +68,7 @@ export default function ProjectDialog({ project, onClose, onAuthor }: Props) {
       <div className={flex({ pos: "relative", direction: "column", h: "full", maxH: "inherit", bg: "white" })}>
         {/* X — 개발자 시트와 같은 시트 최상단 코너 (배너 위) */}
         <CloseButton onClick={onClose} />
+        <SheetHandle />
 
         {/* 배너 — 이전처럼 full-bleed (패딩·라운드 없음) */}
         {banner && (
@@ -129,7 +133,7 @@ export default function ProjectDialog({ project, onClose, onAuthor }: Props) {
         </div>
 
         {/* 소개 (마크다운, 스크롤) */}
-        <div className={css({ flex: 1, minH: 0, overflowY: "auto", px: "6", pb: "6" })}>
+        <div data-sheet-scroll className={css({ flex: 1, minH: 0, overflowY: "auto", px: "6", pb: "6" })}>
           <h3
             className={css({
               fontSize: "xs",

--- a/play-igrus/frontend/src/components/SheetHandle.tsx
+++ b/play-igrus/frontend/src/components/SheetHandle.tsx
@@ -1,0 +1,22 @@
+import { css } from "styled-system/css";
+
+/** 모바일 바텀시트 상단 드래그 손잡이 — 끌어내려 닫을 수 있다는 어포던스 (시각용, 터치는 시트 전체가 처리) */
+export default function SheetHandle() {
+  return (
+    <div
+      className={css({
+        display: { base: "block", sm: "none" },
+        pos: "absolute",
+        top: "3",
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 1,
+        w: "16",
+        h: "4px",
+        rounded: "full",
+        bg: "black/80",
+        pointerEvents: "none",
+      })}
+    />
+  );
+}

--- a/play-igrus/frontend/src/hooks/useSheetDrag.ts
+++ b/play-igrus/frontend/src/hooks/useSheetDrag.ts
@@ -1,0 +1,85 @@
+import { useEffect, type RefObject } from "react";
+
+/**
+ * 모바일 바텀시트를 손가락으로 아래로 끌어내려 닫는 제스처.
+ *
+ * 앱 목록 등 내부 스크롤과 충돌하지 않도록, 안쪽 스크롤 영역([data-sheet-scroll])이
+ * 맨 위에 있고 + 아래로 당기는 수직 제스처일 때만 드래그로 확정한다.
+ * 그 외(목록 스크롤·위로 당김·가로 스와이프)는 네이티브 스크롤에 맡긴다.
+ *
+ * @param sheetRef translateY 로 움직일 시트 요소(<dialog>)
+ * @param onClose  임계치 이상 끌어내렸을 때 호출
+ * @param open     시트가 열려 있는 동안만 true (열릴 때마다 리스너 재부착)
+ */
+export function useSheetDrag(
+  sheetRef: RefObject<HTMLDialogElement | null>,
+  onClose: () => void,
+  open: boolean,
+) {
+  useEffect(() => {
+    const sheet = sheetRef.current;
+    if (!sheet || !open) return;
+    if (!window.matchMedia("(max-width: 639px)").matches) return; // 모바일 전용
+
+    let startX = 0;
+    let startY = 0;
+    let dy = 0;
+    let startedInScroller = false; // 터치가 스크롤 앱 영역에서 시작됐는지
+    let dragging = false; // 이번 터치가 시트 드래그로 확정됐는지
+
+    const onStart = (e: TouchEvent) => {
+      // 스크롤 영역은 시트가 늦게 채워질 수 있어(로딩) 터치 시작마다 다시 찾는다
+      const scroller = sheet.querySelector<HTMLElement>("[data-sheet-scroll]");
+      startedInScroller = !!scroller && scroller.contains(e.target as Node);
+      startX = e.touches[0].clientX;
+      startY = e.touches[0].clientY;
+      dy = 0;
+      dragging = false;
+    };
+
+    const onMove = (e: TouchEvent) => {
+      const t = e.touches[0];
+      if (!dragging) {
+        const dyRaw = t.clientY - startY;
+        const dxRaw = t.clientX - startX;
+        // 아래로(6px 데드존) + 세로 우세 + 스크롤 앱 영역 밖(헤더·배너·손잡이)에서 시작했을 때만 확정.
+        // 앱 목록 영역에서 시작한 터치는 스크롤 여부와 무관하게 시트로 넘어가지 않는다.
+        if (dyRaw > 6 && Math.abs(dyRaw) > Math.abs(dxRaw) && !startedInScroller) {
+          dragging = true;
+          startY = t.clientY; // 재기준점 → dy 0부터 부드럽게
+        } else {
+          return; // 네이티브 스크롤에 맡김
+        }
+      }
+      dy = Math.max(0, t.clientY - startY);
+      e.preventDefault(); // 확정 후엔 배경/내부 스크롤 차단
+      sheet.style.transition = "none";
+      sheet.style.transform = `translateY(${dy}px)`;
+    };
+
+    const onEnd = () => {
+      if (!dragging) return;
+      dragging = false;
+      sheet.style.transition = "transform 0.25s cubic-bezier(0.32, 0.72, 0, 1)";
+      if (dy > 120) {
+        sheet.style.transform = "translateY(100%)";
+        onClose();
+      } else {
+        sheet.style.transform = "translateY(0)";
+      }
+    };
+
+    sheet.addEventListener("touchstart", onStart, { passive: true });
+    sheet.addEventListener("touchmove", onMove, { passive: false });
+    sheet.addEventListener("touchend", onEnd);
+    sheet.addEventListener("touchcancel", onEnd);
+    return () => {
+      sheet.removeEventListener("touchstart", onStart);
+      sheet.removeEventListener("touchmove", onMove);
+      sheet.removeEventListener("touchend", onEnd);
+      sheet.removeEventListener("touchcancel", onEnd);
+      sheet.style.transform = "";
+      sheet.style.transition = "";
+    };
+  }, [sheetRef, onClose, open]);
+}

--- a/play-igrus/frontend/src/pages/HomePage.tsx
+++ b/play-igrus/frontend/src/pages/HomePage.tsx
@@ -30,7 +30,8 @@ export default function HomePage() {
   const open = (p: Project) => {
     setSelected(p); // 목록 데이터로 즉시 열고
     fetchProject(p.id)
-      .then(setSelected) // 본문/배너는 도착하면 채운다
+      // 도착 전에 유저가 닫았거나 다른 작품을 열었으면 되살리지 않는다 (닫힌 시트 재개장 → 스크롤 잠금 잔존 방지)
+      .then((full) => setSelected((cur) => (cur?.id === p.id ? full : cur)))
       .catch(() => {});
   };
 


### PR DESCRIPTION
## 요약
- 모바일 바텀시트(작품 상세·개발자 프로필)를 손가락으로 끌어내려 닫을 수 있게 함
- 앱 카드 스크롤이 가끔 먹통되던 버그 수정

## 변경
- **`useSheetDrag` 훅**: 모바일 전용 끌어내려 닫기. 스크롤 앱 영역(`[data-sheet-scroll]`)에서 시작한 터치는 시트 드래그로 넘어가지 않아 목록 스크롤과 충돌하지 않음. 헤더·배너·손잡이를 잡고 아래로 120px 넘게 당기면 닫힘
- **`SheetHandle`**: 시트 상단 드래그 손잡이(어포던스, 시각용)
- **AuthorDialog**: "출시한 앱" 헤더를 스크롤 밖 고정 영역으로 분리(`sticky`·`z-index` 제거)
- **HomePage 스크롤 먹통 수정**: 유저가 시트를 닫은 뒤 도착한 `fetchProject` 응답이 시트를 되살려 배경 스크롤 잠금(`position:fixed`)이 남던 레이스 제거

## 검증
- `tsc --noEmit` 통과, `vite build` 통과
- 터치 제스처는 실기기/모바일 뷰 확인 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)