### PR TITLE
fix(play-igrus): 랭킹 재계산 주기 매일 04:00 → 매시간

### DIFF
--- a/play-igrus/backend/ranking.go
+++ b/play-igrus/backend/ranking.go
@@ -79,23 +79,14 @@ func recomputeScores(db *sql.DB, today time.Time) error {
 	return tx.Commit()
 }
 
-// startRankingLoop 은 시작 시 1회 + 매일 04:00 KST 에 점수를 재계산한다.
+// startRankingLoop 은 시작 시 1회 + 매시간 점수를 재계산한다.
 func startRankingLoop(db *sql.DB) {
 	go func() {
 		for {
 			if err := recomputeScores(db, kstToday()); err != nil {
 				log.Printf("랭킹 재계산 실패: %v", err)
 			}
-			time.Sleep(untilNextRun())
+			time.Sleep(time.Hour)
 		}
 	}()
-}
-
-func untilNextRun() time.Duration {
-	now := time.Now().In(kst)
-	next := time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0, 0, kst)
-	if !next.After(now) {
-		next = next.Add(24 * time.Hour)
-	}
-	return next.Sub(now)
 }


### PR DESCRIPTION
## 변경 사항
랭킹 캐시 만료 기준을 **1일 → 1시간**으로 변경.

- `startRankingLoop`: 시작 시 1회 + 이후 **매시간** 점수 재계산
- 매일 04:00 KST 스케줄링에 쓰이던 `untilNextRun` 제거 (dead code)

## 참고
- 정각(00분) 정렬이 아니라 서버 시작 시점 기준 1시간 간격입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)