### PR TITLE
feat(sso): inhaplay.com 도메인 세션 연동 — SSO 핸드오프

### DIFF
--- a/backend/src/main/java/igrus/web/security/auth/common/exception/AuthErrorCode.java
+++ b/backend/src/main/java/igrus/web/security/auth/common/exception/AuthErrorCode.java
@@ -31,6 +31,8 @@ public enum AuthErrorCode implements ErrorCode {
     REFRESH_TOKEN_THEFT_DETECTED(401, "토큰 도용이 감지되어 모든 세션이 종료되었습니다"),
     PASSWORD_RESET_TOKEN_INVALID(400, "유효하지 않은 비밀번호 재설정 토큰입니다"),
     PASSWORD_RESET_TOKEN_EXPIRED(400, "비밀번호 재설정 토큰이 만료되었습니다"),
+    SSO_CODE_INVALID(401, "유효하지 않거나 만료된 SSO 코드입니다"),
+    SSO_REDIRECT_URI_NOT_ALLOWED(400, "허용되지 않은 redirect_uri 입니다"),
 
     // Email & Verification
     EMAIL_SEND_FAILED(500, "이메일 발송에 실패했습니다"),

--- a/backend/src/main/java/igrus/web/security/auth/sso/SsoAuthController.java
+++ b/backend/src/main/java/igrus/web/security/auth/sso/SsoAuthController.java
@@ -1,0 +1,53 @@
+package igrus.web.security.auth.sso;
+
+import igrus.web.common.util.ServletContextUtil;
+import igrus.web.generated.api.SsoAuthenticationApi;
+import igrus.web.generated.model.ApiSsoTokenRequest;
+import igrus.web.generated.model.ApiSsoTokenResponse;
+import igrus.web.security.auth.common.util.CookieUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@RestController
+@RequiredArgsConstructor
+public class SsoAuthController implements SsoAuthenticationApi {
+
+    private final SsoService ssoService;
+    private final CookieUtil cookieUtil;
+
+    @Override
+    public ResponseEntity<Void> ssoAuthorize(URI redirectUri) {
+        String redirectUriValue = redirectUri.toString();
+        ssoService.validateRedirectUri(redirectUriValue);
+
+        HttpServletRequest request = ServletContextUtil.getCurrentRequest();
+        String location = cookieUtil.getRefreshTokenFromCookies(request)
+                .flatMap(ssoService::issueCodeForRefreshToken)
+                .map(code -> appendQueryParam(redirectUriValue, "sso_code", code))
+                .orElseGet(() -> appendQueryParam(redirectUriValue, "sso", "none"));
+
+        return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(location)).build();
+    }
+
+    @Override
+    public ResponseEntity<ApiSsoTokenResponse> ssoIssueToken(ApiSsoTokenRequest apiSsoTokenRequest) {
+        SsoTokenResult result = ssoService.exchangeCode(apiSsoTokenRequest.getCode());
+        return ResponseEntity.ok(new ApiSsoTokenResponse()
+                .accessToken(result.accessToken())
+                .refreshToken(result.refreshToken())
+                .expiresIn(result.accessTokenValidity())
+                .refreshExpiresIn(result.refreshTokenValidity()));
+    }
+
+    private static String appendQueryParam(String uri, String name, String value) {
+        String separator = uri.contains("?") ? "&" : "?";
+        return uri + separator + name + "=" + URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/backend/src/main/java/igrus/web/security/auth/sso/SsoCodeStore.java
+++ b/backend/src/main/java/igrus/web/security/auth/sso/SsoCodeStore.java
@@ -1,0 +1,58 @@
+package igrus.web.security.auth.sso;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * SSO 일회용 코드 저장소.
+ *
+ * <p>코드는 60초 TTL, 1회 사용 후 즉시 폐기된다.
+ */
+// ponytail: 프로세스 메모리 저장 — 단일 인스턴스 배포 전제. 다중 인스턴스가 되면 DB/Redis 로 교체.
+@Component
+public class SsoCodeStore {
+
+    static final Duration CODE_TTL = Duration.ofSeconds(60);
+
+    private final Clock clock;
+    private final SecureRandom random = new SecureRandom();
+    private final Map<String, Entry> codes = new ConcurrentHashMap<>();
+
+    private record Entry(Long userId, Instant expiresAt) {}
+
+    public SsoCodeStore(Clock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * 사용자에 대한 일회용 코드를 발급합니다.
+     */
+    public String issue(Long userId) {
+        byte[] buf = new byte[32];
+        random.nextBytes(buf);
+        String code = Base64.getUrlEncoder().withoutPadding().encodeToString(buf);
+        codes.put(code, new Entry(userId, clock.instant().plus(CODE_TTL)));
+        return code;
+    }
+
+    /**
+     * 코드를 소비합니다. 유효하면 userId를 반환하고 코드를 폐기합니다.
+     */
+    public Optional<Long> consume(String code) {
+        Instant now = clock.instant();
+        codes.values().removeIf(e -> now.isAfter(e.expiresAt()));
+        Entry entry = codes.remove(code);
+        if (entry == null || now.isAfter(entry.expiresAt())) {
+            return Optional.empty();
+        }
+        return Optional.of(entry.userId());
+    }
+}

--- a/backend/src/main/java/igrus/web/security/auth/sso/SsoService.java
+++ b/backend/src/main/java/igrus/web/security/auth/sso/SsoService.java
@@ -1,0 +1,106 @@
+package igrus.web.security.auth.sso;
+
+import igrus.web.security.auth.common.domain.RefreshToken;
+import igrus.web.security.auth.common.repository.RefreshTokenRepository;
+import igrus.web.security.auth.sso.exception.SsoCodeInvalidException;
+import igrus.web.security.auth.sso.exception.SsoRedirectUriNotAllowedException;
+import igrus.web.security.jwt.JwtTokenProvider;
+import igrus.web.user.domain.User;
+import igrus.web.user.domain.UserStatus;
+import igrus.web.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 다른 도메인 서비스(play 등)와의 세션 연동(SSO)을 담당합니다.
+ *
+ * <p>흐름: 브라우저가 refresh 쿠키를 들고 authorize로 top-level 리다이렉트
+ * → 일회용 코드 발급 → 서비스 백엔드가 코드를 토큰으로 교환(새 리프레시 토큰 패밀리).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SsoService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final SsoCodeStore codeStore;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${app.jwt.access-token-validity}")
+    private long accessTokenValidity;
+
+    @Value("${app.jwt.refresh-token-validity}")
+    private long refreshTokenValidity;
+
+    @Value("${app.sso.allowed-redirect-origins:}")
+    private List<String> allowedRedirectOrigins;
+
+    /**
+     * redirect_uri가 허용된 origin인지 검증합니다.
+     *
+     * @throws SsoRedirectUriNotAllowedException 절대 URI가 아니거나 허용 목록에 없는 origin인 경우
+     */
+    public void validateRedirectUri(String redirectUri) {
+        URI uri;
+        try {
+            uri = new URI(redirectUri);
+        } catch (URISyntaxException e) {
+            throw new SsoRedirectUriNotAllowedException();
+        }
+        if (!uri.isAbsolute() || uri.getHost() == null) {
+            throw new SsoRedirectUriNotAllowedException();
+        }
+        String origin = uri.getScheme() + "://" + uri.getRawAuthority();
+        if (!allowedRedirectOrigins.contains(origin)) {
+            log.warn("SSO 허용되지 않은 redirect_uri: {}", redirectUri);
+            throw new SsoRedirectUriNotAllowedException();
+        }
+    }
+
+    /**
+     * 유효한 refresh 토큰이면 일회용 코드를 발급합니다.
+     * 비로그인(무효/만료/폐기 토큰)이면 empty — 예외를 던지지 않습니다 (리다이렉트 흐름).
+     */
+    @Transactional(readOnly = true)
+    public Optional<String> issueCodeForRefreshToken(String refreshTokenValue) {
+        return refreshTokenRepository.findByToken(refreshTokenValue)
+                .filter(token -> !token.isRevoked() && !token.isExpired())
+                .map(token -> {
+                    log.info("SSO 코드 발급: userId={}", token.getUser().getId());
+                    return codeStore.issue(token.getUser().getId());
+                });
+    }
+
+    /**
+     * 일회용 코드를 액세스 토큰 + 새 리프레시 토큰(새 토큰 패밀리)으로 교환합니다.
+     *
+     * @throws SsoCodeInvalidException 무효/만료/재사용 코드이거나 사용자가 활성 상태가 아닌 경우
+     */
+    public SsoTokenResult exchangeCode(String code) {
+        Long userId = codeStore.consume(code).orElseThrow(SsoCodeInvalidException::new);
+
+        User user = userRepository.findById(userId).orElseThrow(SsoCodeInvalidException::new);
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            log.warn("SSO 코드 교환 거부 - 비활성 사용자: userId={}, status={}", userId, user.getStatus());
+            throw new SsoCodeInvalidException();
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(
+                user.getId(), user.getStudentId(), user.getRole().name());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+        refreshTokenRepository.save(RefreshToken.createInitial(user, newRefreshToken, refreshTokenValidity));
+
+        log.info("SSO 토큰 발급 성공: userId={}", user.getId());
+        return new SsoTokenResult(accessToken, newRefreshToken, accessTokenValidity, refreshTokenValidity);
+    }
+}

--- a/backend/src/main/java/igrus/web/security/auth/sso/SsoTokenResult.java
+++ b/backend/src/main/java/igrus/web/security/auth/sso/SsoTokenResult.java
@@ -1,0 +1,12 @@
+package igrus.web.security.auth.sso;
+
+/**
+ * SSO 코드 교환 결과 (발급된 토큰 묶음)
+ */
+public record SsoTokenResult(
+        String accessToken,
+        String refreshToken,
+        long accessTokenValidity,
+        long refreshTokenValidity
+) {
+}

--- a/backend/src/main/java/igrus/web/security/auth/sso/exception/SsoCodeInvalidException.java
+++ b/backend/src/main/java/igrus/web/security/auth/sso/exception/SsoCodeInvalidException.java
@@ -1,0 +1,10 @@
+package igrus.web.security.auth.sso.exception;
+
+import igrus.web.common.exception.CustomBaseException;
+import igrus.web.security.auth.common.exception.AuthErrorCode;
+
+public class SsoCodeInvalidException extends CustomBaseException {
+    public SsoCodeInvalidException() {
+        super(AuthErrorCode.SSO_CODE_INVALID);
+    }
+}

--- a/backend/src/main/java/igrus/web/security/auth/sso/exception/SsoRedirectUriNotAllowedException.java
+++ b/backend/src/main/java/igrus/web/security/auth/sso/exception/SsoRedirectUriNotAllowedException.java
@@ -1,0 +1,10 @@
+package igrus.web.security.auth.sso.exception;
+
+import igrus.web.common.exception.CustomBaseException;
+import igrus.web.security.auth.common.exception.AuthErrorCode;
+
+public class SsoRedirectUriNotAllowedException extends CustomBaseException {
+    public SsoRedirectUriNotAllowedException() {
+        super(AuthErrorCode.SSO_REDIRECT_URI_NOT_ALLOWED);
+    }
+}

--- a/backend/src/main/java/igrus/web/security/config/SecurityPaths.java
+++ b/backend/src/main/java/igrus/web/security/config/SecurityPaths.java
@@ -12,6 +12,7 @@ public final class SecurityPaths {
     public static final String[] PUBLIC_PATHS = {
             "/api/v1/health",               // 헬스체크
             "/api/v1/auth/password/**",  // 비밀번호 기반 인증 (로그인, 회원가입, 토큰 갱신)
+            "/api/v1/auth/sso/**",       // SSO 코드 발급·교환 (play 등 다른 도메인 세션 연동)
             "/api/privacy/policy",       // 개인정보 처리방침
             "/api/v1/inquiries/guest",   // 문의 작성 (비로그인 가능)
             "/api/v1/inquiries/lookup",  // 비회원 문의 조회

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -31,6 +31,8 @@ app:
   cookie:
     secure: false
     same-site: Lax
+  sso:
+    allowed-redirect-origins: http://localhost:5173,http://localhost:5174
   webhook:
     baebdung-i:
       enabled: false

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -46,6 +46,8 @@ app:
     same-site: Lax
     domain: igrus.co.kr
   frontend-url: https://www.igrus.co.kr
+  sso:
+    allowed-redirect-origins: https://play.igrus.co.kr,https://inhaplay.com,https://www.inhaplay.com
   webhook:
     baebdung-i:
       secret: ${app.webhook.baebdung-i.secret}

--- a/backend/src/main/resources/application-staging.yml
+++ b/backend/src/main/resources/application-staging.yml
@@ -46,6 +46,8 @@ app:
     same-site: Lax
     domain: igrus.co.kr
   frontend-url: https://staging.igrus.co.kr
+  sso:
+    allowed-redirect-origins: http://localhost:5173,http://localhost:5174
   webhook:
     baebdung-i:
       enabled: false

--- a/backend/src/test/java/igrus/web/security/auth/sso/SsoAuthIntegrationTest.java
+++ b/backend/src/test/java/igrus/web/security/auth/sso/SsoAuthIntegrationTest.java
@@ -1,0 +1,234 @@
+package igrus.web.security.auth.sso;
+
+import igrus.web.security.auth.common.domain.RefreshToken;
+import igrus.web.security.auth.password.controller.ControllerIntegrationTestBase;
+import igrus.web.user.domain.User;
+import igrus.web.user.domain.UserRole;
+import igrus.web.user.domain.UserStatus;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static igrus.web.common.OpenApiValidatorUtil.matchesOpenApiSpec;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * SSO 핸드오프 통합 테스트
+ *
+ * <p>authorize(일회용 코드 발급 리다이렉트)와 token(코드 → 토큰 교환) 흐름을 검증합니다.</p>
+ */
+@DisplayName("SSO 핸드오프 통합 테스트")
+class SsoAuthIntegrationTest extends ControllerIntegrationTestBase {
+
+    private static final String AUTHORIZE_PATH = "/api/v1/auth/sso/authorize";
+    private static final String TOKEN_PATH = "/api/v1/auth/sso/token";
+    private static final String ALLOWED_REDIRECT = "https://play.test";
+
+    @Autowired
+    private SsoService ssoService;
+
+    @Autowired
+    private SsoCodeStore ssoCodeStore;
+
+    @Autowired
+    private Clock clock;
+
+    @BeforeEach
+    void setUp() {
+        setUpControllerTest();
+        Mockito.reset(clock);
+        when(clock.instant()).thenReturn(Instant.now());
+        ReflectionTestUtils.setField(ssoService, "accessTokenValidity", ACCESS_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(ssoService, "refreshTokenValidity", REFRESH_TOKEN_VALIDITY);
+        ReflectionTestUtils.setField(ssoService, "allowedRedirectOrigins", List.of(ALLOWED_REDIRECT));
+    }
+
+    private User createActiveUser() {
+        return createAndSaveUser(TEST_STUDENT_ID, TEST_EMAIL, UserRole.MEMBER, UserStatus.ACTIVE);
+    }
+
+    private String createAndSaveRefreshToken(User user) {
+        String token = jwtTokenProvider.createRefreshToken(user.getId());
+        refreshTokenRepository.save(RefreshToken.createInitial(user, token, REFRESH_TOKEN_VALIDITY));
+        return token;
+    }
+
+    private String extractQueryParam(String location, String name) {
+        return java.util.Arrays.stream(location.substring(location.indexOf('?') + 1).split("&"))
+                .filter(p -> p.startsWith(name + "="))
+                .map(p -> p.substring(name.length() + 1))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Nested
+    @DisplayName("authorize - 일회용 코드 발급")
+    class AuthorizeTest {
+
+        @Test
+        @DisplayName("유효한 refresh 쿠키로 요청 시 sso_code를 붙여 리다이렉트한다")
+        void ssoAuthorize_withValidRefreshCookie_redirectsWithCode() throws Exception {
+            User user = createActiveUser();
+            String refreshToken = createAndSaveRefreshToken(user);
+
+            MvcResult result = mockMvc.perform(get(AUTHORIZE_PATH)
+                            .param("redirect_uri", ALLOWED_REDIRECT + "/")
+                            .cookie(new Cookie("refreshToken", refreshToken)))
+                    .andExpect(status().isFound())
+                    .andReturn();
+
+            String location = result.getResponse().getHeader("Location");
+            assertThat(location).startsWith(ALLOWED_REDIRECT + "/?sso_code=");
+        }
+
+        @Test
+        @DisplayName("refresh 쿠키가 없으면 sso=none으로 리다이렉트한다")
+        void ssoAuthorize_withoutCookie_redirectsWithNone() throws Exception {
+            mockMvc.perform(get(AUTHORIZE_PATH).param("redirect_uri", ALLOWED_REDIRECT + "/"))
+                    .andExpect(status().isFound())
+                    .andExpect(header().string("Location", ALLOWED_REDIRECT + "/?sso=none"));
+        }
+
+        @Test
+        @DisplayName("무효한 refresh 쿠키면 sso=none으로 리다이렉트한다")
+        void ssoAuthorize_withInvalidCookie_redirectsWithNone() throws Exception {
+            mockMvc.perform(get(AUTHORIZE_PATH)
+                            .param("redirect_uri", ALLOWED_REDIRECT + "/")
+                            .cookie(new Cookie("refreshToken", "invalid-token")))
+                    .andExpect(status().isFound())
+                    .andExpect(header().string("Location", ALLOWED_REDIRECT + "/?sso=none"));
+        }
+
+        @Test
+        @DisplayName("허용 목록에 없는 redirect_uri면 400을 반환한다")
+        void ssoAuthorize_withDisallowedRedirectUri_returns400() throws Exception {
+            mockMvc.perform(get(AUTHORIZE_PATH).param("redirect_uri", "https://evil.example/"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("기존 쿼리가 있는 redirect_uri에는 &로 코드를 붙인다")
+        void ssoAuthorize_withQueryInRedirectUri_appendsWithAmpersand() throws Exception {
+            User user = createActiveUser();
+            String refreshToken = createAndSaveRefreshToken(user);
+
+            MvcResult result = mockMvc.perform(get(AUTHORIZE_PATH)
+                            .param("redirect_uri", ALLOWED_REDIRECT + "/?page=2")
+                            .cookie(new Cookie("refreshToken", refreshToken)))
+                    .andExpect(status().isFound())
+                    .andReturn();
+
+            assertThat(result.getResponse().getHeader("Location"))
+                    .startsWith(ALLOWED_REDIRECT + "/?page=2&sso_code=");
+        }
+    }
+
+    @Nested
+    @DisplayName("token - 코드 교환")
+    class TokenExchangeTest {
+
+        private String issueCodeViaAuthorize(String refreshToken) throws Exception {
+            MvcResult result = mockMvc.perform(get(AUTHORIZE_PATH)
+                            .param("redirect_uri", ALLOWED_REDIRECT + "/")
+                            .cookie(new Cookie("refreshToken", refreshToken)))
+                    .andExpect(status().isFound())
+                    .andReturn();
+            return extractQueryParam(result.getResponse().getHeader("Location"), "sso_code");
+        }
+
+        @Test
+        @DisplayName("유효한 코드로 액세스 토큰과 새 리프레시 토큰을 발급받는다")
+        void ssoIssueToken_withValidCode_returnsTokens() throws Exception {
+            User user = createActiveUser();
+            String code = issueCodeViaAuthorize(createAndSaveRefreshToken(user));
+
+            MvcResult result = mockMvc.perform(post(TOKEN_PATH)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("code", code))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                    .andExpect(jsonPath("$.refreshToken").isNotEmpty())
+                    .andExpect(jsonPath("$.expiresIn").value(ACCESS_TOKEN_VALIDITY))
+                    .andExpect(jsonPath("$.refreshExpiresIn").value(REFRESH_TOKEN_VALIDITY))
+                    .andExpect(matchesOpenApiSpec())
+                    .andReturn();
+
+            // 발급된 리프레시 토큰이 새 패밀리로 저장되었는지 확인
+            String newRefreshToken = objectMapper.readTree(result.getResponse().getContentAsString())
+                    .get("refreshToken").asText();
+            assertThat(refreshTokenRepository.findByToken(newRefreshToken)).isPresent();
+        }
+
+        @Test
+        @DisplayName("같은 코드는 두 번 사용할 수 없다")
+        void ssoIssueToken_withReusedCode_returns401() throws Exception {
+            User user = createActiveUser();
+            String code = issueCodeViaAuthorize(createAndSaveRefreshToken(user));
+
+            mockMvc.perform(post(TOKEN_PATH)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("code", code))))
+                    .andExpect(status().isOk());
+
+            mockMvc.perform(post(TOKEN_PATH)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("code", code))))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("만료된 코드는 401을 반환한다")
+        void ssoIssueToken_withExpiredCode_returns401() throws Exception {
+            User user = createActiveUser();
+            Instant issuedAt = Instant.now();
+            when(clock.instant()).thenReturn(issuedAt);
+            String code = issueCodeViaAuthorize(createAndSaveRefreshToken(user));
+
+            when(clock.instant()).thenReturn(issuedAt.plus(SsoCodeStore.CODE_TTL).plusSeconds(1));
+
+            mockMvc.perform(post(TOKEN_PATH)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("code", code))))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 코드는 401을 반환한다")
+        void ssoIssueToken_withUnknownCode_returns401() throws Exception {
+            mockMvc.perform(post(TOKEN_PATH)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("code", "unknown-code"))))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("정지된 사용자의 코드는 401을 반환한다")
+        void ssoIssueToken_withSuspendedUser_returns401() throws Exception {
+            User user = createAndSaveUser(TEST_STUDENT_ID, TEST_EMAIL, UserRole.MEMBER, UserStatus.SUSPENDED);
+            String code = ssoCodeStore.issue(user.getId());
+
+            mockMvc.perform(post(TOKEN_PATH)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("code", code))))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/infra/cdk/lib/igrus-web-v2-stack.ts
+++ b/infra/cdk/lib/igrus-web-v2-stack.ts
@@ -200,7 +200,7 @@ api.igrus.co.kr, ec2.igrus.co.kr {
 	reverse_proxy app:8080
 }
 
-play.igrus.co.kr {
+play.igrus.co.kr, inhaplay.com, www.inhaplay.com {
 	encode gzip
 	reverse_proxy play-api:8080
 }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -93,6 +93,8 @@ tags:
   description: 외부인(비회원) 행사 신청 API
 - name: Password Authentication
   description: 비밀번호 기반 인증 관련 API
+- name: SSO Authentication
+  description: 다른 도메인 서비스(play 등)와의 세션 연동 SSO API
 - name: MyPage
   description: 마이페이지 API
 - name: Survey Form
@@ -234,6 +236,10 @@ paths:
     $ref: ./paths/auth.yaml#/authPasswordLogin
   /api/v1/auth/password/account/recover:
     $ref: ./paths/auth.yaml#/authPasswordAccountRecover
+  /api/v1/auth/sso/authorize:
+    $ref: ./paths/auth.yaml#/authSsoAuthorize
+  /api/v1/auth/sso/token:
+    $ref: ./paths/auth.yaml#/authSsoToken
   /api/v1/admin/users/{userId}/force-activate:
     $ref: ./paths/admin.yaml#/adminUsersByUserIdForceActivate
   /api/v1/admin/semesters/{year}/{semester}/members:

--- a/openapi/paths/auth.yaml
+++ b/openapi/paths/auth.yaml
@@ -376,3 +376,53 @@ authPasswordAccountRecoveryCheck:
       '400':
         description: 잘못된 요청 (학번 형식 오류)
     security: []
+authSsoAuthorize:
+  get:
+    tags:
+    - SSO Authentication
+    summary: SSO 인가 (일회용 코드 발급)
+    description: 브라우저 top-level 리다이렉트로 호출됩니다. refresh 쿠키로 로그인 상태를 확인하고, 로그인되어 있으면 일회용 코드를 redirect_uri에 sso_code 쿼리로 붙여 리다이렉트합니다. 비로그인이면 sso=none으로 리다이렉트합니다. redirect_uri의 origin은 서버 허용 목록에 있어야 합니다.
+    operationId: ssoAuthorize
+    parameters:
+    - name: redirect_uri
+      in: query
+      required: true
+      description: 코드 수신 후 돌아갈 절대 URI (origin이 허용 목록에 있어야 함)
+      schema:
+        type: string
+        format: uri
+    responses:
+      '302':
+        description: redirect_uri로 리다이렉트 (성공 시 ?sso_code=, 비로그인 시 ?sso=none)
+        headers:
+          Location:
+            schema:
+              type: string
+      '400':
+        description: 허용되지 않았거나 잘못된 redirect_uri
+    security: []
+authSsoToken:
+  post:
+    tags:
+    - SSO Authentication
+    summary: SSO 일회용 코드 → 토큰 교환
+    description: ssoAuthorize가 발급한 일회용 코드를 액세스 토큰과 새 리프레시 토큰(새 토큰 패밀리)으로 교환합니다. 코드는 60초 내 1회만 사용할 수 있습니다. 서비스 백엔드(server-to-server) 호출용입니다.
+    operationId: ssoIssueToken
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/auth.yaml#/SsoTokenRequest
+      required: true
+    responses:
+      '200':
+        description: 토큰 발급 성공
+        content:
+          application/json:
+            schema:
+              $ref: ../schemas/auth.yaml#/SsoTokenResponse
+      '400':
+        description: 잘못된 요청 (유효성 검증 실패)
+      '401':
+        description: 유효하지 않거나 만료된 코드
+    security: []

--- a/openapi/schemas/auth.yaml
+++ b/openapi/schemas/auth.yaml
@@ -603,3 +603,35 @@ RecoveryEligibilityResponse:
       type: string
       description: 안내 메시지
       example: 탈퇴한 계정입니다. 복구하시겠습니까?
+SsoTokenRequest:
+  type: object
+  description: SSO 일회용 코드 교환 요청
+  required:
+  - code
+  properties:
+    code:
+      type: string
+      description: ssoAuthorize가 발급한 일회용 코드
+      example: 3q2-8fJd0mX...
+SsoTokenResponse:
+  type: object
+  description: SSO 토큰 교환 응답
+  properties:
+    accessToken:
+      type: string
+      description: JWT Access Token
+      example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+    refreshToken:
+      type: string
+      description: 새로 발급된 Refresh Token (새 토큰 패밀리 — 호출한 서비스가 자체 쿠키로 보관)
+      example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+    expiresIn:
+      type: integer
+      format: int64
+      description: Access Token 만료까지 남은 시간 (밀리초)
+      example: 300000
+    refreshExpiresIn:
+      type: integer
+      format: int64
+      description: Refresh Token 만료까지 남은 시간 (밀리초)
+      example: 1209600000

--- a/play-igrus/backend/main.go
+++ b/play-igrus/backend/main.go
@@ -65,6 +65,13 @@ func main() {
 		mux.Handle("GET /", spaHandler(staticDir))
 	}
 
+	// igrus 인증 프록시 (sso.go — inhaplay.com 등 다른 도메인에서의 세션 유지용)
+	mux.HandleFunc("POST /auth/login", s.ssoLogin)
+	mux.HandleFunc("POST /auth/refresh", s.ssoRefresh)
+	mux.HandleFunc("POST /auth/logout", s.ssoLogout)
+	mux.HandleFunc("POST /auth/sso/start", s.ssoStart)
+	mux.HandleFunc("POST /auth/sso/exchange", s.ssoExchange)
+
 	// 로그인 필요
 	mux.HandleFunc("POST /api/projects", s.auth.requireLogin(s.createProject))
 	mux.HandleFunc("PUT /api/projects/{id}", s.auth.requireLogin(s.updateProject))

--- a/play-igrus/backend/sso.go
+++ b/play-igrus/backend/sso.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// igrus 인증 프록시.
+//
+// inhaplay.com 은 igrus.co.kr 과 등록 도메인이 달라 Domain=igrus.co.kr refresh
+// 쿠키를 공유할 수 없다. 그래서 로그인/갱신/로그아웃을 이 서버가 igrus 에
+// 중계하고, igrus 가 내려주는 refresh 토큰을 이 서버 도메인의 퍼스트파티 쿠키
+// (playRefreshToken)로 다시 심는다. play.igrus.co.kr 에서도 같은 경로를 쓴다.
+//
+// SSO 핸드오프: www 에 로그인돼 있으면 프론트가 igrus 의
+// /api/v1/auth/sso/authorize 로 top-level 리다이렉트해 일회용 코드를 받아오고,
+// 이 서버의 /auth/sso/exchange 가 코드를 토큰으로 교환해 세션을 만든다.
+
+const (
+	igrusRefreshCookie = "refreshToken"     // 스프링 CookieUtil 의 쿠키 이름
+	playRefreshCookie  = "playRefreshToken" // 이 서버가 자기 도메인에 심는 쿠키
+	playSsoStateCookie = "playSsoState"     // SSO 핸드오프 CSRF 바인딩용 state
+	authCookiePath     = "/auth"
+)
+
+func (s *server) setPlayRefreshCookie(w http.ResponseWriter, r *http.Request, value string, maxAge int) {
+	c := &http.Cookie{
+		Name:     playRefreshCookie,
+		Value:    value,
+		Path:     authCookiePath,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		// Caddy 뒤에서는 X-Forwarded-Proto 로 https 여부를 판단 (로컬 dev 는 http)
+		Secure: r.Header.Get("X-Forwarded-Proto") == "https",
+		MaxAge: maxAge,
+	}
+	if value == "" || maxAge < 0 {
+		c.Value = ""
+		c.MaxAge = -1
+	}
+	http.SetCookie(w, c)
+}
+
+// forwardAuth 는 igrus 인증 엔드포인트로 요청을 중계하고, 응답의 refresh
+// Set-Cookie 를 이 서버의 퍼스트파티 쿠키로 바꿔 심은 뒤 상태/본문을 그대로 내린다.
+func (s *server) forwardAuth(w http.ResponseWriter, r *http.Request, igrusPath string, body io.Reader) {
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, s.auth.apiBase+igrusPath, body)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "요청 생성 실패")
+		return
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c, cookieErr := r.Cookie(playRefreshCookie); cookieErr == nil && c.Value != "" {
+		req.AddCookie(&http.Cookie{Name: igrusRefreshCookie, Value: c.Value})
+	}
+	// 로그인 이력(IP/UA)용 원본 정보 전달
+	req.Header.Set("User-Agent", r.UserAgent())
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		req.Header.Set("X-Forwarded-For", xff)
+	}
+
+	resp, err := s.auth.client.Do(req)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "인증 서버에 연결할 수 없습니다")
+		return
+	}
+	defer resp.Body.Close()
+
+	// igrus 가 refresh 쿠키를 새로 내렸으면(로테이션/삭제 포함) 우리 쿠키로 반영
+	for _, c := range resp.Cookies() {
+		if c.Name == igrusRefreshCookie {
+			s.setPlayRefreshCookie(w, r, c.Value, c.MaxAge)
+		}
+	}
+	// 401 이면 세션이 죽은 것 — 들고 있던 쿠키도 정리
+	if resp.StatusCode == http.StatusUnauthorized {
+		s.setPlayRefreshCookie(w, r, "", -1)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body) //nolint:errcheck — 중계 실패는 클라이언트 연결 문제
+}
+
+// POST /auth/login — igrus 로그인 중계. 성공 시 refresh 쿠키를 이 도메인에 심는다.
+func (s *server) ssoLogin(w http.ResponseWriter, r *http.Request) {
+	s.forwardAuth(w, r, "/api/v1/auth/password/login", r.Body)
+}
+
+// POST /auth/refresh — 퍼스트파티 refresh 쿠키로 igrus 토큰 갱신 중계.
+func (s *server) ssoRefresh(w http.ResponseWriter, r *http.Request) {
+	if c, err := r.Cookie(playRefreshCookie); err != nil || c.Value == "" {
+		writeErr(w, http.StatusUnauthorized, "로그인이 필요합니다")
+		return
+	}
+	s.forwardAuth(w, r, "/api/v1/auth/password/refresh", nil)
+}
+
+// POST /auth/logout — igrus 세션(이 서버가 발급받은 토큰 패밀리만) 종료 + 쿠키 삭제.
+// www 세션은 별도 토큰 패밀리라 영향 없다.
+func (s *server) ssoLogout(w http.ResponseWriter, r *http.Request) {
+	if c, err := r.Cookie(playRefreshCookie); err == nil && c.Value != "" {
+		s.forwardAuth(w, r, "/api/v1/auth/password/logout", nil)
+		s.setPlayRefreshCookie(w, r, "", -1)
+		return
+	}
+	s.setPlayRefreshCookie(w, r, "", -1)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// POST /auth/sso/start — SSO 핸드오프 시작. 랜덤 state 를 HttpOnly 쿠키와
+// 응답 본문 양쪽에 내린다. exchange 가 둘의 일치를 요구하므로, 이 브라우저가
+// 직접 시작한 핸드오프가 아니면(공격자가 보낸 sso_code 링크 등) 교환이 거부된다.
+func (s *server) ssoStart(w http.ResponseWriter, r *http.Request) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		writeErr(w, http.StatusInternalServerError, "state 생성 실패")
+		return
+	}
+	state := hex.EncodeToString(buf)
+	http.SetCookie(w, &http.Cookie{
+		Name:     playSsoStateCookie,
+		Value:    state,
+		Path:     authCookiePath,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   r.Header.Get("X-Forwarded-Proto") == "https",
+		MaxAge:   600, // 핸드오프 왕복이면 충분
+	})
+	writeJSON(w, http.StatusOK, map[string]string{"state": state})
+}
+
+// POST /auth/sso/exchange {code, state} — SSO 일회용 코드를 igrus 토큰으로
+// 교환하고 refresh 토큰을 퍼스트파티 쿠키로 심는다. 응답은 accessToken 만 내린다.
+// state 는 /auth/sso/start 가 심은 쿠키와 일치해야 한다 (로그인 CSRF 방지).
+func (s *server) ssoExchange(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Code  string `json:"code"`
+		State string `json:"state"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil || in.Code == "" {
+		writeErr(w, http.StatusBadRequest, "code 가 필요합니다")
+		return
+	}
+
+	stateCookie, err := r.Cookie(playSsoStateCookie)
+	if in.State == "" || err != nil || stateCookie.Value != in.State {
+		writeErr(w, http.StatusForbidden, "SSO state 가 일치하지 않습니다")
+		return
+	}
+	// state 는 1회용 — 검증 즉시 폐기
+	http.SetCookie(w, &http.Cookie{Name: playSsoStateCookie, Value: "", Path: authCookiePath, HttpOnly: true, MaxAge: -1})
+
+	payload, _ := json.Marshal(map[string]string{"code": in.Code})
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost,
+		s.auth.apiBase+"/api/v1/auth/sso/token", bytes.NewReader(payload))
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "요청 생성 실패")
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.auth.client.Do(req)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "인증 서버에 연결할 수 없습니다")
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body) //nolint:errcheck
+		return
+	}
+
+	var out struct {
+		AccessToken      string `json:"accessToken"`
+		RefreshToken     string `json:"refreshToken"`
+		ExpiresIn        int64  `json:"expiresIn"`
+		RefreshExpiresIn int64  `json:"refreshExpiresIn"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil || out.RefreshToken == "" {
+		writeErr(w, http.StatusBadGateway, "인증 서버 응답이 올바르지 않습니다")
+		return
+	}
+
+	s.setPlayRefreshCookie(w, r, out.RefreshToken, int(out.RefreshExpiresIn/1000))
+	writeJSON(w, http.StatusOK, map[string]any{
+		"accessToken": out.AccessToken,
+		"expiresIn":   out.ExpiresIn,
+	})
+}

--- a/play-igrus/backend/sso_test.go
+++ b/play-igrus/backend/sso_test.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// 가짜 igrus 백엔드 — sso 프록시가 쿠키를 올바르게 번역하는지 검증용.
+func newFakeIgrus(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /api/v1/auth/sso/token", func(w http.ResponseWriter, r *http.Request) {
+		var in struct{ Code string }
+		json.NewDecoder(r.Body).Decode(&in)
+		if in.Code != "good-code" {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{"message": "유효하지 않거나 만료된 SSO 코드입니다"})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": "at-1", "refreshToken": "rt-1",
+			"expiresIn": 300000, "refreshExpiresIn": 1209600000,
+		})
+	})
+
+	mux.HandleFunc("POST /api/v1/auth/password/refresh", func(w http.ResponseWriter, r *http.Request) {
+		c, err := r.Cookie(igrusRefreshCookie)
+		if err != nil || c.Value != "rt-1" {
+			http.SetCookie(w, &http.Cookie{Name: igrusRefreshCookie, Value: "", MaxAge: -1, Path: "/api/v1/auth"})
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// 로테이션: 새 refresh 토큰을 igrus 도메인 쿠키로 내림
+		http.SetCookie(w, &http.Cookie{Name: igrusRefreshCookie, Value: "rt-2", MaxAge: 1209600, Path: "/api/v1/auth"})
+		json.NewEncoder(w).Encode(map[string]any{"accessToken": "at-2", "expiresIn": 300000})
+	})
+
+	mux.HandleFunc("POST /api/v1/auth/password/login", func(w http.ResponseWriter, r *http.Request) {
+		var in struct{ StudentID, Password string }
+		json.NewDecoder(r.Body).Decode(&in)
+		if in.Password != "pw" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{Name: igrusRefreshCookie, Value: "rt-login", MaxAge: 1209600, Path: "/api/v1/auth"})
+		json.NewEncoder(w).Encode(map[string]any{"accessToken": "at-login"})
+	})
+
+	mux.HandleFunc("POST /api/v1/auth/password/logout", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: igrusRefreshCookie, Value: "", MaxAge: -1, Path: "/api/v1/auth"})
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func playCookie(res *http.Response) *http.Cookie {
+	for _, c := range res.Cookies() {
+		if c.Name == playRefreshCookie {
+			return c
+		}
+	}
+	return nil
+}
+
+// state 쿠키를 포함해 exchange 요청을 만든다.
+func exchangeRequest(body, cookieState string) *http.Request {
+	r := httptest.NewRequest("POST", "/auth/sso/exchange", strings.NewReader(body))
+	if cookieState != "" {
+		r.AddCookie(&http.Cookie{Name: playSsoStateCookie, Value: cookieState})
+	}
+	return r
+}
+
+func TestSsoStart(t *testing.T) {
+	s := &server{}
+	w := httptest.NewRecorder()
+	s.ssoStart(w, httptest.NewRequest("POST", "/auth/sso/start", nil))
+	res := w.Result()
+	if res.StatusCode != 200 {
+		t.Fatalf("status = %d", res.StatusCode)
+	}
+	var body struct{ State string }
+	json.NewDecoder(res.Body).Decode(&body)
+	var stateCookie *http.Cookie
+	for _, c := range res.Cookies() {
+		if c.Name == playSsoStateCookie {
+			stateCookie = c
+		}
+	}
+	if stateCookie == nil || !stateCookie.HttpOnly || stateCookie.Value == "" {
+		t.Fatalf("state 쿠키가 잘못 설정됨: %+v", stateCookie)
+	}
+	if body.State != stateCookie.Value {
+		t.Errorf("본문 state(%q) != 쿠키 state(%q)", body.State, stateCookie.Value)
+	}
+}
+
+func TestSsoExchange(t *testing.T) {
+	s := &server{auth: newAuthenticator(newFakeIgrus(t).URL)}
+
+	// 성공: state 일치 → 쿠키 심고 accessToken 만 내린다
+	w := httptest.NewRecorder()
+	s.ssoExchange(w, exchangeRequest(`{"code":"good-code","state":"st-1"}`, "st-1"))
+	res := w.Result()
+	if res.StatusCode != 200 {
+		t.Fatalf("status = %d", res.StatusCode)
+	}
+	c := playCookie(res)
+	if c == nil || c.Value != "rt-1" || !c.HttpOnly || c.Path != authCookiePath {
+		t.Fatalf("refresh 쿠키가 잘못 설정됨: %+v", c)
+	}
+	var body map[string]any
+	json.NewDecoder(res.Body).Decode(&body)
+	if body["accessToken"] != "at-1" {
+		t.Errorf("accessToken 누락: %v", body)
+	}
+	if _, leaked := body["refreshToken"]; leaked {
+		t.Error("refreshToken 이 응답 본문으로 새면 안 된다")
+	}
+
+	// 로그인 CSRF 방어: state 불일치/누락이면 코드가 유효해도 403
+	for name, r := range map[string]*http.Request{
+		"state 불일치":  exchangeRequest(`{"code":"good-code","state":"st-1"}`, "other"),
+		"state 쿠키 없음": exchangeRequest(`{"code":"good-code","state":"st-1"}`, ""),
+		"state 필드 없음": exchangeRequest(`{"code":"good-code"}`, "st-1"),
+	} {
+		w = httptest.NewRecorder()
+		s.ssoExchange(w, r)
+		if w.Result().StatusCode != 403 {
+			t.Errorf("%s status = %d, want 403", name, w.Result().StatusCode)
+		}
+		if c := playCookie(w.Result()); c != nil {
+			t.Errorf("%s 인데 refresh 쿠키가 설정됨", name)
+		}
+	}
+
+	// 실패: 무효 코드는 상태 중계, refresh 쿠키 없음
+	w = httptest.NewRecorder()
+	s.ssoExchange(w, exchangeRequest(`{"code":"bad","state":"st-1"}`, "st-1"))
+	if w.Result().StatusCode != 401 {
+		t.Errorf("무효 코드 status = %d, want 401", w.Result().StatusCode)
+	}
+	if c := playCookie(w.Result()); c != nil {
+		t.Error("무효 코드인데 refresh 쿠키가 설정됨")
+	}
+
+	// code 없음 → 400
+	w = httptest.NewRecorder()
+	s.ssoExchange(w, exchangeRequest(`{}`, "st-1"))
+	if w.Result().StatusCode != 400 {
+		t.Errorf("code 없음 status = %d, want 400", w.Result().StatusCode)
+	}
+}
+
+func TestSsoRefresh(t *testing.T) {
+	s := &server{auth: newAuthenticator(newFakeIgrus(t).URL)}
+
+	// 쿠키 없음 → igrus 안 가고 401
+	w := httptest.NewRecorder()
+	s.ssoRefresh(w, httptest.NewRequest("POST", "/auth/refresh", nil))
+	if w.Result().StatusCode != 401 {
+		t.Fatalf("쿠키 없음 status = %d, want 401", w.Result().StatusCode)
+	}
+
+	// 유효 쿠키 → 로테이션된 토큰으로 쿠키 갱신
+	w = httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/auth/refresh", nil)
+	r.AddCookie(&http.Cookie{Name: playRefreshCookie, Value: "rt-1"})
+	s.ssoRefresh(w, r)
+	res := w.Result()
+	if res.StatusCode != 200 {
+		t.Fatalf("status = %d", res.StatusCode)
+	}
+	if c := playCookie(res); c == nil || c.Value != "rt-2" {
+		t.Fatalf("로테이션 쿠키 미반영: %+v", c)
+	}
+
+	// 무효 쿠키 → 401 + 쿠키 삭제
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("POST", "/auth/refresh", nil)
+	r.AddCookie(&http.Cookie{Name: playRefreshCookie, Value: "rt-stale"})
+	s.ssoRefresh(w, r)
+	res = w.Result()
+	if res.StatusCode != 401 {
+		t.Fatalf("무효 쿠키 status = %d, want 401", res.StatusCode)
+	}
+	if c := playCookie(res); c == nil || c.Value != "" || c.MaxAge >= 0 {
+		t.Fatalf("무효 세션 쿠키가 삭제되지 않음: %+v", c)
+	}
+}
+
+func TestSsoLoginAndLogout(t *testing.T) {
+	s := &server{auth: newAuthenticator(newFakeIgrus(t).URL)}
+
+	// 로그인 성공 → 퍼스트파티 쿠키
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/auth/login", strings.NewReader(`{"studentId":"12345678","password":"pw"}`))
+	s.ssoLogin(w, r)
+	res := w.Result()
+	if res.StatusCode != 200 {
+		t.Fatalf("status = %d", res.StatusCode)
+	}
+	if c := playCookie(res); c == nil || c.Value != "rt-login" {
+		t.Fatalf("로그인 쿠키 미설정: %+v", c)
+	}
+
+	// 로그인 실패 → 상태 중계, 쿠키 없음
+	w = httptest.NewRecorder()
+	s.ssoLogin(w, httptest.NewRequest("POST", "/auth/login", strings.NewReader(`{"studentId":"1","password":"wrong"}`)))
+	if w.Result().StatusCode != 401 {
+		t.Errorf("로그인 실패 status = %d, want 401", w.Result().StatusCode)
+	}
+
+	// 로그아웃 → 쿠키 삭제 (igrus 세션 종료 중계 포함)
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("POST", "/auth/logout", nil)
+	r.AddCookie(&http.Cookie{Name: playRefreshCookie, Value: "rt-login"})
+	s.ssoLogout(w, r)
+	res = w.Result()
+	if c := playCookie(res); c == nil || c.Value != "" || c.MaxAge >= 0 {
+		t.Fatalf("로그아웃 후 쿠키가 삭제되지 않음: %+v", c)
+	}
+
+	// 쿠키 없이 로그아웃해도 200
+	w = httptest.NewRecorder()
+	s.ssoLogout(w, httptest.NewRequest("POST", "/auth/logout", nil))
+	if w.Result().StatusCode != 200 {
+		t.Errorf("빈 로그아웃 status = %d, want 200", w.Result().StatusCode)
+	}
+}
+
+// X-Forwarded-Proto: https 일 때만 Secure 쿠키가 된다 (Caddy 뒤 prod).
+func TestPlayCookieSecureFlag(t *testing.T) {
+	s := &server{}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/auth/refresh", nil)
+	r.Header.Set("X-Forwarded-Proto", "https")
+	s.setPlayRefreshCookie(w, r, "v", 100)
+	if c := playCookie(w.Result()); c == nil || !c.Secure {
+		t.Error("https 요청인데 Secure 쿠키가 아님")
+	}
+
+	w = httptest.NewRecorder()
+	s.setPlayRefreshCookie(w, httptest.NewRequest("POST", "/auth/refresh", nil), "v", 100)
+	if c := playCookie(w.Result()); c == nil || c.Secure {
+		t.Error("로컬 http 인데 Secure 쿠키면 dev 에서 동작 안 함")
+	}
+}

--- a/play-igrus/frontend/src/api/client.ts
+++ b/play-igrus/frontend/src/api/client.ts
@@ -14,14 +14,16 @@ export class ApiError extends Error {
   }
 }
 
-// ── 세션 (www 프론트 client.ts 와 동일 패턴) ─────────────────────────
-// accessToken 은 origin 별 격리지만, refresh 쿠키는 Domain=igrus.co.kr 라
-// www 에서 로그인했으면 여기서도 refresh 한 번으로 세션이 복원된다.
+// ── 세션 ─────────────────────────────────────────────────────────────
+// 인증은 play 백엔드의 /auth/* 프록시를 통한다. 프록시가 igrus refresh 토큰을
+// "이 도메인의 퍼스트파티 쿠키"로 심기 때문에 inhaplay.com 처럼 igrus.co.kr 과
+// 등록 도메인이 달라도 세션이 유지된다. www 에서 로그인한 세션은 igrus 의
+// /api/v1/auth/sso/authorize 로 1회 top-level 리다이렉트(SSO 핸드오프)해 가져온다.
 
 let refreshPromise: Promise<string> | null = null;
 
 async function refreshAccessToken(): Promise<string> {
-  const res = await fetch(`${IGRUS_API}/api/v1/auth/password/refresh`, {
+  const res = await fetch(`${PLAY_API}/auth/refresh`, {
     method: "POST",
     credentials: "include",
   });
@@ -40,13 +42,69 @@ function ensureRefresh(): Promise<string> {
   return refreshPromise;
 }
 
-/** 앱 시작 시 1회 — refresh 쿠키로 세션 복원 시도. 비로그인이면 조용히 실패. */
+// SSO 바운스는 탭 세션당 1회만 — 리다이렉트 루프 방지
+const SSO_ATTEMPTED_KEY = "playSsoAttempted";
+
+/** SSO 일회용 코드를 play 세션(퍼스트파티 refresh 쿠키)으로 교환.
+ *  state 는 /auth/sso/start 가 심은 쿠키와 서버에서 대조된다 (로그인 CSRF 방지). */
+async function exchangeSsoCode(code: string, state: string): Promise<void> {
+  const res = await fetch(`${PLAY_API}/auth/sso/exchange`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code, state }),
+  });
+  if (!res.ok) return; // 만료/재사용 코드, state 불일치 — 비로그인으로 진행
+  const data = (await res.json()) as { accessToken: string };
+  useAuthStore.getState().setAccessToken(data.accessToken);
+}
+
+/** SSO 핸드오프 시작 — state 발급 후 igrus authorize 로 top-level 리다이렉트 */
+async function startSsoHandoff(): Promise<void> {
+  const res = await fetch(`${PLAY_API}/auth/sso/start`, {
+    method: "POST",
+    credentials: "include",
+  });
+  if (!res.ok) throw new ApiError(res.status, "SSO 시작 실패");
+  const { state } = (await res.json()) as { state: string };
+  const back = new URL(location.href);
+  back.searchParams.set("sso_state", state);
+  location.replace(
+    `${IGRUS_API}/api/v1/auth/sso/authorize?redirect_uri=${encodeURIComponent(back.toString())}`,
+  );
+}
+
+/**
+ * 앱 시작 시 1회 — 퍼스트파티 refresh 쿠키로 세션 복원을 시도하고,
+ * 실패하면 www 세션을 가져오기 위해 igrus SSO authorize 로 1회 리다이렉트한다.
+ * (돌아올 때 ?sso_code= 또는 ?sso=none 이 붙는다)
+ */
 export async function bootstrapAuth(): Promise<void> {
   try {
+    const url = new URL(location.href);
+    if (url.searchParams.has("sso_code") || url.searchParams.has("sso")) {
+      sessionStorage.setItem(SSO_ATTEMPTED_KEY, "1");
+      const code = url.searchParams.get("sso_code");
+      const state = url.searchParams.get("sso_state");
+      url.searchParams.delete("sso_code");
+      url.searchParams.delete("sso_state");
+      url.searchParams.delete("sso");
+      history.replaceState(null, "", url);
+      if (code && state) await exchangeSsoCode(code, state);
+    }
     if (!useAuthStore.getState().accessToken) await ensureRefresh();
     await loadProfile();
   } catch {
-    // 비로그인 방문자 — 무시
+    // 비로그인 — www 에 로그인돼 있을 수 있으니 SSO 핸드오프 1회 시도
+    if (!sessionStorage.getItem(SSO_ATTEMPTED_KEY)) {
+      sessionStorage.setItem(SSO_ATTEMPTED_KEY, "1");
+      try {
+        await startSsoHandoff();
+        return; // 리다이렉트로 떠남
+      } catch {
+        // play 서버 문제 — 비로그인으로 진행
+      }
+    }
   } finally {
     useAuthStore.getState().setBootstrapped();
   }
@@ -59,9 +117,9 @@ export async function loadProfile(): Promise<User> {
 }
 
 export async function login(studentId: string, password: string): Promise<void> {
-  const res = await fetch(`${IGRUS_API}/api/v1/auth/password/login`, {
+  const res = await fetch(`${PLAY_API}/auth/login`, {
     method: "POST",
-    credentials: "include", // Set-Cookie Domain=igrus.co.kr — www 와 세션 공유
+    credentials: "include", // 프록시가 refresh 토큰을 이 도메인 쿠키로 심는다
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ studentId, password }),
   });
@@ -75,11 +133,12 @@ export async function login(studentId: string, password: string): Promise<void> 
 }
 
 export async function logout(): Promise<void> {
-  // 도메인 쿠키가 지워지므로 www 쪽도 함께 로그아웃된다 (SSO 정상 동작)
-  await fetch(`${IGRUS_API}/api/v1/auth/password/logout`, {
+  // play 전용 토큰 패밀리만 종료한다 — www 세션은 영향 없음
+  await fetch(`${PLAY_API}/auth/logout`, {
     method: "POST",
     credentials: "include",
   }).catch(() => {});
+  sessionStorage.setItem(SSO_ATTEMPTED_KEY, "1"); // 로그아웃 직후 SSO 재바운스 방지
   useAuthStore.getState().clear();
 }
 

--- a/play-igrus/frontend/src/main.tsx
+++ b/play-igrus/frontend/src/main.tsx
@@ -11,7 +11,7 @@ import ProfilePage from "./pages/ProfilePage";
 import AdminPage from "./pages/AdminPage";
 import "./index.css";
 
-// www 등 다른 *.igrus.co.kr 에서 로그인한 세션을 refresh 쿠키로 복원
+// 퍼스트파티 refresh 쿠키로 세션 복원, 없으면 igrus SSO 핸드오프 1회 시도
 void bootstrapAuth();
 
 const router = createBrowserRouter([

--- a/play-igrus/frontend/vite.config.ts
+++ b/play-igrus/frontend/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig(({ mode }) => {
     server: {
       proxy: {
         "/api": { target: playTarget, changeOrigin: true },
+        "/auth": { target: playTarget, changeOrigin: true },
         "/images": { target: playTarget, changeOrigin: true },
         "/igrus-api": {
           target: igrusTarget,


### PR DESCRIPTION
## 개요

play-igrus 를 새 도메인 `inhaplay.com` 으로 서빙하면서도 www.igrus.co.kr 로그인 세션을 이어받을 수 있도록 SSO 핸드오프를 구현한다. 등록 도메인이 달라 `Domain=igrus.co.kr` refresh 쿠키를 공유할 수 없으므로, OAuth 와 같은 일회용 코드 교환 방식을 쓴다.

## 변경 사항

### 스프링 (backend, contract-first)
- `GET /api/v1/auth/sso/authorize?redirect_uri=` — top-level 리다이렉트로 호출. refresh 쿠키가 유효하면 60초 TTL·1회용 코드를 `?sso_code=` 로 붙여 리다이렉트, 비로그인이면 `?sso=none`. redirect_uri origin 은 `app.sso.allowed-redirect-origins` allowlist 검증.
- `POST /api/v1/auth/sso/token` — 코드를 액세스 토큰 + 새 refresh 토큰 패밀리로 교환 (server-to-server).
- 코드 저장은 in-memory `SsoCodeStore` (단일 인스턴스 전제).
- 통합 테스트 10개 (`SsoAuthIntegrationTest`).

### play-api (Go)
- `/auth/login·refresh·logout` 프록시 — igrus 인증을 중계하고 refresh 토큰을 **자기 도메인 퍼스트파티 쿠키**(`playRefreshToken`)로 재설정. play.igrus.co.kr / inhaplay.com 동일 경로.
- `/auth/sso/start` + `/auth/sso/exchange` — state 쿠키 바인딩(HttpOnly)으로 **로그인 CSRF 방지** 후 코드 교환.
- 테스트: state 불일치/누락 403, 쿠키 누출 방지 등 (`sso_test.go`).

### play 프론트
- 인증 호출을 same-origin `/auth/*` 로 전환.
- `bootstrapAuth`: 쿠키 refresh 실패 시 igrus authorize 로 1회 SSO 바운스 (sessionStorage 가드로 루프 방지), 복귀 시 `sso_code`+`sso_state` 교환.

### infra
- Caddyfile 에 `inhaplay.com, www.inhaplay.com` 추가 (EC2 에는 SSM 으로 적용 완료, DNS·TLS 발급 확인됨).

## 동작 변경
- play 로그아웃은 이제 play 토큰 패밀리만 종료한다 (www 세션 유지 — 이전에는 도메인 쿠키 공유라 같이 로그아웃됐음).

## 테스트
- 백엔드 전체 `gradlew test` 통과
- `go test ./...` 통과
- 프론트 `pnpm build`(tsc)·`pnpm lint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)