### PR TITLE
feat(auth): 로그인·회원가입 흐름형 재디자인 + 회원 가입 먹통 버그 수정

### DIFF
--- a/frontend/src/components/feature/auth/LoginForm.tsx
+++ b/frontend/src/components/feature/auth/LoginForm.tsx
@@ -1,8 +1,9 @@
 import { type FormEvent, useState } from "react";
 import { Link } from "react-router-dom";
-import { User, Lock, ArrowRight, Eye, EyeOff } from "lucide-react";
+import { User, Lock, Eye, EyeOff, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 
 interface LoginFormData {
   studentId: string;
@@ -33,167 +34,120 @@ export default function LoginForm({
   };
 
   return (
-    <div className="overflow-hidden rounded-r4 border border-border bg-card shadow-2xl">
-      <div className="grid min-h-[520px] grid-cols-1 lg:grid-cols-5">
-        {/* Brand Panel */}
-        <div className="login-brand-panel relative flex flex-col justify-between overflow-hidden p-s6 lg:col-span-2 lg:p-s7">
-          {/* Decorative circles */}
-          <div className="pointer-events-none absolute inset-0">
-            <div className="absolute -right-10 -top-10 h-40 w-40 rounded-full border-2 border-primary/20" />
-            <div className="absolute -left-8 top-1/3 h-24 w-24 rounded-full border border-primary/15" />
-            <div className="absolute -bottom-6 right-1/4 h-32 w-32 rounded-full border border-primary/10" />
-            {/* Dot grid overlay */}
-            <div className="login-dot-grid absolute inset-0" />
-          </div>
-
-          {/* Brand content */}
-          <div className="relative z-10">
-            <div className="mb-s4 flex items-center gap-s3 lg:mb-s7">
-              <img
-                src="/igruslogo.png"
-                alt="IGRUS"
-                className="h-9 w-9 lg:h-11 lg:w-11"
-              />
-              <span className="text-lg font-bold tracking-tight text-primary">
-                IGRUS
-              </span>
-            </div>
-
-            <h1 className="mb-s2 hidden text-4xl font-extrabold leading-tight text-foreground lg:block">
-              Welcome
-            </h1>
-            <p className="hidden text-foreground/80 typo-b2 lg:block">
-              IGRUS에 오신 것을 환영합니다.
-            </p>
-
-            {/* Mobile-only compact text */}
-            <p className="text-foreground/80 typo-b2 lg:hidden">
-              IGRUS에 오신 것을 환영합니다.
-            </p>
-          </div>
-
-          <p className="relative z-10 hidden text-foreground/60 typo-c1 lg:block">
-            인하대학교 IT 동아리
-          </p>
-        </div>
-
-        {/* Form Panel */}
-        <div className="flex flex-col justify-center p-s6 lg:col-span-3 lg:p-s7">
-          <div className="mb-s6">
-            <h2 className="mb-s2 typo-h2">로그인</h2>
-            <p className="text-muted-foreground typo-b2">
-              학번과 비밀번호를 입력해주세요
-            </p>
-          </div>
-
-          <form onSubmit={handleSubmit} className="space-y-s5">
-            {/* Student ID */}
-            <div>
-              <label className="mb-s2 block text-muted-foreground typo-label">
-                학번
-              </label>
-              <div className="relative">
-                <User
-                  size={18}
-                  className="absolute left-s4 top-1/2 -translate-y-1/2 text-muted-foreground"
-                />
-                <Input
-                  type="text"
-                  name="username"
-                  autoComplete="username"
-                  placeholder="8자리 학번 입력"
-                  value={studentId}
-                  onChange={(e) => setStudentId(e.target.value)}
-                  required
-                  className={`w-full rounded-r3 border py-s5 pl-12 pr-s4 transition-all ${
-                    errors.studentId
-                      ? "border-destructive focus:border-destructive"
-                      : "border-border focus:border-primary"
-                  }`}
-                />
-              </div>
-              {errors.studentId && (
-                <p className="mt-s1 text-destructive typo-c1">
-                  {errors.studentId}
-                </p>
-              )}
-            </div>
-
-            {/* Password */}
-            <div>
-              <label className="mb-s2 block text-muted-foreground typo-label">
-                비밀번호
-              </label>
-              <div className="group relative">
-                <Lock
-                  size={18}
-                  className="absolute left-s4 top-1/2 -translate-y-1/2 text-muted-foreground"
-                />
-                <Input
-                  type={showPassword ? "text" : "password"}
-                  name="password"
-                  autoComplete="current-password"
-                  placeholder="영문, 숫자 포함 8자 이상"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  className={`w-full rounded-r3 border py-s5 pl-12 pr-12 transition-all ${
-                    errors.password
-                      ? "border-destructive focus:border-destructive"
-                      : "border-border focus:border-primary"
-                  }`}
-                />
-                <button
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-s4 top-1/2 -translate-y-1/2 text-muted-foreground opacity-0 transition-all hover:text-foreground group-focus-within:opacity-100"
-                >
-                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-                </button>
-              </div>
-              {errors.password && (
-                <p className="mt-s1 text-destructive typo-c1">
-                  {errors.password}
-                </p>
-              )}
-            </div>
-
-            {/* Forgot password */}
-            <div className="flex justify-end">
-              <Link
-                to="/forgot-password"
-                className="text-primary transition hover:text-primary/80 typo-c1"
-              >
-                비밀번호를 잊으셨나요?
-              </Link>
-            </div>
-
-            {/* Submit */}
-            <Button
-              type="submit"
-              disabled={loading}
-              className="flex w-full items-center justify-center gap-s2 rounded-r3 py-s5 font-bold"
-            >
-              {loading ? "로그인 중..." : "로그인"}
-              {!loading && <ArrowRight size={18} />}
-            </Button>
-          </form>
-
-          {/* Sign up link */}
-          <div className="mt-s6 text-center">
-            <p className="text-muted-foreground typo-b2">
-              아직 계정이 없으신가요?{" "}
-              <Link
-                to="/signup"
-                className="font-semibold text-primary transition hover:text-primary/80"
-              >
-                회원가입
-              </Link>
-            </p>
-          </div>
-        </div>
+    <div>
+      {/* 헤더 */}
+      <div className="mb-s6 flex flex-col items-center text-center">
+        <img src="/igruslogo.png" alt="IGRUS" className="h-12 w-12" />
+        <h1 className="mt-s4 typo-h2 text-foreground">로그인</h1>
+        <p className="mt-s1 typo-b2 text-muted-foreground">
+          학번과 비밀번호로 로그인해요
+        </p>
       </div>
+
+      <form onSubmit={handleSubmit} className="space-y-s4">
+        {/* 학번 */}
+        <div>
+          <label className="mb-s2 block text-sm font-medium text-foreground">
+            학번
+          </label>
+          <div className="relative">
+            <User
+              size={18}
+              className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              type="text"
+              name="username"
+              autoComplete="username"
+              placeholder="8자리 학번"
+              value={studentId}
+              onChange={(e) => setStudentId(e.target.value)}
+              required
+              className={cn(
+                "h-11 rounded-r3 pl-10",
+                errors.studentId && "border-destructive",
+              )}
+            />
+          </div>
+          {errors.studentId && (
+            <p className="mt-s2 text-sm text-destructive">{errors.studentId}</p>
+          )}
+        </div>
+
+        {/* 비밀번호 */}
+        <div>
+          <label className="mb-s2 block text-sm font-medium text-foreground">
+            비밀번호
+          </label>
+          <div className="relative">
+            <Lock
+              size={18}
+              className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              type={showPassword ? "text" : "password"}
+              name="password"
+              autoComplete="current-password"
+              placeholder="비밀번호"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className={cn(
+                "h-11 rounded-r3 pl-10 pr-10",
+                errors.password && "border-destructive",
+              )}
+            />
+            <button
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            >
+              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            </button>
+          </div>
+          {errors.password && (
+            <p className="mt-s2 text-sm text-destructive">{errors.password}</p>
+          )}
+        </div>
+
+        {/* 비밀번호 찾기 */}
+        <div className="flex justify-end">
+          <Link
+            to="/forgot-password"
+            className="text-sm text-muted-foreground transition-colors hover:text-primary"
+          >
+            비밀번호를 잊으셨나요?
+          </Link>
+        </div>
+
+        {/* 로그인 버튼 */}
+        <Button
+          type="submit"
+          disabled={loading}
+          className="h-12 w-full cursor-pointer text-base font-bold"
+        >
+          {loading ? (
+            <>
+              <Loader2 size={18} className="animate-spin" />
+              로그인 중...
+            </>
+          ) : (
+            "로그인"
+          )}
+        </Button>
+      </form>
+
+      {/* 회원가입 링크 */}
+      <p className="mt-s6 text-center text-sm text-muted-foreground">
+        아직 계정이 없으신가요?{" "}
+        <Link
+          to="/signup"
+          className="font-semibold text-primary hover:underline"
+        >
+          회원가입
+        </Link>
+      </p>
     </div>
   );
 }

--- a/frontend/src/components/feature/auth/LoginForm.tsx
+++ b/frontend/src/components/feature/auth/LoginForm.tsx
@@ -99,6 +99,8 @@ export default function LoginForm({
                 />
                 <Input
                   type="text"
+                  name="username"
+                  autoComplete="username"
                   placeholder="8자리 학번 입력"
                   value={studentId}
                   onChange={(e) => setStudentId(e.target.value)}
@@ -129,6 +131,8 @@ export default function LoginForm({
                 />
                 <Input
                   type={showPassword ? "text" : "password"}
+                  name="password"
+                  autoComplete="current-password"
                   placeholder="영문, 숫자 포함 8자 이상"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1070,47 +1070,6 @@
    Login Page
    ============================================ */
 
-/* 브랜드 패널 그라디언트 — 히어로 섹션 배경 색상 사용 */
-.login-brand-panel {
-  background:
-    radial-gradient(
-      circle at 15% 40%,
-      rgba(3, 166, 158, 0.32) 0%,
-      transparent 65%
-    ),
-    radial-gradient(
-      circle at 85% 20%,
-      rgba(23, 162, 184, 0.26) 0%,
-      transparent 55%
-    ),
-    radial-gradient(
-      circle at 60% 85%,
-      rgba(111, 66, 193, 0.22) 0%,
-      transparent 55%
-    ),
-    #ffffff;
-}
-
-/* 브랜드 패널 도트 그리드 */
-.login-dot-grid {
-  background-image: radial-gradient(
-    circle,
-    rgba(3, 166, 158, 0.18) 1px,
-    transparent 1px
-  );
-  background-size: 24px 24px;
-  mask-image: radial-gradient(
-    ellipse 70% 60% at 70% 30%,
-    black 0%,
-    transparent 70%
-  );
-  -webkit-mask-image: radial-gradient(
-    ellipse 70% 60% at 70% 30%,
-    black 0%,
-    transparent 70%
-  );
-}
-
 /* ============================================
    React DatePicker Custom Styling
    ============================================ */

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -225,8 +225,8 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex h-full items-center justify-center px-s4">
-      <div className="w-full max-w-4xl animate-in slide-in-from-bottom-8 duration-500">
+    <div className="flex min-h-full items-center justify-center px-s4 py-s7">
+      <div className="w-full max-w-sm">
         <LoginForm onSubmit={handleLogin} loading={loading} />
       </div>
     </div>

--- a/frontend/src/pages/auth/SignupPage.tsx
+++ b/frontend/src/pages/auth/SignupPage.tsx
@@ -23,6 +23,8 @@ import {
   Copy,
   CircleCheck,
   LogIn,
+  ShieldCheck,
+  type LucideIcon,
 } from "lucide-react";
 import {
   useSignup,
@@ -409,870 +411,918 @@ export default function SignupPage() {
 
   const slackInviteUrl = import.meta.env.VITE_SLACK_INVITE_URL;
 
+  // --- 완료 화면 ---
   if (signupCompleted) {
     return (
-      <div className="flex items-center justify-center min-h-full py-s6 px-s4">
-        <div className="w-full max-w-lg animate-in slide-in-from-bottom-6 duration-500">
-          {/* 완료 아이콘 및 메시지 */}
-          <div className="text-center mb-s7">
-            <div className="mx-auto w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center mb-s5">
-              <CircleCheck
-                size={36}
-                className="text-green-600 dark:text-green-400"
-              />
-            </div>
-            <h1 className="typo-h2 text-foreground">회원가입 완료!</h1>
-            <p className="typo-b2 text-muted-foreground mt-s2">
-              IGRUS 회원가입이 성공적으로 완료되었습니다.
-            </p>
-            {completedTempStudentId && (
-              <div className="mt-s4 inline-flex items-center gap-s2 bg-primary/10 text-primary rounded-r2 px-s4 py-s2">
-                <Key size={16} />
-                <span className="typo-b2 font-medium">
-                  임시 학번: {completedTempStudentId}
-                </span>
-              </div>
-            )}
+      <div className="mx-auto w-full max-w-lg px-s4 py-s7 animate-in slide-in-from-bottom-4 duration-500">
+        {/* 완료 아이콘 및 메시지 */}
+        <div className="text-center mb-s7">
+          <div className="mx-auto w-16 h-16 rounded-full bg-brand-l1 dark:bg-primary/15 flex items-center justify-center mb-s5">
+            <CircleCheck size={36} className="text-primary" />
           </div>
-
-          {/* 슬랙 안내 섹션 */}
-          {slackInviteUrl && (
-            <div className="rounded-r4 border bg-card p-s6 shadow-sm mb-s5">
-              <h2 className="typo-h4 text-foreground mb-s4">
-                슬랙 채널에 참여하세요
-              </h2>
-              <p className="typo-b2 text-muted-foreground mb-s5">
-                IGRUS의 주요 소통은 슬랙에서 이루어집니다.
-                <br />
-                아래 버튼을 눌러 슬랙 워크스페이스에 참여해 주세요.
-              </p>
-              <a
-                href={slackInviteUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block"
-              >
-                <Button type="button" className="w-full cursor-pointer">
-                  IGRUS 슬랙 참여하기
-                  <ExternalLink size={16} />
-                </Button>
-              </a>
+          <h1 className="typo-h2 text-foreground">회원가입 완료!</h1>
+          <p className="typo-b2 text-muted-foreground mt-s2">
+            IGRUS 회원가입이 성공적으로 완료되었습니다.
+          </p>
+          {completedTempStudentId && (
+            <div className="mt-s4 inline-flex items-center gap-s2 bg-primary/10 text-primary rounded-full px-s4 py-s2">
+              <Key size={16} />
+              <span className="typo-b2 font-semibold">
+                임시 학번: {completedTempStudentId}
+              </span>
             </div>
           )}
-
-          {/* 로그인 이동 버튼 */}
-          <Button
-            type="button"
-            variant={slackInviteUrl ? "outline" : "default"}
-            className="w-full cursor-pointer"
-            onClick={() => navigate("/login")}
-          >
-            <LogIn size={16} />
-            로그인하러 가기
-          </Button>
         </div>
+
+        {/* 슬랙 안내 섹션 */}
+        {slackInviteUrl && (
+          <div className="rounded-r4 border bg-card p-s6 shadow-sm mb-s4">
+            <h2 className="typo-h4 text-foreground mb-s3">
+              슬랙 채널에 참여하세요
+            </h2>
+            <p className="typo-b2 text-muted-foreground mb-s5">
+              IGRUS의 주요 소통은 슬랙에서 이루어집니다.
+              <br />
+              아래 버튼을 눌러 슬랙 워크스페이스에 참여해 주세요.
+            </p>
+            <a
+              href={slackInviteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block"
+            >
+              <Button
+                type="button"
+                className="w-full h-12 text-base cursor-pointer"
+              >
+                IGRUS 슬랙 참여하기
+                <ExternalLink size={16} />
+              </Button>
+            </a>
+          </div>
+        )}
+
+        {/* 로그인 이동 버튼 */}
+        <Button
+          type="button"
+          variant={slackInviteUrl ? "outline" : "default"}
+          className="w-full h-12 text-base cursor-pointer"
+          onClick={() => navigate("/login")}
+        >
+          <LogIn size={16} />
+          로그인하러 가기
+        </Button>
       </div>
     );
   }
 
-  return (
-    <div className="flex items-center justify-center min-h-full py-s6 px-s4">
-      <div className="w-full max-w-2xl animate-in slide-in-from-bottom-6 duration-500">
-        {/* Header */}
-        <div className="text-center mb-s7">
+  // --- 가입 유형 선택 화면 ---
+  if (!memberType) {
+    return (
+      <div className="mx-auto w-full max-w-md px-s4 py-s7 animate-in slide-in-from-bottom-4 duration-500">
+        <div className="text-center mb-s6">
           <h1 className="typo-h2 text-foreground">IGRUS 회원가입</h1>
           <p className="typo-b2 text-muted-foreground mt-s1">
-            동아리에 가입하여 다양한 활동에 참여하세요
+            가입 유형을 선택해주세요
           </p>
         </div>
 
-        {/* Membership Type Selection */}
-        {!memberType && (
-          <div className="rounded-r4 border bg-card p-s6 shadow-sm space-y-s4">
-            <button
-              type="button"
-              onClick={() => {
-                setMemberType("member");
-                setValue("wishes", []);
-                setValue("interests", []);
-                setValue("joinRoute", "");
-              }}
-              className="w-full rounded-r2 border border-border bg-muted p-s5 text-left hover:border-primary/50 transition-all cursor-pointer"
-            >
-              <div className="flex items-center gap-s2 mb-s1">
-                <Wallet size={18} className="text-primary" />
-                <span className="typo-h4 text-foreground">회원으로 가입</span>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                회비를 납부하고 동아리 활동에 참여합니다
-              </p>
-            </button>
+        <div className="space-y-s3">
+          <TypeChoice
+            icon={Wallet}
+            title="회원으로 가입"
+            description="회비를 납부하고 동아리 활동에 참여합니다"
+            onClick={() => {
+              setMemberType("member");
+              setValue("wishes", []);
+              setValue("interests", []);
+              setValue("joinRoute", "");
+            }}
+          />
+          <TypeChoice
+            icon={User}
+            title="비회원으로 가입"
+            description="회비 납부 없이 가입합니다"
+            onClick={() => {
+              setMemberType("guest");
+              // 비회원은 기타 섹션을 입력받지 않으므로 스키마·API 필수값을 "기타"로 채움
+              // (wishes의 "기타"는 enum 매핑에서 걸러져 빈 배열로 전송됨)
+              setValue("wishes", ["기타"]);
+              setValue("interests", ["기타"]);
+              setValue("joinRoute", "기타");
+            }}
+          />
+        </div>
 
-            <button
-              type="button"
-              onClick={() => {
-                setMemberType("guest");
-                // 비회원은 기타 섹션을 입력받지 않으므로 스키마·API 필수값을 "기타"로 채움
-                // (wishes의 "기타"는 enum 매핑에서 걸러져 빈 배열로 전송됨)
-                setValue("wishes", ["기타"]);
-                setValue("interests", ["기타"]);
-                setValue("joinRoute", "기타");
-              }}
-              className="w-full rounded-r2 border border-border bg-muted p-s5 text-left hover:border-primary/50 transition-all cursor-pointer"
-            >
-              <div className="flex items-center gap-s2 mb-s1">
-                <User size={18} className="text-primary" />
-                <span className="typo-h4 text-foreground">비회원으로 가입</span>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                회비 납부 없이 가입합니다
-              </p>
-            </button>
+        <p className="text-center text-sm text-muted-foreground mt-s6">
+          이미 계정이 있으신가요?{" "}
+          <Link
+            to="/login"
+            className="text-primary font-semibold hover:underline"
+          >
+            로그인
+          </Link>
+        </p>
+      </div>
+    );
+  }
 
-            <p className="text-center text-sm text-muted-foreground">
-              이미 계정이 있으신가요?{" "}
-              <Link
-                to="/login"
-                className="text-primary font-medium hover:underline"
+  // --- 가입 폼 화면 ---
+  return (
+    <div className="mx-auto w-full max-w-lg px-s4 pt-s6 pb-s7">
+      {/* 헤더 */}
+      <div className="mb-s5">
+        <button
+          type="button"
+          onClick={() => setMemberType(undefined)}
+          className="inline-flex items-center gap-s1 text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer mb-s3"
+        >
+          <ChevronLeft size={16} />
+          가입 유형 다시 선택
+        </button>
+        <h1 className="typo-h2 text-foreground">
+          {memberType === "member" ? "회원 가입" : "비회원 가입"}
+        </h1>
+        <p className="typo-b2 text-muted-foreground mt-s1">
+          학번과 비밀번호로 로그인해요. 아래 정보를 입력해주세요.
+        </p>
+      </div>
+
+      {serverError && (
+        <div className="mb-s4 rounded-r3 bg-destructive/10 border border-destructive/20 p-s4 text-sm text-destructive">
+          {serverError}
+        </div>
+      )}
+
+      <form onSubmit={(e) => e.preventDefault()} className="space-y-s4">
+        {/* 계정 (로그인 정보) */}
+        <SectionCard
+          icon={Lock}
+          title="계정"
+          hint="이 학번과 비밀번호로 로그인해요"
+        >
+          {!useTempStudentId && (
+            <FormField
+              label="학번"
+              error={
+                errors.studentId?.message ||
+                (studentIdCheck.isDuplicate
+                  ? studentIdCheck.message
+                  : undefined)
+              }
+              success={
+                studentIdCheck.isAvailable ? studentIdCheck.message : undefined
+              }
+            >
+              <div className="relative">
+                <User
+                  size={18}
+                  className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+                />
+                <Input
+                  {...register("studentId", {
+                    onBlur: () => {
+                      const value = getValues("studentId");
+                      if (/^\d{8}$/.test(value)) {
+                        checkStudentId(value);
+                      }
+                    },
+                    onChange: () => {
+                      resetStudentId();
+                    },
+                  })}
+                  placeholder="12345678"
+                  maxLength={8}
+                  autoComplete="username"
+                  className={cn(
+                    "h-11 rounded-r3 pl-10",
+                    (studentIdCheck.isChecking || studentIdCheck.isAvailable) &&
+                      "pr-10",
+                  )}
+                />
+                {studentIdCheck.isChecking && (
+                  <Loader2
+                    size={16}
+                    className="absolute right-s3 top-1/2 -translate-y-1/2 animate-spin text-muted-foreground"
+                  />
+                )}
+                {studentIdCheck.isAvailable && !studentIdCheck.isChecking && (
+                  <Check
+                    size={16}
+                    className="absolute right-s3 top-1/2 -translate-y-1/2 text-primary"
+                  />
+                )}
+              </div>
+            </FormField>
+          )}
+
+          {isTempStudentIdPeriod && (
+            <label className="flex items-center gap-s3 cursor-pointer group rounded-r3 border border-border p-s3">
+              <input
+                type="checkbox"
+                checked={useTempStudentId}
+                onChange={(e) => {
+                  setUseTempStudentId(e.target.checked);
+                  if (e.target.checked) {
+                    setValue("studentId", "");
+                    clearErrors("studentId");
+                    resetStudentId();
+                    setValue("grade", 1, { shouldValidate: true });
+                  }
+                }}
+                className="cursor-pointer accent-primary"
+              />
+              <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
+                신입생이라서 아직 학번이 나오지 않았어요
+              </span>
+            </label>
+          )}
+
+          {useTempStudentId && (
+            <div className="flex items-start gap-s2 rounded-r3 bg-brand-l1 dark:bg-primary/10 border border-brand-l2 dark:border-primary/30 p-s3">
+              <Info size={16} className="text-primary shrink-0 mt-0.5" />
+              <p className="text-sm text-foreground/80">
+                임시 학번이 자동으로 발급되어 이메일로 전송됩니다.
+                <br />
+                학번이 나오면 <strong>마이페이지</strong>에서 실제 학번으로
+                변경해주세요.
+              </p>
+            </div>
+          )}
+
+          <FormField label="비밀번호" error={errors.password?.message}>
+            <div className="relative">
+              <Lock
+                size={18}
+                className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                {...register("password")}
+                type={showPassword ? "text" : "password"}
+                autoComplete="new-password"
+                placeholder="영문·숫자 포함 8자 이상"
+                className="h-11 rounded-r3 pl-10 pr-10"
+              />
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
               >
-                로그인
-              </Link>
-            </p>
-          </div>
-        )}
+                {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+              </button>
+            </div>
+          </FormField>
 
-        {/* Form Card */}
-        {memberType && (
-          <div className="rounded-r4 border bg-card p-s6 shadow-sm">
-            {serverError && (
-              <div className="mb-s5 rounded-r2 bg-destructive/10 border border-destructive/20 p-s4 text-sm text-destructive">
-                {serverError}
+          <FormField
+            label="비밀번호 확인"
+            error={errors.passwordConfirm?.message}
+            success={
+              passwordConfirmTouched &&
+              !errors.passwordConfirm &&
+              watch("passwordConfirm")
+                ? "비밀번호가 일치합니다."
+                : undefined
+            }
+          >
+            <div className="relative">
+              <Lock
+                size={18}
+                className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                {...register("passwordConfirm", {
+                  onBlur: () => {
+                    setPasswordConfirmTouched(true);
+                    trigger("passwordConfirm");
+                  },
+                })}
+                type={showPasswordConfirm ? "text" : "password"}
+                autoComplete="new-password"
+                placeholder="비밀번호 재입력"
+                className="h-11 rounded-r3 pl-10 pr-10"
+              />
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => setShowPasswordConfirm(!showPasswordConfirm)}
+                className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+              >
+                {showPasswordConfirm ? <EyeOff size={18} /> : <Eye size={18} />}
+              </button>
+            </div>
+          </FormField>
+        </SectionCard>
+
+        {/* 이메일 인증 */}
+        <SectionCard
+          icon={Mail}
+          title="이메일 인증"
+          hint="가입 확인 메일을 받을 이메일이에요"
+        >
+          <FormField
+            error={
+              errors.emailLocal?.message ||
+              errors.customDomain?.message ||
+              (emailCheck.isDuplicate ? emailCheck.message : undefined)
+            }
+            success={emailCheck.isAvailable ? emailCheck.message : undefined}
+          >
+            <div className="flex items-center gap-s2">
+              <div className="relative flex-1">
+                <Mail
+                  size={18}
+                  className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+                />
+                <Input
+                  {...register("emailLocal", {
+                    onBlur: () => {
+                      const fullEmail = composeEmail();
+                      if (fullEmail) checkEmail(fullEmail);
+                    },
+                    onChange: () => {
+                      resetEmail();
+                    },
+                  })}
+                  placeholder="아이디"
+                  autoComplete="email"
+                  disabled={emailVerified}
+                  className="h-11 rounded-r3 pl-10"
+                />
+              </div>
+              <span className="text-muted-foreground font-bold shrink-0">
+                @
+              </span>
+              <div className="relative flex-1">
+                <select
+                  {...register("emailDomain", {
+                    onChange: () => {
+                      resetEmail();
+                      // 도메인이 커스텀이 아니고 로컬파트가 있으면 즉시 체크
+                      setTimeout(() => {
+                        const fullEmail = composeEmail();
+                        if (
+                          fullEmail &&
+                          getValues("emailDomain") !== "custom"
+                        ) {
+                          checkEmail(fullEmail);
+                        }
+                      }, 0);
+                    },
+                  })}
+                  disabled={emailVerified}
+                  className={cn(
+                    "w-full h-11 rounded-r3 border border-input bg-background text-foreground px-s3 text-sm",
+                    "appearance-none cursor-pointer transition-all outline-none",
+                    "focus:border-ring focus:ring-ring/50 focus:ring-[3px]",
+                  )}
+                >
+                  {domainOptions.map((d) => (
+                    <option
+                      key={d.value}
+                      value={d.value}
+                      className="bg-background text-foreground"
+                    >
+                      {d.label}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown
+                  size={16}
+                  className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+                />
+              </div>
+            </div>
+            {emailDomain === "custom" && (
+              <Input
+                {...register("customDomain", {
+                  validate: (value) => {
+                    if (
+                      getValues("emailDomain") === "custom" &&
+                      (!value || value.length === 0)
+                    ) {
+                      return "도메인을 입력해주세요.";
+                    }
+                    return true;
+                  },
+                  onBlur: () => {
+                    const fullEmail = composeEmail();
+                    if (fullEmail) checkEmail(fullEmail);
+                  },
+                  onChange: () => {
+                    resetEmail();
+                  },
+                })}
+                placeholder="도메인 입력 (예: example.com)"
+                disabled={emailVerified}
+                className="h-11 rounded-r3 mt-s2"
+              />
+            )}
+            {emailCheck.isChecking && (
+              <div className="flex items-center gap-s1 mt-s1">
+                <Loader2
+                  size={14}
+                  className="animate-spin text-muted-foreground"
+                />
+                <span className="text-sm text-muted-foreground">
+                  확인 중...
+                </span>
               </div>
             )}
 
-            <form onSubmit={(e) => e.preventDefault()}>
-              <div className="space-y-s5">
-                {!useTempStudentId && (
-                  <FormField
-                    label="학번"
-                    error={
-                      errors.studentId?.message ||
-                      (studentIdCheck.isDuplicate
-                        ? studentIdCheck.message
-                        : undefined)
-                    }
-                    success={
-                      studentIdCheck.isAvailable
-                        ? studentIdCheck.message
-                        : undefined
-                    }
-                  >
-                    <div className="relative">
-                      <User
-                        size={18}
-                        className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
-                      />
-                      <Input
-                        {...register("studentId", {
-                          onBlur: () => {
-                            const value = getValues("studentId");
-                            if (/^\d{8}$/.test(value)) {
-                              checkStudentId(value);
-                            }
-                          },
-                          onChange: () => {
-                            resetStudentId();
-                          },
-                        })}
-                        placeholder="12345678"
-                        maxLength={8}
-                        className={cn(
-                          "pl-10",
-                          (studentIdCheck.isChecking ||
-                            studentIdCheck.isAvailable) &&
-                            "pr-10",
-                        )}
-                      />
-                      {studentIdCheck.isChecking && (
-                        <Loader2
-                          size={16}
-                          className="absolute right-s3 top-1/2 -translate-y-1/2 animate-spin text-muted-foreground"
-                        />
-                      )}
-                      {studentIdCheck.isAvailable &&
-                        !studentIdCheck.isChecking && (
-                          <Check
-                            size={16}
-                            className="absolute right-s3 top-1/2 -translate-y-1/2 text-green-600"
-                          />
-                        )}
-                    </div>
-                  </FormField>
-                )}
-
-                {isTempStudentIdPeriod && (
-                  <label className="flex items-center gap-s3 cursor-pointer group rounded-r2 border border-border p-s3">
-                    <input
-                      type="checkbox"
-                      checked={useTempStudentId}
-                      onChange={(e) => {
-                        setUseTempStudentId(e.target.checked);
-                        if (e.target.checked) {
-                          setValue("studentId", "");
-                          clearErrors("studentId");
-                          resetStudentId();
-                          setValue("grade", 1, { shouldValidate: true });
-                        }
-                      }}
-                      className="cursor-pointer accent-primary"
-                    />
-                    <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
-                      신입생이라서 아직 학번이 나오지 않았어요
-                    </span>
-                  </label>
-                )}
-
-                {useTempStudentId && (
-                  <div className="flex items-start gap-s2 rounded-r2 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 p-s3">
-                    <Info size={16} className="text-blue-600 shrink-0 mt-0.5" />
-                    <p className="text-sm text-blue-700 dark:text-blue-400">
-                      임시 학번이 자동으로 발급되어 이메일로 전송됩니다.
-                      <br />
-                      학번이 나오면 <strong>마이페이지</strong>에서 실제
-                      학번으로 변경해주세요.
-                    </p>
-                  </div>
-                )}
-
-                <FormField label="이름" error={errors.name?.message}>
-                  <div className="relative">
-                    <User
-                      size={18}
-                      className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
-                    />
-                    <Input
-                      {...register("name")}
-                      placeholder="홍길동"
-                      className="pl-10"
-                    />
-                  </div>
-                </FormField>
-
-                <FormField label="비밀번호" error={errors.password?.message}>
-                  <div className="relative">
-                    <Lock
-                      size={18}
-                      className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
-                    />
-                    <Input
-                      {...register("password")}
-                      type={showPassword ? "text" : "password"}
-                      placeholder="비밀번호 입력"
-                      className="pl-10 pr-10"
-                    />
-                    <button
-                      type="button"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                    >
-                      {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-                    </button>
-                  </div>
-                </FormField>
-
-                <FormField
-                  label="비밀번호 확인"
-                  error={errors.passwordConfirm?.message}
-                  success={
-                    passwordConfirmTouched &&
-                    !errors.passwordConfirm &&
-                    watch("passwordConfirm")
-                      ? "비밀번호가 일치합니다."
-                      : undefined
+            {/* 이메일 인증하기 버튼 (버튼을 눌러야 인증 코드 발송) */}
+            {!codeSent && !emailVerified && (
+              <div className="mt-s3 space-y-s2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleSendCode}
+                  disabled={
+                    sendingCode ||
+                    emailCheck.isChecking ||
+                    emailCheck.isDuplicate
                   }
+                  className="w-full h-11 cursor-pointer"
                 >
-                  <div className="relative">
-                    <Lock
+                  {sendingCode ? (
+                    <>
+                      <Loader2 size={16} className="animate-spin" />
+                      인증 코드 발송 중...
+                    </>
+                  ) : (
+                    "이메일 인증하기"
+                  )}
+                </Button>
+                {verificationError && (
+                  <p className="text-sm text-destructive">
+                    {verificationError}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* 인증 코드 입력 UI */}
+            {codeSent && !emailVerified && (
+              <div className="mt-s3 space-y-s3">
+                <div className="flex items-center gap-s2">
+                  <div className="relative flex-1">
+                    <Key
                       size={18}
                       className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
                     />
                     <Input
-                      {...register("passwordConfirm", {
-                        onBlur: () => {
-                          setPasswordConfirmTouched(true);
-                          trigger("passwordConfirm");
-                        },
-                      })}
-                      type={showPasswordConfirm ? "text" : "password"}
-                      placeholder="비밀번호 재입력"
-                      className="pl-10 pr-10"
-                    />
-                    <button
-                      type="button"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() =>
-                        setShowPasswordConfirm(!showPasswordConfirm)
+                      type="text"
+                      placeholder="6자리 인증 코드"
+                      value={verificationCode}
+                      onChange={(e) =>
+                        setVerificationCode(
+                          e.target.value.replace(/\D/g, "").slice(0, 6),
+                        )
                       }
-                      className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                    >
-                      {showPasswordConfirm ? (
-                        <EyeOff size={18} />
-                      ) : (
-                        <Eye size={18} />
-                      )}
-                    </button>
-                  </div>
-                </FormField>
-
-                <FormField label="성별" error={errors.gender?.message}>
-                  <div className="grid grid-cols-2 gap-s3">
-                    {(["MALE", "FEMALE"] as const).map((g) => (
-                      <button
-                        key={g}
-                        type="button"
-                        onClick={() =>
-                          setValue("gender", g, { shouldValidate: true })
-                        }
-                        className={cn(
-                          "h-10 rounded-r2 border text-sm font-medium transition-all cursor-pointer",
-                          watch("gender") === g
-                            ? "bg-primary text-primary-foreground border-primary"
-                            : "bg-muted border-border text-foreground hover:border-primary/50",
-                        )}
-                      >
-                        {g === "MALE" ? "남성" : "여성"}
-                      </button>
-                    ))}
-                  </div>
-                </FormField>
-
-                <FormField label="학과" error={errors.department?.message}>
-                  <div className="relative">
-                    <Building2
-                      size={18}
-                      className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+                      maxLength={6}
+                      className="h-11 rounded-r3 pl-10 tracking-widest"
                     />
-                    <select
-                      {...register("department")}
+                  </div>
+                  <Button
+                    type="button"
+                    onClick={handleVerifyCode}
+                    disabled={
+                      verifyingCode ||
+                      verificationCode.length !== 6 ||
+                      codeTimer.isExpired
+                    }
+                    className="shrink-0 h-11 cursor-pointer"
+                  >
+                    {verifyingCode ? (
+                      <Loader2 size={16} className="animate-spin" />
+                    ) : (
+                      "인증 확인"
+                    )}
+                  </Button>
+                </div>
+
+                <p className="text-sm text-muted-foreground">
+                  이메일이 오지 않으면 스팸 메일함을 확인해주세요.
+                </p>
+
+                <div className="flex items-center gap-s5">
+                  {codeTimer.isRunning && (
+                    <div
                       className={cn(
-                        "w-full h-9 rounded-r2 border border-input bg-background text-foreground pl-10 pr-10 text-sm",
-                        "appearance-none cursor-pointer transition-all outline-none",
-                        "focus:border-ring focus:ring-ring/50 focus:ring-[3px]",
-                        !watch("department") && "text-muted-foreground",
+                        "flex items-center gap-s1 text-sm transition-colors",
+                        codeTimer.remaining <= 60
+                          ? "text-destructive"
+                          : codeTimer.remaining <= 180
+                            ? "text-amber-500"
+                            : "text-primary",
                       )}
                     >
+                      <Clock size={14} />
+                      <span>남은 시간 {codeTimer.formatted}</span>
+                    </div>
+                  )}
+                  {codeTimer.isExpired && (
+                    <p className="text-sm text-destructive">
+                      인증 코드가 만료되었습니다.
+                    </p>
+                  )}
+                  <button
+                    type="button"
+                    onClick={handleResendCode}
+                    disabled={sendingCode || !resendCooldown.isExpired}
+                    className="text-sm text-muted-foreground hover:text-primary transition cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {sendingCode
+                      ? "재발송 중..."
+                      : !resendCooldown.isExpired
+                        ? `재발송 (${resendCooldown.remaining}초)`
+                        : "인증 코드 재발송"}
+                  </button>
+                </div>
+
+                {verificationError && (
+                  <p className="text-sm text-destructive">
+                    {verificationError}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* 인증 완료 */}
+            {emailVerified && (
+              <div className="flex items-center gap-s1 mt-s3 text-primary">
+                <Check size={16} />
+                <span className="text-sm font-medium">
+                  이메일 인증이 완료되었습니다
+                </span>
+              </div>
+            )}
+          </FormField>
+        </SectionCard>
+
+        {/* 기본 정보 */}
+        <SectionCard icon={User} title="기본 정보">
+          <FormField label="이름" error={errors.name?.message}>
+            <div className="relative">
+              <User
+                size={18}
+                className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                {...register("name")}
+                placeholder="홍길동"
+                className="h-11 rounded-r3 pl-10"
+              />
+            </div>
+          </FormField>
+
+          <FormField label="성별" error={errors.gender?.message}>
+            <div className="grid grid-cols-2 gap-s3">
+              {(["MALE", "FEMALE"] as const).map((g) => (
+                <button
+                  key={g}
+                  type="button"
+                  onClick={() =>
+                    setValue("gender", g, { shouldValidate: true })
+                  }
+                  className={cn(
+                    "h-11 rounded-r3 border text-sm font-medium transition-all cursor-pointer",
+                    watch("gender") === g
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "bg-muted border-border text-foreground hover:border-primary/50",
+                  )}
+                >
+                  {g === "MALE" ? "남성" : "여성"}
+                </button>
+              ))}
+            </div>
+          </FormField>
+
+          <FormField label="학과" error={errors.department?.message}>
+            <div className="relative">
+              <Building2
+                size={18}
+                className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+              />
+              <select
+                {...register("department")}
+                className={cn(
+                  "w-full h-11 rounded-r3 border border-input bg-background text-foreground pl-10 pr-10 text-sm",
+                  "appearance-none cursor-pointer transition-all outline-none",
+                  "focus:border-ring focus:ring-ring/50 focus:ring-[3px]",
+                  !watch("department") && "text-muted-foreground",
+                )}
+              >
+                <option value="" className="bg-background text-foreground">
+                  학과를 선택하세요
+                </option>
+                {majorOptions.map((college) => (
+                  <optgroup key={college.title} label={college.title}>
+                    {college.items.map((dept) => (
                       <option
-                        value=""
+                        key={dept.key}
+                        value={dept.value}
                         className="bg-background text-foreground"
                       >
-                        학과를 선택하세요
+                        {dept.value}
                       </option>
-                      {majorOptions.map((college) => (
-                        <optgroup key={college.title} label={college.title}>
-                          {college.items.map((dept) => (
-                            <option
-                              key={dept.key}
-                              value={dept.value}
-                              className="bg-background text-foreground"
-                            >
-                              {dept.value}
-                            </option>
-                          ))}
-                        </optgroup>
-                      ))}
-                    </select>
-                    <ChevronDown
-                      size={16}
-                      className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
-                    />
-                  </div>
-                </FormField>
-
-                <FormField label="학년" error={errors.grade?.message}>
-                  <div className="grid grid-cols-4 gap-s2">
-                    {[1, 2, 3, 4].map((g) => (
-                      <button
-                        key={g}
-                        type="button"
-                        onClick={() =>
-                          setValue("grade", g, { shouldValidate: true })
-                        }
-                        className={cn(
-                          "h-10 rounded-r2 border text-sm font-medium transition-all cursor-pointer",
-                          watch("grade") === g
-                            ? "bg-primary text-primary-foreground border-primary"
-                            : "bg-muted border-border text-foreground hover:border-primary/50",
-                        )}
-                      >
-                        {g}학년
-                      </button>
                     ))}
-                  </div>
-                </FormField>
+                  </optgroup>
+                ))}
+              </select>
+              <ChevronDown
+                size={16}
+                className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+              />
+            </div>
+          </FormField>
 
-                <FormField
-                  label={ENROLLMENT_STATUS_TITLE}
-                  error={errors.enrollmentStatus?.message}
+          <FormField label="학년" error={errors.grade?.message}>
+            <div className="grid grid-cols-4 gap-s2">
+              {[1, 2, 3, 4].map((g) => (
+                <button
+                  key={g}
+                  type="button"
+                  onClick={() => setValue("grade", g, { shouldValidate: true })}
+                  className={cn(
+                    "h-11 rounded-r3 border text-sm font-medium transition-all cursor-pointer",
+                    watch("grade") === g
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "bg-muted border-border text-foreground hover:border-primary/50",
+                  )}
                 >
-                  <div className="grid grid-cols-3 gap-s2">
-                    {enrollmentStatusOptions.map((status) => (
-                      <button
-                        key={status}
-                        type="button"
-                        onClick={() =>
-                          setValue("enrollmentStatus", status, {
-                            shouldValidate: true,
-                          })
-                        }
-                        className={cn(
-                          "h-10 rounded-r2 border text-sm font-medium transition-all cursor-pointer",
-                          watch("enrollmentStatus") === status
-                            ? "bg-primary text-primary-foreground border-primary"
-                            : "bg-muted border-border text-foreground hover:border-primary/50",
-                        )}
-                      >
-                        {status}
-                      </button>
-                    ))}
-                  </div>
-                </FormField>
+                  {g}학년
+                </button>
+              ))}
+            </div>
+          </FormField>
 
-                <FormField
-                  label="이메일"
-                  error={
-                    errors.emailLocal?.message ||
-                    errors.customDomain?.message ||
-                    (emailCheck.isDuplicate ? emailCheck.message : undefined)
+          <FormField
+            label={ENROLLMENT_STATUS_TITLE}
+            error={errors.enrollmentStatus?.message}
+          >
+            <div className="grid grid-cols-3 gap-s2">
+              {enrollmentStatusOptions.map((status) => (
+                <button
+                  key={status}
+                  type="button"
+                  onClick={() =>
+                    setValue("enrollmentStatus", status, {
+                      shouldValidate: true,
+                    })
                   }
-                  success={
-                    emailCheck.isAvailable ? emailCheck.message : undefined
-                  }
+                  className={cn(
+                    "h-11 rounded-r3 border text-sm font-medium transition-all cursor-pointer",
+                    watch("enrollmentStatus") === status
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "bg-muted border-border text-foreground hover:border-primary/50",
+                  )}
                 >
-                  <div className="flex items-center gap-s2">
-                    <div className="relative flex-1">
-                      <Mail
-                        size={18}
-                        className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
-                      />
-                      <Input
-                        {...register("emailLocal", {
-                          onBlur: () => {
-                            const fullEmail = composeEmail();
-                            if (fullEmail) checkEmail(fullEmail);
-                          },
-                          onChange: () => {
-                            resetEmail();
-                          },
-                        })}
-                        placeholder="아이디"
-                        disabled={emailVerified}
-                        className="pl-10"
-                      />
-                    </div>
-                    <span className="text-muted-foreground font-bold shrink-0">
-                      @
-                    </span>
-                    <div className="relative flex-1">
-                      <select
-                        {...register("emailDomain", {
-                          onChange: () => {
-                            resetEmail();
-                            // 도메인이 커스텀이 아니고 로컬파트가 있으면 즉시 체크
-                            setTimeout(() => {
-                              const fullEmail = composeEmail();
-                              if (
-                                fullEmail &&
-                                getValues("emailDomain") !== "custom"
-                              ) {
-                                checkEmail(fullEmail);
-                              }
-                            }, 0);
-                          },
-                        })}
-                        disabled={emailVerified}
-                        className={cn(
-                          "w-full h-9 rounded-r2 border border-input bg-background text-foreground px-s3 text-sm",
-                          "appearance-none cursor-pointer transition-all outline-none",
-                          "focus:border-ring focus:ring-ring/50 focus:ring-[3px]",
-                        )}
-                      >
-                        {domainOptions.map((d) => (
-                          <option
-                            key={d.value}
-                            value={d.value}
-                            className="bg-background text-foreground"
-                          >
-                            {d.label}
-                          </option>
-                        ))}
-                      </select>
-                      <ChevronDown
-                        size={16}
-                        className="absolute right-s3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
-                      />
-                    </div>
-                  </div>
-                  {emailDomain === "custom" && (
-                    <Input
-                      {...register("customDomain", {
-                        validate: (value) => {
-                          if (
-                            getValues("emailDomain") === "custom" &&
-                            (!value || value.length === 0)
-                          ) {
-                            return "도메인을 입력해주세요.";
-                          }
-                          return true;
-                        },
-                        onBlur: () => {
-                          const fullEmail = composeEmail();
-                          if (fullEmail) checkEmail(fullEmail);
-                        },
-                        onChange: () => {
-                          resetEmail();
-                        },
-                      })}
-                      placeholder="도메인 입력 (예: example.com)"
-                      disabled={emailVerified}
-                      className="mt-s2"
-                    />
-                  )}
-                  {emailCheck.isChecking && (
-                    <div className="flex items-center gap-s1 mt-s1">
-                      <Loader2
-                        size={14}
-                        className="animate-spin text-muted-foreground"
-                      />
-                      <span className="text-sm text-muted-foreground">
-                        확인 중...
-                      </span>
-                    </div>
-                  )}
+                  {status}
+                </button>
+              ))}
+            </div>
+          </FormField>
+        </SectionCard>
 
-                  {/* 이메일 인증하기 버튼 (버튼을 눌러야 인증 코드 발송) */}
-                  {!codeSent && !emailVerified && (
-                    <div className="mt-s3 space-y-s2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onClick={handleSendCode}
-                        disabled={
-                          sendingCode ||
-                          emailCheck.isChecking ||
-                          emailCheck.isDuplicate
-                        }
-                        className="w-full cursor-pointer"
-                      >
-                        {sendingCode ? (
-                          <>
-                            <Loader2 size={16} className="animate-spin" />
-                            인증 코드 발송 중...
-                          </>
-                        ) : (
-                          "이메일 인증하기"
-                        )}
-                      </Button>
-                      {verificationError && (
-                        <p className="text-sm text-destructive">
-                          {verificationError}
-                        </p>
-                      )}
-                    </div>
-                  )}
-
-                  {/* 인증 코드 입력 UI */}
-                  {codeSent && !emailVerified && (
-                    <div className="mt-s3 space-y-s3">
-                      <div className="flex items-center gap-s2">
-                        <div className="relative flex-1">
-                          <Key
-                            size={18}
-                            className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
-                          />
-                          <Input
-                            type="text"
-                            placeholder="6자리 인증 코드"
-                            value={verificationCode}
-                            onChange={(e) =>
-                              setVerificationCode(
-                                e.target.value.replace(/\D/g, "").slice(0, 6),
-                              )
-                            }
-                            maxLength={6}
-                            className="pl-10 tracking-widest"
-                          />
-                        </div>
-                        <Button
-                          type="button"
-                          onClick={handleVerifyCode}
-                          disabled={
-                            verifyingCode ||
-                            verificationCode.length !== 6 ||
-                            codeTimer.isExpired
-                          }
-                          className="shrink-0 cursor-pointer"
-                        >
-                          {verifyingCode ? (
-                            <Loader2 size={16} className="animate-spin" />
-                          ) : (
-                            "인증 확인"
-                          )}
-                        </Button>
-                      </div>
-
-                      <p className="text-sm text-muted-foreground">
-                        이메일이 오지 않으면 스팸 메일함을 확인해주세요.
-                      </p>
-
-                      <div className="flex items-center gap-s5">
-                        {codeTimer.isRunning && (
-                          <div
-                            className={cn(
-                              "flex items-center gap-s1 text-sm transition-colors",
-                              codeTimer.remaining <= 60
-                                ? "text-destructive"
-                                : codeTimer.remaining <= 180
-                                  ? "text-amber-500"
-                                  : "text-primary",
-                            )}
-                          >
-                            <Clock size={14} />
-                            <span>남은 시간 {codeTimer.formatted}</span>
-                          </div>
-                        )}
-                        {codeTimer.isExpired && (
-                          <p className="text-sm text-destructive">
-                            인증 코드가 만료되었습니다.
-                          </p>
-                        )}
-                        <button
-                          type="button"
-                          onClick={handleResendCode}
-                          disabled={sendingCode || !resendCooldown.isExpired}
-                          className="text-sm text-muted-foreground hover:text-primary transition cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          {sendingCode
-                            ? "재발송 중..."
-                            : !resendCooldown.isExpired
-                              ? `재발송 (${resendCooldown.remaining}초)`
-                              : "인증 코드 재발송"}
-                        </button>
-                      </div>
-
-                      {verificationError && (
-                        <p className="text-sm text-destructive">
-                          {verificationError}
-                        </p>
-                      )}
-                    </div>
-                  )}
-
-                  {/* 인증 완료 */}
-                  {emailVerified && (
-                    <div className="flex items-center gap-s1 mt-s3 text-green-600">
-                      <Check size={16} />
-                      <span className="text-sm font-medium">
-                        이메일 인증이 완료되었습니다
-                      </span>
-                    </div>
-                  )}
-                </FormField>
-
-                <FormField
-                  label="전화번호"
-                  error={
-                    errors.phoneNumber?.message ||
-                    (phoneNumberCheck.isDuplicate
-                      ? phoneNumberCheck.message
-                      : undefined)
-                  }
-                  success={
-                    phoneNumberCheck.isAvailable
-                      ? phoneNumberCheck.message
-                      : undefined
-                  }
-                >
-                  <div className="relative">
-                    <Phone
-                      size={18}
-                      className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
-                    />
-                    <Input
-                      {...register("phoneNumber", {
-                        onBlur: () => {
-                          const value = getValues("phoneNumber");
-                          if (/^\d{3}-\d{4}-\d{4}$/.test(value)) {
-                            checkPhoneNumber(value);
-                          }
-                        },
-                        onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-                          const digits = e.target.value
-                            .replace(/\D/g, "")
-                            .slice(0, 11);
-                          setValue("phoneNumber", formatPhoneNumber(digits));
-                          resetPhoneNumber();
-                        },
-                      })}
-                      placeholder="010-1234-5678"
-                      maxLength={13}
-                      className={cn(
-                        "pl-10",
-                        (phoneNumberCheck.isChecking ||
-                          phoneNumberCheck.isAvailable) &&
-                          "pr-10",
-                      )}
-                    />
-                    {phoneNumberCheck.isChecking && (
-                      <Loader2
-                        size={16}
-                        className="absolute right-s3 top-1/2 -translate-y-1/2 animate-spin text-muted-foreground"
-                      />
-                    )}
-                    {phoneNumberCheck.isAvailable &&
-                      !phoneNumberCheck.isChecking && (
-                        <Check
-                          size={16}
-                          className="absolute right-s3 top-1/2 -translate-y-1/2 text-green-600"
-                        />
-                      )}
-                  </div>
-                </FormField>
-
-                <div className="space-y-s3 rounded-r2 border border-border p-s4">
-                  <FormField error={errors.privacyConsent?.message}>
-                    <div className="flex items-center justify-between">
-                      <label className="flex items-center gap-s3 cursor-pointer group">
-                        <input
-                          type="checkbox"
-                          {...register("privacyConsent")}
-                          className="cursor-pointer accent-primary"
-                        />
-                        <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
-                          개인정보 처리방침에 동의합니다 (필수)
-                        </span>
-                      </label>
-                      <Link
-                        to="/privacy"
-                        target="_blank"
-                        className="text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        <ExternalLink size={16} />
-                      </Link>
-                    </div>
-                  </FormField>
-
-                  <FormField error={errors.termsConsent?.message}>
-                    <div className="flex items-center justify-between">
-                      <label className="flex items-center gap-s3 cursor-pointer group">
-                        <input
-                          type="checkbox"
-                          {...register("termsConsent")}
-                          className="cursor-pointer accent-primary"
-                        />
-                        <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
-                          이용약관에 동의합니다 (필수)
-                        </span>
-                      </label>
-                      <Link
-                        to="/terms"
-                        target="_blank"
-                        className="text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        <ExternalLink size={16} />
-                      </Link>
-                    </div>
-                  </FormField>
-                </div>
-              </div>
-
-              {/* 회비 납부 안내 (회원 전용) */}
-              {memberType === "member" && (
-                <div className="mt-s7 rounded-r2 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 p-s4 space-y-s2">
-                  <div className="flex items-center gap-s2">
-                    <Wallet size={16} className="text-amber-600 shrink-0" />
-                    <p className="text-sm font-bold text-amber-700 dark:text-amber-400">
-                      회비 2만원을 납부해주세요
-                    </p>
-                  </div>
-                  <p className="text-sm text-amber-700 dark:text-amber-400">
-                    입금자명 양식: 학번 2자리+이름 (ex. 26김아그)
-                  </p>
-                  <p className="text-sm text-amber-700 dark:text-amber-400 flex items-center">
-                    입금계좌: 토스뱅크 1002-3803-2581
-                    <button
-                      type="button"
-                      onClick={handleCopyAccount}
-                      className="inline-flex items-center ml-s2 hover:text-primary transition-colors cursor-pointer"
-                      title="계좌번호 복사"
-                    >
-                      {copied ? (
-                        <Check size={14} className="text-green-600" />
-                      ) : (
-                        <Copy size={14} />
-                      )}
-                    </button>
-                  </p>
-                  <p className="text-sm text-amber-700 dark:text-amber-400">
-                    입금자명 양식을 지키지 않으실 경우, 회비 납부 명단에서
-                    누락될 수 있습니다.
-                  </p>
-                </div>
-              )}
-
-              {/* Submit */}
-              <Button
-                type="button"
-                disabled={isSubmitting}
-                onClick={() => {
-                  if (useTempStudentId) {
-                    setValue("studentId", "00000000");
-                  }
-                  handleSubmit(onSubmit)();
-                }}
-                className="w-full mt-s6 cursor-pointer"
-              >
-                {isSubmitting ? (
-                  <>
-                    <Loader2 size={18} className="animate-spin" />
-                    가입 중...
-                  </>
-                ) : (
-                  <>
-                    회원가입
-                    <Check size={18} />
-                  </>
+        {/* 연락처 */}
+        <SectionCard icon={Phone} title="연락처">
+          <FormField
+            label="전화번호"
+            error={
+              errors.phoneNumber?.message ||
+              (phoneNumberCheck.isDuplicate
+                ? phoneNumberCheck.message
+                : undefined)
+            }
+            success={
+              phoneNumberCheck.isAvailable
+                ? phoneNumberCheck.message
+                : undefined
+            }
+          >
+            <div className="relative">
+              <Phone
+                size={18}
+                className="absolute left-s3 top-1/2 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                {...register("phoneNumber", {
+                  onBlur: () => {
+                    const value = getValues("phoneNumber");
+                    if (/^\d{3}-\d{4}-\d{4}$/.test(value)) {
+                      checkPhoneNumber(value);
+                    }
+                  },
+                  onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                    const digits = e.target.value
+                      .replace(/\D/g, "")
+                      .slice(0, 11);
+                    setValue("phoneNumber", formatPhoneNumber(digits));
+                    resetPhoneNumber();
+                  },
+                })}
+                placeholder="010-1234-5678"
+                maxLength={13}
+                className={cn(
+                  "h-11 rounded-r3 pl-10",
+                  (phoneNumberCheck.isChecking ||
+                    phoneNumberCheck.isAvailable) &&
+                    "pr-10",
                 )}
-              </Button>
+              />
+              {phoneNumberCheck.isChecking && (
+                <Loader2
+                  size={16}
+                  className="absolute right-s3 top-1/2 -translate-y-1/2 animate-spin text-muted-foreground"
+                />
+              )}
+              {phoneNumberCheck.isAvailable && !phoneNumberCheck.isChecking && (
+                <Check
+                  size={16}
+                  className="absolute right-s3 top-1/2 -translate-y-1/2 text-primary"
+                />
+              )}
+            </div>
+          </FormField>
+        </SectionCard>
 
+        {/* 약관 동의 */}
+        <SectionCard icon={ShieldCheck} title="약관 동의">
+          <FormField error={errors.privacyConsent?.message}>
+            <div className="flex items-center justify-between">
+              <label className="flex items-center gap-s3 cursor-pointer group">
+                <input
+                  type="checkbox"
+                  {...register("privacyConsent")}
+                  className="cursor-pointer accent-primary"
+                />
+                <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
+                  개인정보 처리방침에 동의합니다 (필수)
+                </span>
+              </label>
+              <Link
+                to="/privacy"
+                target="_blank"
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ExternalLink size={16} />
+              </Link>
+            </div>
+          </FormField>
+
+          <FormField error={errors.termsConsent?.message}>
+            <div className="flex items-center justify-between">
+              <label className="flex items-center gap-s3 cursor-pointer group">
+                <input
+                  type="checkbox"
+                  {...register("termsConsent")}
+                  className="cursor-pointer accent-primary"
+                />
+                <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
+                  이용약관에 동의합니다 (필수)
+                </span>
+              </label>
+              <Link
+                to="/terms"
+                target="_blank"
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ExternalLink size={16} />
+              </Link>
+            </div>
+          </FormField>
+        </SectionCard>
+
+        {/* 회비 납부 안내 (회원 전용) */}
+        {memberType === "member" && (
+          <div className="rounded-r4 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 p-s4 space-y-s2">
+            <div className="flex items-center gap-s2">
+              <Wallet size={16} className="text-amber-600 shrink-0" />
+              <p className="text-sm font-bold text-amber-700 dark:text-amber-400">
+                회비 2만원을 납부해주세요
+              </p>
+            </div>
+            <p className="text-sm text-amber-700 dark:text-amber-400">
+              입금자명 양식: 학번 2자리+이름 (ex. 26김아그)
+            </p>
+            <p className="text-sm text-amber-700 dark:text-amber-400 flex items-center">
+              입금계좌: 토스뱅크 1002-3803-2581
               <button
                 type="button"
-                onClick={() => setMemberType(undefined)}
-                className="flex items-center justify-center gap-s1 w-full mt-s4 text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                onClick={handleCopyAccount}
+                className="inline-flex items-center ml-s2 hover:text-primary transition-colors cursor-pointer"
+                title="계좌번호 복사"
               >
-                <ChevronLeft size={16} />
-                가입 유형 다시 선택
+                {copied ? (
+                  <Check size={14} className="text-primary" />
+                ) : (
+                  <Copy size={14} />
+                )}
               </button>
-            </form>
-
-            {/* Login Link */}
-            <p className="text-center text-sm text-muted-foreground mt-s5">
-              이미 계정이 있으신가요?{" "}
-              <Link
-                to="/login"
-                className="text-primary font-medium hover:underline"
-              >
-                로그인
-              </Link>
+            </p>
+            <p className="text-sm text-amber-700 dark:text-amber-400">
+              입금자명 양식을 지키지 않으실 경우, 회비 납부 명단에서 누락될 수
+              있습니다.
             </p>
           </div>
         )}
-      </div>
+
+        {/* 로그인 링크 */}
+        <p className="text-center text-sm text-muted-foreground">
+          이미 계정이 있으신가요?{" "}
+          <Link
+            to="/login"
+            className="text-primary font-semibold hover:underline"
+          >
+            로그인
+          </Link>
+        </p>
+
+        {/* 하단 고정 CTA */}
+        <div className="sticky bottom-0 z-10 -mx-s4 px-s4 pt-s3 pb-[max(1rem,env(safe-area-inset-bottom))] bg-background/90 backdrop-blur-sm border-t border-border">
+          <Button
+            type="button"
+            disabled={isSubmitting}
+            onClick={() => {
+              if (useTempStudentId) {
+                setValue("studentId", "00000000");
+              }
+              handleSubmit(onSubmit)();
+            }}
+            className="w-full h-12 text-base font-bold cursor-pointer"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 size={18} className="animate-spin" />
+                가입 중...
+              </>
+            ) : (
+              "가입하기"
+            )}
+          </Button>
+        </div>
+      </form>
     </div>
   );
 }
 
 // --- Sub Components ---
+
+function TypeChoice({
+  icon: Icon,
+  title,
+  description,
+  onClick,
+}: {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-center gap-s4 rounded-r4 border bg-card p-s5 text-left shadow-sm hover:border-primary transition-all cursor-pointer"
+    >
+      <div className="flex items-center justify-center w-11 h-11 shrink-0 rounded-full bg-brand-l1 dark:bg-primary/15">
+        <Icon size={20} className="text-primary" />
+      </div>
+      <div className="min-w-0">
+        <p className="typo-h4 text-foreground">{title}</p>
+        <p className="text-sm text-muted-foreground mt-0.5">{description}</p>
+      </div>
+    </button>
+  );
+}
+
+function SectionCard({
+  icon: Icon,
+  title,
+  hint,
+  children,
+}: {
+  icon: LucideIcon;
+  title: string;
+  hint?: string | undefined;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-r4 border bg-card p-s5 shadow-sm">
+      <div className="mb-s4">
+        <div className="flex items-center gap-s2">
+          <Icon size={16} className="text-primary" />
+          <h2 className="text-sm font-bold text-foreground tracking-tight">
+            {title}
+          </h2>
+        </div>
+        {hint && <p className="mt-s1 text-xs text-muted-foreground">{hint}</p>}
+      </div>
+      <div className="space-y-s4">{children}</div>
+    </section>
+  );
+}
 
 function FormField({
   label,
@@ -1298,7 +1348,7 @@ function FormField({
       {error && (
         <p
           className={cn(
-            "mt-s3 text-sm",
+            "mt-s2 text-sm",
             mutedError ? "text-muted-foreground" : "text-destructive",
           )}
         >
@@ -1306,7 +1356,7 @@ function FormField({
         </p>
       )}
       {!error && success && (
-        <p className="mt-s3 text-sm text-green-600">{success}</p>
+        <p className="mt-s2 text-sm text-primary">{success}</p>
       )}
     </div>
   );

--- a/frontend/src/pages/auth/SignupPage.tsx
+++ b/frontend/src/pages/auth/SignupPage.tsx
@@ -82,7 +82,7 @@ const signupSchema = z
       .optional()
       .refine((v) => v !== undefined, { message: "학년을 선택해주세요." }),
     enrollmentStatus: z.string().min(1, "재학/휴학 여부를 선택해주세요."),
-    emailLocal: z.string().min(1, "이메일 아이디를 입력해주세요."),
+    emailLocal: z.string().min(1, "이메일을 입력해주세요."),
     emailDomain: z.string().min(1, "도메인을 선택해주세요."),
     customDomain: z.string().optional(),
     phoneNumber: z
@@ -414,7 +414,7 @@ export default function SignupPage() {
   // --- 완료 화면 ---
   if (signupCompleted) {
     return (
-      <div className="mx-auto w-full max-w-lg px-s4 py-s7 animate-in slide-in-from-bottom-4 duration-500">
+      <div className="mx-auto w-full max-w-lg px-s4 py-s7 max-sm:w-screen max-sm:relative max-sm:left-1/2 max-sm:-translate-x-1/2">
         {/* 완료 아이콘 및 메시지 */}
         <div className="text-center mb-s7">
           <div className="mx-auto w-16 h-16 rounded-full bg-brand-l1 dark:bg-primary/15 flex items-center justify-center mb-s5">
@@ -436,7 +436,7 @@ export default function SignupPage() {
 
         {/* 슬랙 안내 섹션 */}
         {slackInviteUrl && (
-          <div className="rounded-r4 border bg-card p-s6 shadow-sm mb-s4">
+          <div className="mb-s6">
             <h2 className="typo-h4 text-foreground mb-s3">
               슬랙 채널에 참여하세요
             </h2>
@@ -479,7 +479,7 @@ export default function SignupPage() {
   // --- 가입 유형 선택 화면 ---
   if (!memberType) {
     return (
-      <div className="mx-auto w-full max-w-md px-s4 py-s7 animate-in slide-in-from-bottom-4 duration-500">
+      <div className="mx-auto w-full max-w-md px-s4 py-s7 max-sm:w-screen max-sm:relative max-sm:left-1/2 max-sm:-translate-x-1/2">
         <div className="text-center mb-s6">
           <h1 className="typo-h2 text-foreground">IGRUS 회원가입</h1>
           <p className="typo-b2 text-muted-foreground mt-s1">
@@ -494,9 +494,11 @@ export default function SignupPage() {
             description="회비를 납부하고 동아리 활동에 참여합니다"
             onClick={() => {
               setMemberType("member");
-              setValue("wishes", []);
-              setValue("interests", []);
-              setValue("joinRoute", "");
+              // 희망활동/관심/가입경로 입력 UI는 제거됨 — 스키마 필수(min 1) 충족용
+              // 더미값. "기타"는 enum 매핑에서 걸러져 빈 값으로 전송된다. (비회원과 동일)
+              setValue("wishes", ["기타"]);
+              setValue("interests", ["기타"]);
+              setValue("joinRoute", "기타");
             }}
           />
           <TypeChoice
@@ -513,23 +515,13 @@ export default function SignupPage() {
             }}
           />
         </div>
-
-        <p className="text-center text-sm text-muted-foreground mt-s6">
-          이미 계정이 있으신가요?{" "}
-          <Link
-            to="/login"
-            className="text-primary font-semibold hover:underline"
-          >
-            로그인
-          </Link>
-        </p>
       </div>
     );
   }
 
   // --- 가입 폼 화면 ---
   return (
-    <div className="mx-auto w-full max-w-lg px-s4 pt-s6 pb-s7">
+    <div className="mx-auto w-full max-w-lg px-s4 pt-s6 pb-s2 max-sm:w-screen max-sm:relative max-sm:left-1/2 max-sm:-translate-x-1/2">
       {/* 헤더 */}
       <div className="mb-s5">
         <button
@@ -554,9 +546,9 @@ export default function SignupPage() {
         </div>
       )}
 
-      <form onSubmit={(e) => e.preventDefault()} className="space-y-s4">
+      <form onSubmit={(e) => e.preventDefault()} className="space-y-s6">
         {/* 계정 (로그인 정보) */}
-        <SectionCard
+        <Section
           icon={Lock}
           title="계정"
           hint="이 학번과 비밀번호로 로그인해요"
@@ -699,7 +691,7 @@ export default function SignupPage() {
                 })}
                 type={showPasswordConfirm ? "text" : "password"}
                 autoComplete="new-password"
-                placeholder="비밀번호 재입력"
+                placeholder="비밀번호 한 번 더 입력"
                 className="h-11 rounded-r3 pl-10 pr-10"
               />
               <button
@@ -712,10 +704,10 @@ export default function SignupPage() {
               </button>
             </div>
           </FormField>
-        </SectionCard>
+        </Section>
 
         {/* 이메일 인증 */}
-        <SectionCard
+        <Section
           icon={Mail}
           title="이메일 인증"
           hint="가입 확인 메일을 받을 이메일이에요"
@@ -744,7 +736,7 @@ export default function SignupPage() {
                       resetEmail();
                     },
                   })}
-                  placeholder="아이디"
+                  placeholder="이메일"
                   autoComplete="email"
                   disabled={emailVerified}
                   className="h-11 rounded-r3 pl-10"
@@ -813,7 +805,7 @@ export default function SignupPage() {
                     resetEmail();
                   },
                 })}
-                placeholder="도메인 입력 (예: example.com)"
+                placeholder="직접 입력 (예: gmail.com)"
                 disabled={emailVerified}
                 className="h-11 rounded-r3 mt-s2"
               />
@@ -872,7 +864,7 @@ export default function SignupPage() {
                     />
                     <Input
                       type="text"
-                      placeholder="6자리 인증 코드"
+                      placeholder="인증 코드 6자리"
                       value={verificationCode}
                       onChange={(e) =>
                         setVerificationCode(
@@ -958,10 +950,10 @@ export default function SignupPage() {
               </div>
             )}
           </FormField>
-        </SectionCard>
+        </Section>
 
         {/* 기본 정보 */}
-        <SectionCard icon={User} title="기본 정보">
+        <Section icon={User} title="기본 정보">
           <FormField label="이름" error={errors.name?.message}>
             <div className="relative">
               <User
@@ -1083,10 +1075,6 @@ export default function SignupPage() {
               ))}
             </div>
           </FormField>
-        </SectionCard>
-
-        {/* 연락처 */}
-        <SectionCard icon={Phone} title="연락처">
           <FormField
             label="전화번호"
             error={
@@ -1145,10 +1133,10 @@ export default function SignupPage() {
               )}
             </div>
           </FormField>
-        </SectionCard>
+        </Section>
 
         {/* 약관 동의 */}
-        <SectionCard icon={ShieldCheck} title="약관 동의">
+        <Section icon={ShieldCheck} title="약관 동의">
           <FormField error={errors.privacyConsent?.message}>
             <div className="flex items-center justify-between">
               <label className="flex items-center gap-s3 cursor-pointer group">
@@ -1192,7 +1180,7 @@ export default function SignupPage() {
               </Link>
             </div>
           </FormField>
-        </SectionCard>
+        </Section>
 
         {/* 회비 납부 안내 (회원 전용) */}
         {memberType === "member" && (
@@ -1228,19 +1216,8 @@ export default function SignupPage() {
           </div>
         )}
 
-        {/* 로그인 링크 */}
-        <p className="text-center text-sm text-muted-foreground">
-          이미 계정이 있으신가요?{" "}
-          <Link
-            to="/login"
-            className="text-primary font-semibold hover:underline"
-          >
-            로그인
-          </Link>
-        </p>
-
         {/* 하단 고정 CTA */}
-        <div className="sticky bottom-0 z-10 -mx-s4 px-s4 pt-s3 pb-[max(1rem,env(safe-area-inset-bottom))] bg-background/90 backdrop-blur-sm border-t border-border">
+        <div className="sticky bottom-0 z-10 -mx-s4 px-s4 pt-s3 pb-[max(0.5rem,env(safe-area-inset-bottom))] bg-background">
           <Button
             type="button"
             disabled={isSubmitting}
@@ -1284,7 +1261,7 @@ function TypeChoice({
     <button
       type="button"
       onClick={onClick}
-      className="w-full flex items-center gap-s4 rounded-r4 border bg-card p-s5 text-left shadow-sm hover:border-primary transition-all cursor-pointer"
+      className="w-full flex items-center gap-s4 rounded-r3 border border-border p-s4 text-left hover:border-primary hover:bg-muted/40 transition-all cursor-pointer"
     >
       <div className="flex items-center justify-center w-11 h-11 shrink-0 rounded-full bg-brand-l1 dark:bg-primary/15">
         <Icon size={20} className="text-primary" />
@@ -1297,7 +1274,7 @@ function TypeChoice({
   );
 }
 
-function SectionCard({
+function Section({
   icon: Icon,
   title,
   hint,
@@ -1309,7 +1286,7 @@ function SectionCard({
   children: React.ReactNode;
 }) {
   return (
-    <section className="rounded-r4 border bg-card p-s5 shadow-sm">
+    <section className="pt-s6 border-t border-border/60 first-of-type:border-t-0 first-of-type:pt-0">
       <div className="mb-s4">
         <div className="flex items-center gap-s2">
           <Icon size={16} className="text-primary" />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,8 +10,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
 
-  const apiTarget =
-    env.VITE_API_TARGET || "https://staging-api.igrus.co.kr:8080";
+  const apiTarget = env.VITE_API_TARGET || "https://api.igrus.co.kr";
 
   return {
     plugins: [


### PR DESCRIPTION
## 요약
회원가입·로그인 페이지를 예전 카드 디자인에서 **흐름형(flowing) 레이아웃**으로 전면 개편하고, 모바일 UX를 개선했습니다. 브랜드 컬러(청록 `primary`)와 모든 로직·검증·API는 그대로 유지합니다.

## 회원가입 (`SignupPage.tsx`)
- 카드 박스 제거 → 섹션 라벨 + 여백으로 구분되는 흐름형 폼
- **로그인 정보(학번+비밀번호)를 맨 앞 "계정" 섹션으로** 묶어 배치
- 연락처(전화번호)를 기본 정보로 통합, 별도 섹션 제거
- 회원가입 페이지의 "이미 계정이 있으신가요? 로그인" 유도 링크 제거
- 모바일 좌우 여백 축소(레이아웃 강제 패딩 상쇄), 진입 애니메이션·그림자 제거
- 하단 고정 CTA("가입하기"), 문구·플레이스홀더 정리

## 로그인 (`LoginForm.tsx`, `LoginPage.tsx`)
- 2단 브랜드 패널·`shadow-2xl`·장식 원·도트그리드·진입 애니메이션 제거
- 회원가입과 동일한 흐름형 단일 컬럼으로 재디자인
- 로그인 처리·계정 복구 로직은 그대로 보존
- 안 쓰게 된 CSS(`login-brand-panel`, `login-dot-grid`) 삭제

## 버그 수정
- **회원 가입 먹통**: 회원 선택 시 `wishes/interests/joinRoute`를 빈 값으로 세팅해 zod `min(1)` 검증에 걸리는데, 해당 필드 UI가 없어 에러도 안 뜨고 `가입하기`가 무반응이던 문제 → 비회원과 동일한 유효 더미값으로 통일해 해결
- **크롬 자동완성**: 학번을 아이디로 학습하도록 `autocomplete` 부여(로그인 username/current-password, 회원가입 username/new-password/email)

## 기타
- dev 프록시 기본 타깃을 운영 API(`api.igrus.co.kr`)로 변경 (스테이징 메일 발송 500 회피)

## 검증
- `tsc --noEmit`, `pnpm lint`(0 error), `pnpm build` 모두 통과
- 참고: DB/API에는 회원·비회원 구분 필드가 없음(memberType은 프론트 전용, 회비 안내 노출만 결정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)