### PR TITLE
play 유입 회원가입 완료 시 play 로그인으로 복귀 (utm)

### DIFF
--- a/frontend/src/pages/auth/SignupPage.tsx
+++ b/frontend/src/pages/auth/SignupPage.tsx
@@ -467,7 +467,18 @@ export default function SignupPage() {
           type="button"
           variant={slackInviteUrl ? "outline" : "default"}
           className="w-full h-12 text-base cursor-pointer"
-          onClick={() => navigate("/login")}
+          onClick={() => {
+            // play.igrus 에서 온 회원가입(utm_source=play)이면 play 로그인으로 되돌려보낸다.
+            // utm 등 쿼리스트링은 그대로 전달해 경로가 바뀌어도 유지되게 함.
+            if (
+              new URLSearchParams(window.location.search).get("utm_source") ===
+              "play"
+            ) {
+              window.location.href = `https://play.igrus.co.kr/login${window.location.search}`;
+              return;
+            }
+            navigate("/login");
+          }}
         >
           <LogIn size={16} />
           로그인하러 가기

--- a/play-igrus/frontend/src/pages/LoginPage.tsx
+++ b/play-igrus/frontend/src/pages/LoginPage.tsx
@@ -80,7 +80,7 @@ export default function LoginPage() {
       <p className={css({ fontSize: "sm", color: "gray.500", mt: "6", textAlign: "center" })}>
         계정이 없다면{" "}
         <a
-          href="https://www.igrus.co.kr/signup"
+          href="https://www.igrus.co.kr/signup?utm_source=play"
           className={css({ color: "indigo.600", fontWeight: "600" })}
         >
           아이그루스에서 가입


### PR DESCRIPTION
## 배경
play.igrus 에서 회원가입 시 아이그루스(www) 가입 페이지로 넘어가는데, 가입 완료 후 www 로그인으로 빠져 play 흐름이 끊김.

## 변경
- **play `LoginPage`**: 회원가입 링크 → `https://www.igrus.co.kr/signup?utm_source=play`
- **www `SignupPage`** 완료 버튼: URL에 `utm_source=play` 있으면 `https://play.igrus.co.kr/login` 으로 **쿼리스트링 유지한 채** 이동. 없으면 기존대로 www `/login`.

## 흐름
1. play 가입 클릭 → `www.igrus.co.kr/signup?utm_source=play`
2. 가입 완료 → "로그인하러 가기" → `play.igrus.co.kr/login?utm_source=play`
3. www 직접 가입 사용자는 영향 없음

회원가입은 `/signup` 단일 라우트 인라인 처리라 utm이 완료 시점까지 URL에 그대로 유지됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)