### PR TITLE
앱 이름 Inha Play로 변경

### DIFF
--- a/play-igrus/frontend/index.html
+++ b/play-igrus/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="인하대 학생들이 만든 앱과 게임을 만나보세요" />
-    <title>Play Inha</title>
+    <title>Inha Play</title>
   </head>
   <body>
     <div id="root"></div>

--- a/play-igrus/frontend/src/components/Layout.tsx
+++ b/play-igrus/frontend/src/components/Layout.tsx
@@ -61,7 +61,7 @@ export default function Layout() {
               className={css({ h: "8", w: "8", rounded: "lg", objectFit: "cover" })}
             />
             <span>
-              Play <span className={css({ color: "indigo.600" })}>Inha</span>
+              <span className={css({ color: "indigo.600" })}>Inha</span> Play
             </span>
           </Link>
 


### PR DESCRIPTION
## 변경 내용
play-igrus 앱의 표시 이름을 **Inha Play**로 변경.

- `index.html` `<title>`: `Play Inha` → `Inha Play`
- 헤더 로고: 파란색(indigo.600) **Inha** + Play

도메인·API URL(`igrus.co.kr`, `play-api`, `VITE_*`)은 인프라 식별자라 변경하지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)