### PR TITLE
바텀시트 드래그 판정 재설계 (스크롤 가능 여부 기준 + 상대 이동 누적)

### DIFF
--- a/play-igrus/frontend/src/hooks/useSheetDrag.ts
+++ b/play-igrus/frontend/src/hooks/useSheetDrag.ts
@@ -4,10 +4,13 @@ import { useEffect, type RefObject } from "react";
  * 모바일 바텀시트를 손가락으로 아래로 끌어내려 닫는 제스처.
  *
  * 안쪽 스크롤 영역([data-sheet-scroll])과 충돌하지 않도록:
- * - 스크롤 가능한 목록에서 스크롤이 시작되면(scrollTop>0) 그 제스처는 네이티브 전용 →
- *   시트는 안 내려가고 목록만 스크롤된다.
- * - 목록이 맨 위이거나 요소가 적어 스크롤 불가하면, 아래로 당김을 시트 드래그로 처리한다.
- *   기준점(anchor)을 최상단 위치로 따라가므로 위로 갔다가 아래로 반전해도 그 지점부터 내려간다.
+ * - 그 영역이 "스크롤 가능"(내용이 넘침, scrollHeight>clientHeight)하면, 거기서 시작한
+ *   터치는 통째로 네이티브 스크롤에 맡긴다 → 시트는 고정, 목록만 스크롤.
+ *   (현재 scrollTop 위치가 아니라 스크롤 가능 여부로 판단한다.)
+ * - 스크롤 불가(요소가 적음)하거나 손잡이·헤더 등에서 시작하면 시트 드래그로 처리한다.
+ *
+ * dy 는 pointer-down 이후 매 move 의 상대 이동을 누적한다. 아래로 가면 늘고 위로 가면
+ * 0 까지 줄어들므로, 위로 갔다가 아래로 반전해도 그 지점부터 자연스럽게 내려간다.
  *
  * @param sheetRef translateY 로 움직일 시트 요소(<dialog>)
  * @param onClose  임계치 이상 끌어내렸을 때 호출
@@ -23,61 +26,34 @@ export function useSheetDrag(
     if (!sheet || !open) return;
     if (!window.matchMedia("(max-width: 639px)").matches) return; // 모바일 전용
 
-    let startY = 0; // 드래그 확정 후 translateY 기준점(아래로 당기기 시작 지점)
-    let anchorX = 0; // 아래로 당기기 기준점 X (반환점마다 갱신)
-    let anchorY = 0; // 아래로 당기기 기준점 Y
-    let dy = 0;
-    let scroller: HTMLElement | null = null; // 터치가 시작된 시점의 스크롤 앱 영역
-    let startedInScroller = false; // 터치가 스크롤 앱 영역에서 시작됐는지
-    let canScroll = false; // 그 영역이 실제로 스크롤 가능한지(내용이 넘치는지)
-    let nativeLock = false; // 이번 터치가 네이티브 스크롤 전용으로 확정됐는지
+    let lastY = 0; // 직전 move 의 y — 상대 이동 계산용
+    let dy = 0; // 시트가 내려간 누적 거리(>=0)
+    let scrollable = false; // 이번 터치가 스크롤 가능한 영역에서 시작했는지
     let dragging = false; // 이번 터치가 시트 드래그로 확정됐는지
 
     const onStart = (e: TouchEvent) => {
       // 스크롤 영역은 시트가 늦게 채워질 수 있어(로딩) 터치 시작마다 다시 찾는다
-      scroller = sheet.querySelector<HTMLElement>("[data-sheet-scroll]");
-      startedInScroller = !!scroller && scroller.contains(e.target as Node);
-      canScroll = !!scroller && scroller.scrollHeight - scroller.clientHeight > 1;
-      anchorX = e.touches[0].clientX;
-      anchorY = e.touches[0].clientY;
+      const scroller = sheet.querySelector<HTMLElement>("[data-sheet-scroll]");
+      scrollable =
+        !!scroller &&
+        scroller.contains(e.target as Node) &&
+        scroller.scrollHeight - scroller.clientHeight > 1;
+      lastY = e.touches[0].clientY;
       dy = 0;
-      nativeLock = false;
       dragging = false;
     };
 
     const onMove = (e: TouchEvent) => {
+      if (scrollable) return; // 스크롤 가능 목록 → 네이티브 스크롤에 맡김(시트 고정)
       const t = e.touches[0];
+      // 직전 위치 대비 상대 이동을 누적: 아래로 가면 늘고, 위로 가면 0까지 준다.
+      dy = Math.max(0, dy + (t.clientY - lastY));
+      lastY = t.clientY;
       if (!dragging) {
-        // 스크롤 가능한 영역에서 실제 스크롤이 시작되면(scrollTop>0) 이번 제스처는
-        // 끝까지 네이티브 스크롤 전용 → 시트는 안 내려가고 목록만 스크롤된다.
-        if (startedInScroller && canScroll) {
-          if (scroller && scroller.scrollTop > 0) nativeLock = true;
-          if (nativeLock) {
-            anchorX = t.clientX; // 맨 위로 되돌아온 뒤 당김에 대비해 기준점만 따라감
-            anchorY = t.clientY;
-            return;
-          }
-          // 여기부터는 스크롤 가능하지만 아직 맨 위(scrollTop 0)이고 스크롤이 시작되지 않은 상태
-        }
-        // 손가락이 기준점보다 위로 올라가면 기준점을 갱신한다.
-        // → 위로 스크롤/이동했다가 방향을 바꿔 아래로 당기면 그 반환점부터 시트가 내려간다.
-        if (t.clientY < anchorY) {
-          anchorX = t.clientX;
-          anchorY = t.clientY;
-          return;
-        }
-        const pull = t.clientY - anchorY; // 기준점 대비 아래로 당긴 양
-        const dxRaw = t.clientX - anchorX;
-        // 아래로(6px 데드존) + 세로 우세(수직 기준 약 60°까지 허용)일 때 시트 드래그 확정.
-        if (pull > 6 && pull * 2 > Math.abs(dxRaw)) {
-          dragging = true;
-          startY = anchorY; // 반환점을 translateY 기준으로 → dy 0부터 부드럽게
-        } else {
-          return; // 네이티브 스크롤에 맡김
-        }
+        if (dy < 6) return; // 미세 이동(탭 등) 무시
+        dragging = true;
       }
-      dy = Math.max(0, t.clientY - startY);
-      e.preventDefault(); // 확정 후엔 배경/내부 스크롤 차단
+      e.preventDefault(); // 확정 후엔 배경/페이지 스크롤 차단(pull-to-refresh 방지)
       sheet.style.transition = "none";
       sheet.style.transform = `translateY(${dy}px)`;
     };

--- a/play-igrus/frontend/src/hooks/useSheetDrag.ts
+++ b/play-igrus/frontend/src/hooks/useSheetDrag.ts
@@ -3,9 +3,11 @@ import { useEffect, type RefObject } from "react";
 /**
  * 모바일 바텀시트를 손가락으로 아래로 끌어내려 닫는 제스처.
  *
- * 앱 목록 등 내부 스크롤과 충돌하지 않도록, 안쪽 스크롤 영역([data-sheet-scroll])이
- * 맨 위에 있고 + 아래로 당기는 수직 제스처일 때만 드래그로 확정한다.
- * 그 외(목록 스크롤·위로 당김·가로 스와이프)는 네이티브 스크롤에 맡긴다.
+ * 안쪽 스크롤 영역([data-sheet-scroll])과 충돌하지 않도록:
+ * - 스크롤 가능한 목록에서 스크롤이 시작되면(scrollTop>0) 그 제스처는 네이티브 전용 →
+ *   시트는 안 내려가고 목록만 스크롤된다.
+ * - 목록이 맨 위이거나 요소가 적어 스크롤 불가하면, 아래로 당김을 시트 드래그로 처리한다.
+ *   기준점(anchor)을 최상단 위치로 따라가므로 위로 갔다가 아래로 반전해도 그 지점부터 내려간다.
  *
  * @param sheetRef translateY 로 움직일 시트 요소(<dialog>)
  * @param onClose  임계치 이상 끌어내렸을 때 호출
@@ -21,36 +23,55 @@ export function useSheetDrag(
     if (!sheet || !open) return;
     if (!window.matchMedia("(max-width: 639px)").matches) return; // 모바일 전용
 
-    let startX = 0;
-    let startY = 0;
+    let startY = 0; // 드래그 확정 후 translateY 기준점(아래로 당기기 시작 지점)
+    let anchorX = 0; // 아래로 당기기 기준점 X (반환점마다 갱신)
+    let anchorY = 0; // 아래로 당기기 기준점 Y
     let dy = 0;
     let scroller: HTMLElement | null = null; // 터치가 시작된 시점의 스크롤 앱 영역
     let startedInScroller = false; // 터치가 스크롤 앱 영역에서 시작됐는지
+    let canScroll = false; // 그 영역이 실제로 스크롤 가능한지(내용이 넘치는지)
+    let nativeLock = false; // 이번 터치가 네이티브 스크롤 전용으로 확정됐는지
     let dragging = false; // 이번 터치가 시트 드래그로 확정됐는지
 
     const onStart = (e: TouchEvent) => {
       // 스크롤 영역은 시트가 늦게 채워질 수 있어(로딩) 터치 시작마다 다시 찾는다
       scroller = sheet.querySelector<HTMLElement>("[data-sheet-scroll]");
       startedInScroller = !!scroller && scroller.contains(e.target as Node);
-      startX = e.touches[0].clientX;
-      startY = e.touches[0].clientY;
+      canScroll = !!scroller && scroller.scrollHeight - scroller.clientHeight > 1;
+      anchorX = e.touches[0].clientX;
+      anchorY = e.touches[0].clientY;
       dy = 0;
+      nativeLock = false;
       dragging = false;
     };
 
     const onMove = (e: TouchEvent) => {
       const t = e.touches[0];
       if (!dragging) {
-        const dyRaw = t.clientY - startY;
-        const dxRaw = t.clientX - startX;
-        // 스크롤 앱 영역에서 시작했어도, 그 영역이 맨 위(scrollTop<=0)면 시트로 넘긴다.
-        // → 목록이 스크롤 가능하고 아직 위가 아니면 네이티브 스크롤,
-        //   맨 위이거나 요소가 적어 스크롤 불가면 시트가 내려감(창 전체 pull-to-refresh 방지).
-        const scrollerAtTop = !startedInScroller || !scroller || scroller.scrollTop <= 0;
-        // 아래로(6px 데드존) + 세로 우세 + 스크롤 영역이 맨 위일 때만 확정.
-        if (dyRaw > 6 && Math.abs(dyRaw) > Math.abs(dxRaw) && scrollerAtTop) {
+        // 스크롤 가능한 영역에서 실제 스크롤이 시작되면(scrollTop>0) 이번 제스처는
+        // 끝까지 네이티브 스크롤 전용 → 시트는 안 내려가고 목록만 스크롤된다.
+        if (startedInScroller && canScroll) {
+          if (scroller && scroller.scrollTop > 0) nativeLock = true;
+          if (nativeLock) {
+            anchorX = t.clientX; // 맨 위로 되돌아온 뒤 당김에 대비해 기준점만 따라감
+            anchorY = t.clientY;
+            return;
+          }
+          // 여기부터는 스크롤 가능하지만 아직 맨 위(scrollTop 0)이고 스크롤이 시작되지 않은 상태
+        }
+        // 손가락이 기준점보다 위로 올라가면 기준점을 갱신한다.
+        // → 위로 스크롤/이동했다가 방향을 바꿔 아래로 당기면 그 반환점부터 시트가 내려간다.
+        if (t.clientY < anchorY) {
+          anchorX = t.clientX;
+          anchorY = t.clientY;
+          return;
+        }
+        const pull = t.clientY - anchorY; // 기준점 대비 아래로 당긴 양
+        const dxRaw = t.clientX - anchorX;
+        // 아래로(6px 데드존) + 세로 우세(수직 기준 약 60°까지 허용)일 때 시트 드래그 확정.
+        if (pull > 6 && pull * 2 > Math.abs(dxRaw)) {
           dragging = true;
-          startY = t.clientY; // 재기준점 → dy 0부터 부드럽게
+          startY = anchorY; // 반환점을 translateY 기준으로 → dy 0부터 부드럽게
         } else {
           return; // 네이티브 스크롤에 맡김
         }


### PR DESCRIPTION
## 배경
바텀시트 제스처가 (1) 요소 적어 스크롤 불가 목록에서 아래로 당기면 창 전체 새로고침, (2) 위로 갔다 아래로 반전 시 안 내려감, (3) 스크롤 가능 목록에서 시트가 뒤섞여 드래그되는 문제.

## 요구사항 & 동작
| 상황 | 동작 |
|---|---|
| 스크롤 가능 목록(내용 넘침)에서 시작 | 목록만 네이티브 스크롤, 시트 고정 |
| 요소 적어 스크롤 불가 + 아래로 | 시트 내려감/닫힘 |
| 위로 갔다가 아래로 반전 | 반전점부터 시트 내려감 |

## 구현 (`useSheetDrag`)
- **스크롤 가능 여부 기준**: `scrollHeight - clientHeight > 1` 로 판단. `scrollTop` 위치로 판단하지 않음 — 맨 위여도 스크롤 가능한 요소면 네이티브 스크롤 우선.
- **상대 이동 누적**: `dy = max(0, dy + (현재Y - 직전Y))`. 아래로 가면 늘고 위로 가면 0까지 줄어 위→아래 반전을 자연 처리.
- 6px 데드존으로 탭/미세 이동 보호, 드래그 확정 후 `preventDefault` 로 pull-to-refresh 차단.

로컬 dev 실제 확인 완료. tsc·oxlint 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)