### PR TITLE
바텀시트: 스크롤 불가 목록에서 창 전체 새로고침되는 버그 수정

### DIFF
--- a/play-igrus/frontend/src/components/AuthorDialog.tsx
+++ b/play-igrus/frontend/src/components/AuthorDialog.tsx
@@ -165,7 +165,7 @@ export default function AuthorDialog({ projectId, onClose, onProject }: Props) {
               출시한 앱
             </h3>
 
-            <div data-sheet-scroll className={css({ flex: 1, minH: 0, overflowY: "auto", px: "6", pb: "6" })}>
+            <div data-sheet-scroll className={css({ flex: 1, minH: 0, overflowY: "auto", overscrollBehavior: "contain", px: "6", pb: "6" })}>
               {projects.length === 0 ? (
                 <p className={css({ fontSize: "sm", color: "gray.400", py: "6", textAlign: "center" })}>
                   아직 공개된 작품이 없습니다

--- a/play-igrus/frontend/src/components/ProjectDialog.tsx
+++ b/play-igrus/frontend/src/components/ProjectDialog.tsx
@@ -133,7 +133,7 @@ export default function ProjectDialog({ project, onClose, onAuthor }: Props) {
         </div>
 
         {/* 소개 (마크다운, 스크롤) */}
-        <div data-sheet-scroll className={css({ flex: 1, minH: 0, overflowY: "auto", px: "6", pb: "6" })}>
+        <div data-sheet-scroll className={css({ flex: 1, minH: 0, overflowY: "auto", overscrollBehavior: "contain", px: "6", pb: "6" })}>
           <h3
             className={css({
               fontSize: "xs",

--- a/play-igrus/frontend/src/hooks/useSheetDrag.ts
+++ b/play-igrus/frontend/src/hooks/useSheetDrag.ts
@@ -24,12 +24,13 @@ export function useSheetDrag(
     let startX = 0;
     let startY = 0;
     let dy = 0;
+    let scroller: HTMLElement | null = null; // 터치가 시작된 시점의 스크롤 앱 영역
     let startedInScroller = false; // 터치가 스크롤 앱 영역에서 시작됐는지
     let dragging = false; // 이번 터치가 시트 드래그로 확정됐는지
 
     const onStart = (e: TouchEvent) => {
       // 스크롤 영역은 시트가 늦게 채워질 수 있어(로딩) 터치 시작마다 다시 찾는다
-      const scroller = sheet.querySelector<HTMLElement>("[data-sheet-scroll]");
+      scroller = sheet.querySelector<HTMLElement>("[data-sheet-scroll]");
       startedInScroller = !!scroller && scroller.contains(e.target as Node);
       startX = e.touches[0].clientX;
       startY = e.touches[0].clientY;
@@ -42,9 +43,12 @@ export function useSheetDrag(
       if (!dragging) {
         const dyRaw = t.clientY - startY;
         const dxRaw = t.clientX - startX;
-        // 아래로(6px 데드존) + 세로 우세 + 스크롤 앱 영역 밖(헤더·배너·손잡이)에서 시작했을 때만 확정.
-        // 앱 목록 영역에서 시작한 터치는 스크롤 여부와 무관하게 시트로 넘어가지 않는다.
-        if (dyRaw > 6 && Math.abs(dyRaw) > Math.abs(dxRaw) && !startedInScroller) {
+        // 스크롤 앱 영역에서 시작했어도, 그 영역이 맨 위(scrollTop<=0)면 시트로 넘긴다.
+        // → 목록이 스크롤 가능하고 아직 위가 아니면 네이티브 스크롤,
+        //   맨 위이거나 요소가 적어 스크롤 불가면 시트가 내려감(창 전체 pull-to-refresh 방지).
+        const scrollerAtTop = !startedInScroller || !scroller || scroller.scrollTop <= 0;
+        // 아래로(6px 데드존) + 세로 우세 + 스크롤 영역이 맨 위일 때만 확정.
+        if (dyRaw > 6 && Math.abs(dyRaw) > Math.abs(dxRaw) && scrollerAtTop) {
           dragging = true;
           startY = t.clientY; // 재기준점 → dy 0부터 부드럽게
         } else {


### PR DESCRIPTION
## 버그
바텀시트의 목록 요소가 적어 스크롤 불가한 상태에서 아래로 당기면, 시트가 내려가지 않고 **창 전체가 오버스크롤되어 pull-to-refresh(새로고침)** 로 이어짐.

## 근본 원인
`useSheetDrag`의 `onMove`가 스크롤 영역(`[data-sheet-scroll]`)에서 시작한 터치를 무조건 시트 드래그에서 제외(`!startedInScroller`)했음. 목록이 스크롤 불가일 때 네이티브가 아래 당김을 소비하지 못해 브라우저가 페이지 전체 오버스크롤로 escalate → 새로고침.

## 수정
- **`useSheetDrag`**: 가드를 `scrollTop <= 0`(맨 위 = 스크롤 불가 포함) 체크로 교체. 스크롤 영역에서 시작해도 맨 위면 시트 드래그로 확정하고 `e.preventDefault()`로 페이지 오버스크롤 차단.
- **`ProjectDialog`/`AuthorDialog`**: 스크롤러에 `overscroll-behavior: contain` 방어 추가.

## 동작
| 상황 | 결과 |
|---|---|
| 요소 적어 스크롤 불가 + 아래로 | 시트 내려감/닫힘 (수정) |
| 긴 목록 맨 위에서 아래로 | 시트 내려감 |
| 긴 목록 중간 스크롤 | 목록 네이티브 스크롤 (시트 유지) |
| 헤더/손잡이에서 아래로 | 기존대로 시트 드래그 |

tsc·oxlint 통과. 터치 제스처라 실제 모바일 확인은 배포 후 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)